### PR TITLE
Add in support for static TREs

### DIFF
--- a/modules/c++/nitf/include/nitf/BandSource.hpp
+++ b/modules/c++/nitf/include/nitf/BandSource.hpp
@@ -164,7 +164,7 @@ public:
 protected:
     virtual void nextBlock(void* buf,
                            const void* block,
-                           nitf::Uint32 blockNumber,
+                           nitf::Uint32 /*blockNumber*/,
                            nitf::Uint64 blockSize) throw (::nitf::NITFException)
     {
         memcpy(buf, block, blockSize);

--- a/modules/c++/nitf/include/nitf/PluginRegistry.hpp
+++ b/modules/c++/nitf/include/nitf/PluginRegistry.hpp
@@ -62,6 +62,15 @@ public:
     static nitf_CompressionInterface* retrieveCompressionInterface(
             const std::string& comp) throw(nitf::NITFException);
 
+    /*!
+     * Checks if a TRE handler exists for 'ident'
+     *
+     * \param ident ID of the TRE
+     *
+     * \return true if a TRE handler exists, false otherwise
+     */
+    static bool treHandlerExists(const std::string& ident);
+
 private:
     PluginRegistry()
     {

--- a/modules/c++/nitf/source/PluginRegistry.cpp
+++ b/modules/c++/nitf/source/PluginRegistry.cpp
@@ -60,4 +60,9 @@ nitf_CompressionInterface* PluginRegistry::retrieveCompressionInterface(
 
     return compIface;
 }
+
+bool PluginRegistry::treHandlerExists(const std::string& ident)
+{
+    return nitf_PluginRegistry_TREHandlerExists(ident.c_str());
+}
 }

--- a/modules/c++/nitf/tests/test_static_plugin.cpp
+++ b/modules/c++/nitf/tests/test_static_plugin.cpp
@@ -22,7 +22,10 @@
 
 #include <import/nitf.hpp>
 
+namespace
+{
 NITF_TRE_STATIC_HANDLER_REF(PIAPEA);
+}
 
 int main(int argc, char** argv)
 {
@@ -39,9 +42,13 @@ int main(int argc, char** argv)
         }
         return 0;
     }
-    catch (except::Throwable& t)
+    catch (const except::Throwable& t)
     {
-        std::cout << t.getTrace() << std::endl;
+        std::cerr << t.getTrace() << std::endl;
+    }
+    catch (...)
+    {
+        std::cerr << "Unknown exception\n";
     }
     return 1;
 }

--- a/modules/c++/nitf/wscript
+++ b/modules/c++/nitf/wscript
@@ -9,7 +9,7 @@ USELIB_LOCAL    = 'nitf-c'
 LANG            = 'c++'
 TEST_FILTER     = 'test_functional.cpp test_handles.cpp ' \
                   'test_mem_source.cpp test_static_plugin.cpp'
-APPS            = 'apps/show_nitf++.cpp'
+APPS            = join('apps', 'show_nitf++.cpp')
 
 options = configure = distclean = lambda p: None
 
@@ -17,23 +17,19 @@ def build(bld):
     bld.module(**globals())
     
     env = bld.get_env()
-    app_targets = []
     for app in APPS.split():
         app_name = splitext(basename(app))[0]
-        app_targets.append(app_name)
         bld.program_helper(module_deps=NAME,
                            source=app, path=bld.path,
                            name=app_name)
 
-    bld(features='add_targets', target='nitf-c++-apps',
-        targets_to_add=app_targets)
-
-    tests = bld.path.ant_glob(join('tests', '*.cpp'))
-    test_targets = []
-    for test in tests:
-        test_filename = str(test)
-        if test_filename not in TEST_FILTER:
-            test_targets.append(splitext(test_filename)[0])
-
-    bld(features='add_targets', target='nitf-c++-tests',
-        targets_to_add=test_targets)
+    # We can only test static "plugins" if we've got them enabled
+    # If we do, we have to build this test directly ourselves because we need
+    # to link in the TRE that it uses (so it's in TEST_FILTER regardless of if
+    # we're going to build it or not)
+    if bld.env['enable_static_tres']:
+        bld.program_helper(module_deps=NAME,
+                           use='PIAPEA-static-c',
+                           source=join('tests', 'test_static_plugin.cpp'),
+                           name='test_static_plugin',
+                           install_path='${PREFIX}/tests/%s' % NAME)

--- a/modules/c/j2k/shared/wscript
+++ b/modules/c/j2k/shared/wscript
@@ -2,7 +2,7 @@ import os, subprocess
 from waflib import Options
 from os.path import splitext, dirname, join
 
-MAINTAINER         = 'adam.sylvester@gd-ais.com'
+MAINTAINER         = 'adam.sylvester@mdaus.com'
 VERSION            = '1.0'
 LANG               = 'c'
 USE                = 'nitf-c j2k-c'

--- a/modules/c/jpeg/wscript
+++ b/modules/c/jpeg/wscript
@@ -2,7 +2,7 @@ import os, shutil
 from waflib import Options
 from build import unzipper
 
-MAINTAINER         = 'adam.sylvester@gd-ais.com'
+MAINTAINER         = 'adam.sylvester@mdaus.com'
 VERSION            = '1.0'
 LANG               = 'c'
 NAME               = 'LibjpegDecompress'

--- a/modules/c/nitf/include/nitf/Defines.h
+++ b/modules/c/nitf/include/nitf/Defines.h
@@ -72,13 +72,12 @@
 
 #ifdef __cplusplus
 #define NITF_TRE_STATIC_HANDLER_REF(_Tre) \
-        extern "C" char** _Tre##_init(nitf_Error*); \
+        extern "C" const char** _Tre##_init(nitf_Error*); \
         extern "C" nitf_TREHandler* _Tre##_handler(nitf_Error*);
 #else
 #define NITF_TRE_STATIC_HANDLER_REF(_Tre) \
-        extern char** _Tre##_init(nitf_Error*); \
+        extern const char** _Tre##_init(nitf_Error*); \
         extern nitf_TREHandler* _Tre##_handler(nitf_Error*);
 #endif
-
 
 #endif

--- a/modules/c/nitf/include/nitf/PluginRegistry.h
+++ b/modules/c/nitf/include/nitf/PluginRegistry.h
@@ -116,6 +116,16 @@ NITFAPI(NITF_BOOL)
     nitf_PluginRegistry_loadPlugin(const char* fullPathName, nitf_Error* error);
 
 /*!
+ * Checks if a TRE handler exists for 'ident'
+ *
+ * \param ident ID of the TRE
+ *
+ * \return true if a TRE handler exists, false otherwise
+ */
+NITFAPI(NITF_BOOL)
+nitf_PluginRegistry_TREHandlerExists(const char* ident);
+
+/*!
  *  Unload the plugin registry.  This will unload the DLLs and free
  *  the nodes in the data structure containing them.  Since this is
  *  normally called implicitly (by the destructor at exit), if you

--- a/modules/c/nitf/shared/wscript
+++ b/modules/c/nitf/shared/wscript
@@ -2,7 +2,7 @@ import os, subprocess
 from waflib import Options
 from os.path import splitext, dirname, join
 
-MAINTAINER         = 'adam.sylvester@gd-ais.com'
+MAINTAINER         = 'adam.sylvester@mdaus.com'
 VERSION            = '1.0'
 LANG               = 'c'
 USE                = 'nitf-c'
@@ -10,26 +10,44 @@ PLUGIN             = 'nitf'
 REMOVEPLUGINPREFIX = True
 DEFINES            = ['NITF_MODULE_EXPORTS']
 
-configure = options = distclean = lambda p: None
+distclean = lambda p: None
+
+def options(opt):
+    opt.add_option('--enable-static-tres', action='store_true', default=False, dest='enable_static_tres',
+                   help='Enable static TRE support')
+
+def configure(conf):
+    # If it's already defined in a wscript, don't touch
+    if not conf.env['enable_static_tres']:
+        conf.env['enable_static_tres'] = Options.options.enable_static_tres
 
 def build(bld):
     variant = bld.env['VARIANT'] or 'default'
     env = bld.all_envs[variant]
     
     pluginList = []
-    plugins = bld.path.ant_glob('*.c')
+    tres = bld.path.ant_glob('*.c')
 
-    for p in plugins:
-        filename = str(p)
+    for tre in tres:
+        filename = str(tre)
 
+        # Build the TRE as a plugin
         kw = globals()
-        pluginName = splitext(filename)[0]
-        kw['NAME'] = pluginName
-        kw['LIBNAME'] = pluginName
+        treName = splitext(filename)[0]
+        kw['NAME'] = treName
+        kw['LIBNAME'] = treName
         kw['SOURCE'] = filename
 
         bld.plugin(**kw)
-        pluginList.append(pluginName)
+        pluginList.append(treName)
+
+        # Build the TRE as a static library
+        if env['enable_static_tres']:
+            staticName = treName + '-static'
+            kw['NAME'] = staticName
+            kw['LIBNAME'] = staticName
+
+            bld.module(**kw)
 
     bld(features='add_targets', target='nitro-plugins',
         targets_to_add=pluginList)

--- a/modules/c/nitf/wscript
+++ b/modules/c/nitf/wscript
@@ -22,19 +22,24 @@ TEST_FILTER     = 'test_1band_rw_line.c ' \
                   'test_des.c ' \
                   'test_ext_iter.c ' \
                   'test_ImageIO_read_data.c ' \
-                  'test_ImageIO_writePattern.c ' \
-                  'test_static_plugin.c' 
+                  'test_ImageIO_writePattern.c'
 
 SUBDIRS = 'shared apps'
 
-configure = options = distclean = lambda p: None
+distclean = lambda p: None
+
+def options(opt):
+    opt.recurse(SUBDIRS)
+
+def configure(conf):
+    conf.recurse(SUBDIRS)
 
 def build(bld):
-    env = bld.module(**globals())
+    bld.module(**globals())
     bld.recurse(SUBDIRS)
 
     #run doxygen
-    if 'DOXYGEN' in env and Options.is_install:
+    if 'DOXYGEN' in bld.env and Options.is_install:
         bld(rule='${DOXYGEN}', cwd=bld.path.abspath(), always=True)
         try:
             htmlDocs = bld.path.find_dir('doc/html')
@@ -42,23 +47,3 @@ def build(bld):
                 relpath = f.path_from(htmlDocs)
                 bld.install_files('${PREFIX}/share/doc/nitf/c/%s' % relpath, f.abspath())
         except:{}
-
-    # Convenience target
-    # We do this mainly so that from the top-level wscript we can choose what to build
-    tests = bld.path.ant_glob(os.path.join('tests', '*.c'))
-    test_targets = []
-    for test in tests:
-        test_filename = str(test)
-        if test_filename not in TEST_FILTER:
-            test_targets.append(os.path.splitext(test_filename)[0])
-
-    bld(features='add_targets', target='nitf-c-tests',
-        targets_to_add=test_targets)
-
-    tests = bld.path.ant_glob(os.path.join('unittests', '*.c'))
-    test_targets = []
-    for test in tests:
-        test_targets.append(os.path.splitext(str(test))[0])
-    
-    bld(features='add_targets', target='nitf-c-unittests',
-        targets_to_add=test_targets)


### PR DESCRIPTION
Adding back in the ability to link TREs in statically rather than requiring them to be built as plugins.  Support very similar to this was in NITRO previously but was removed when we updated to waf 1.7 a few years ago.  Two changes with this support:
1. TREs are still built only as plugins by default.  You need to use the new configure option `--enable-static-tres` to get this support.
2. Rather than a single static library that contains all the TREs, each TRE is built individually.  This lets you potentially target and link in only the TRE(s) you care about.

Resurrected `test_static_plugin.cpp` and got it linking with the TRE it uses properly.  Use that as an example of both how to use this support in the code as well as how to link properly.