### PR TITLE
Support writing pieces of a NITF

### DIFF
--- a/modules/c++/nitf/include/nitf/Writer.hpp
+++ b/modules/c++/nitf/include/nitf/Writer.hpp
@@ -162,6 +162,65 @@ public:
     //! Get the warningList
     nitf::List getWarningList();
 
+    // NOTE: In general the following methods are not needed.  Only use these
+    //       if you know what you're doing and are trying to write out a NITF
+    //       piecemeal rather than through the normal Writer object interface.
+
+    /*!
+     * Writes out the file header (skips over the FL field as the total file
+     * length is not known yet).  No seeking is performed so the underlying IO
+     * object should be at the beginning of the file.
+     *
+     * \param fileLenOff Output parameter providing the offset in bytes in the
+     *     file to the file length (FL) field in the header so that you can
+     *     write it out later once the file length is known
+     * \param hdrLen Output parameter providing the total number of bytes the
+     *     file header is on disk
+     */
+    void writeHeader(nitf::Off& fileLenOff, nitf::Uint32& hdrLen);
+
+    /*!
+     * Writes out an image subheader.  No seeking is performed so the underlying
+     * IO object should be at the appropriate spot in the file prior to this
+     * call.
+     *
+     * \param subhdr Image subheader to write out
+     * \param version NITF file version to write (you probably want NITF_VER_21)
+     * \param comratOff Output parameter containing the offset in bytes in the
+     *     file where the COMRAT field would be populated for compressed files
+     */
+    void writeImageSubheader(nitf::ImageSubheader subheader,
+                             nitf::Version version,
+                             nitf::Off& comratOff);
+
+    /*!
+     * Writes out a data extension subheader.  No seeking is performed so the
+     * underlying IO object should be at the appropriate spot in the file prior
+     * to this call.
+     *
+     * \param subhdr Data extension subheader to write out
+     * \param userSublen Output parameter containing the length in bytes of the
+     *     user subheader
+     * \param version NITF file version to write (you probably want NITF_VER_21)
+     */
+    void writeDESubheader(nitf::DESubheader subheader,
+                          nitf::Uint32& userSublen,
+                          nitf::Version version);
+
+    /*!
+     * Writes an int64 field to the writer in its current position
+     *
+     * \param field Value of the field to write out
+     * \param length Length of the field to write out
+     * \param fill Fill character to use for any remaining bytes
+     * \param fillDir Fill direction (NITF_WRITER_FILL_LEFT or
+     *     NITF_WRITER_FILL_RIGHT)
+     */
+    void writeInt64Field(nitf::Uint64 field,
+                         nitf::Uint32 length,
+                         char fill,
+                         nitf::Uint32 fillDir);
+
 private:
     nitf_Error error;
 

--- a/modules/c++/nitf/source/Writer.cpp
+++ b/modules/c++/nitf/source/Writer.cpp
@@ -255,3 +255,58 @@ nitf::List Writer::getWarningList()
 {
     return nitf::List(getNativeOrThrow()->warningList);
 }
+
+void Writer::writeHeader(nitf::Off& fileLenOff, nitf::Uint32& hdrLen)
+{
+    if (!nitf_Writer_writeHeader(getNativeOrThrow(),
+                                 &fileLenOff,
+                                 &hdrLen,
+                                 &error))
+    {
+        throw nitf::NITFException(&error);
+    }
+}
+
+void Writer::writeImageSubheader(nitf::ImageSubheader subheader,
+                                 nitf::Version version,
+                                 nitf::Off& comratOff)
+{
+    if (!nitf_Writer_writeImageSubheader(getNativeOrThrow(),
+                                         subheader.getNativeOrThrow(),
+                                         version,
+                                         &comratOff,
+                                         &error))
+    {
+        throw nitf::NITFException(&error);
+    }
+}
+
+void Writer::writeDESubheader(nitf::DESubheader subheader,
+                              nitf::Uint32& userSublen,
+                              nitf::Version version)
+{
+    if (!nitf_Writer_writeDESubheader(getNativeOrThrow(),
+                                      subheader.getNativeOrThrow(),
+                                      &userSublen,
+                                      version,
+                                      &error))
+    {
+        throw nitf::NITFException(&error);
+    }
+}
+
+void Writer::writeInt64Field(nitf::Uint64 field,
+                             nitf::Uint32 length,
+                             char fill,
+                             nitf::Uint32 fillDir)
+{
+    if (!nitf_Writer_writeInt64Field(getNativeOrThrow(),
+                                     field,
+                                     length,
+                                     fill,
+                                     fillDir,
+                                     &error))
+    {
+        throw nitf::NITFException(&error);
+    }
+}

--- a/modules/c/nitf/include/nitf/Writer.h
+++ b/modules/c/nitf/include/nitf/Writer.h
@@ -32,6 +32,11 @@
 
 NITF_CXX_GUARD
 
+// These represent the fill direction when writing NITF fields (i.e. do you
+// fill with, say, spaces on the left or right of the field)
+#define NITF_WRITER_FILL_LEFT 1
+#define NITF_WRITER_FILL_RIGHT 2
+
 /*!
  *  \struct nitf_Writer
  *  \brief  This object represents the 2.1 (2.0?) file writer
@@ -172,6 +177,90 @@ NITFAPI(nitf_SegmentWriter*) nitf_Writer_newDEWriter(nitf_Writer *writer,
  */
 NITFAPI(NITF_BOOL) nitf_Writer_write(nitf_Writer * writer, nitf_Error * error);
 
+// NOTE: In general the following functions are not needed.  Only use these
+//       if you know what you're doing and are trying to write out a NITF
+//       piecemeal rather than through the normal Writer object interface.
+
+/*!
+ * Writes out the file header (skips over the FL field as the total file length
+ * is not known yet).  No seeking is performed so the underlying IO object
+ * should be at the beginning of the file.
+ *
+ * \param writer Initialized writer object
+ * \param fileLenOff Output parameter providing the offset in bytes in the file
+ *     to the file length (FL) field in the header so that you can write it out
+ *     later once the file length is known
+ * \param hdrLen Output parameter providing the total number of bytes the file
+ *     header is on disk
+ * \param error Output parameter providing the error if one occurs
+ *
+ * \return NITF_SUCCESS on success, NITF_FAILURE otherwise
+ *
+ */
+NITFPROT(NITF_BOOL) nitf_Writer_writeHeader(nitf_Writer* writer,
+                                            nitf_Off* fileLenOff,
+                                            nitf_Uint32* hdrLen,
+                                            nitf_Error* error);
+
+/*!
+ * Writes out an image subheader.  No seeking is performed so the underlying
+ * IO object should be at the appropriate spot in the file prior to this call.
+ *
+ * \param writer Initialized writer object
+ * \param subhdr Image subheader to write out
+ * \param fver NITF file version to write (you probably want NITF_VER_21)
+ * \param comratOff Output parameter containing the offset in bytes in the
+ *     file where the COMRAT field would be populated for compressed files
+ * \param error Output parameter providing the error if one occurs
+ *
+ * \return NITF_SUCCESS on success, NITF_FAILURE otherwise
+ */
+NITFPROT(NITF_BOOL)
+nitf_Writer_writeImageSubheader(nitf_Writer* writer,
+                                const nitf_ImageSubheader* subhdr,
+                                nitf_Version fver,
+                                nitf_Off* comratOff,
+                                nitf_Error* error);
+
+/*!
+ * Writes out a data extension subheader.  No seeking is performed so the
+ * underlying IO object should be at the appropriate spot in the file prior to
+ * this call.
+ *
+ * \param writer Initialized writer object
+ * \param subhdr Data extension subheader to write out
+ * \param userSublen Output parameter containing the length in bytes of the
+ *     user subheader
+ * \param fver NITF file version to write (you probably want NITF_VER_21)
+ * \param error Output parameter providing the error if one occurs
+ *
+ * \return NITF_SUCCESS on success, NITF_FAILURE otherwise
+ */
+NITFPROT(NITF_BOOL) nitf_Writer_writeDESubheader(nitf_Writer* writer,
+                                                 const nitf_DESubheader* subhdr,
+                                                 nitf_Uint32* userSublen,
+                                                 nitf_Version fver,
+                                                 nitf_Error* error);
+
+/*!
+ * Writes an int64 field to the writer in its current position
+ *
+ * \param writer Initialized writer object
+ * \param field Value of the field to write out
+ * \param length Length of the field to write out
+ * \param fill Fill character to use for any remaining bytes
+ * \param fillDir Fill direction (NITF_WRITER_FILL_LEFT or
+ *     NITF_WRITER_FILL_RIGHT)
+ * \param error Output parameter providing the error if one occurs
+ *
+ * \return NITF_SUCCESS on success, NITF_FAILURE otherwise
+ */
+NITFPROT(NITF_BOOL) nitf_Writer_writeInt64Field(nitf_Writer* writer,
+                                                nitf_Uint64 field,
+                                                nitf_Uint32 length,
+                                                char fill,
+                                                nitf_Uint32 fillDir,
+                                                nitf_Error* error);
 
 NITF_CXX_ENDGUARD
 

--- a/modules/c/nitf/source/Writer.c
+++ b/modules/c/nitf/source/Writer.c
@@ -35,8 +35,8 @@
 /*  These define chars for filling fields  */
 #define SPACE ' '
 #define ZERO '0'
-#define FILL_LEFT 1
-#define FILL_RIGHT 2
+#define FILL_LEFT NITF_WRITER_FILL_LEFT
+#define FILL_RIGHT NITF_WRITER_FILL_RIGHT
 
 /* define some maximum data lengths */
 #define NITF_MAX_IMAGE_LENGTH NITF_INT64(9999999999)
@@ -60,7 +60,7 @@
         goto CATCH_ERROR;
 
 #define NITF_WRITE_INT64_FIELD(value_, fld_, fil_, dir_) \
-    if (!writeInt64Field(writer, value_, fld_##_SZ, fil_, dir_, error)) \
+    if (!nitf_Writer_writeInt64Field(writer, value_, fld_##_SZ, fil_, dir_, error)) \
         goto CATCH_ERROR;
 
 
@@ -148,12 +148,11 @@ NITFPRIV(NITF_BOOL) writeField(nitf_Writer * writer,
                                nitf_Uint32 length, nitf_Error * error);
 
 /*  Pads a string with a fill character                              */
-/*  fld The input string                                             */
-/*  fill The fill character                                          */
+/*  field The input string                                             */
 /*  length The total length of the string                            */
+/*  fill The fill character                                          */
 /*  fillDir The fill direction (either FILL_LEFT or FILL_RIGHT)      */
-NITFPRIV(NITF_BOOL) padString(nitf_Writer * writer,
-                              char *field,
+NITFPRIV(NITF_BOOL) padString(char *field,
                               nitf_Uint32 length,
                               char fill,
                               const nitf_Uint32 fillDir,
@@ -193,7 +192,7 @@ NITFPRIV(NITF_BOOL) writeStringField(nitf_Writer * writer,
     memset(buf, '\0', length + 1);
     memcpy(buf, field, length);
 
-    if (!padString(writer, buf, length, fill, fillDir, error))
+    if (!padString(buf, length, fill, fillDir, error))
         goto CATCH_ERROR;
 
     if (!writeField(writer, buf, length, error))
@@ -252,7 +251,7 @@ NITFPRIV(NITF_BOOL) writeValue(nitf_Writer * writer,
     {
         memcpy(buf, field->raw, length);
 
-        if (!padString(writer, buf, length, fill, fillDir, error))
+        if (!padString(buf, length, fill, fillDir, error))
             goto CATCH_ERROR;
     }
 
@@ -280,7 +279,7 @@ NITFPRIV(NITF_BOOL) writeIntField(nitf_Writer * writer,
     memset(buf, '\0', 20);
     NITF_SNPRINTF(buf, 20, "%d", field);
 
-    if (padString(writer, buf, length, fill, fillDir, error))
+    if (padString(buf, length, fill, fillDir, error))
     {
         return writeField(writer, buf, length, error);
     }
@@ -293,19 +292,19 @@ NITFPRIV(NITF_BOOL) writeIntField(nitf_Writer * writer,
 
 
 /* This function pads the given nitf_Uint64, and writes it to the IOHandle */
-NITFPRIV(NITF_BOOL) writeInt64Field(nitf_Writer * writer,
-                                    nitf_Uint64 field,
-                                    nitf_Uint32 length,
-                                    char fill,
-                                    const nitf_Uint32 fillDir,
-                                    nitf_Error * error)
+NITFPROT(NITF_BOOL) nitf_Writer_writeInt64Field(nitf_Writer* writer,
+                                                nitf_Uint64 field,
+                                                nitf_Uint32 length,
+                                                char fill,
+                                                nitf_Uint32 fillDir,
+                                                nitf_Error* error)
 {
     char buf[20];
 
     memset(buf, '\0', 20);
     NITF_SNPRINTF(buf, 20, "%lld", (long long int)field);
 
-    if (padString(writer, buf, length, fill, fillDir, error))
+    if (padString(buf, length, fill, fillDir, error))
     {
         return writeField(writer, buf, length, error);
     }
@@ -397,8 +396,7 @@ CATCH_ERROR:
 
 
 /* This function pads the given string with the fill character */
-NITFPRIV(NITF_BOOL) padString(nitf_Writer * writer,
-                              char *field,
+NITFPRIV(NITF_BOOL) padString(char *field,
                               nitf_Uint32 length,
                               char fill,
                               const nitf_Uint32 fillDir,
@@ -972,10 +970,10 @@ NITFAPI(void) nitf_Writer_destruct(nitf_Writer ** writer)
 }
 
 
-NITFPRIV(NITF_BOOL) writeHeader(nitf_Writer * writer,
-                                nitf_Off * fileLenOff,
-                                nitf_Uint32 * hdrLen,
-                                nitf_Error * error)
+NITFPROT(NITF_BOOL) nitf_Writer_writeHeader(nitf_Writer* writer,
+                                            nitf_Off* fileLenOff,
+                                            nitf_Uint32* hdrLen,
+                                            nitf_Error* error)
 {
     nitf_Uint32 numImages, numGraphics, numLabels;
     nitf_Uint32 numTexts, numDES, numRES;
@@ -1119,12 +1117,12 @@ CATCH_ERROR:
 }
 
 
-NITFPRIV(NITF_BOOL)
-nitf_Writer_writeImageSubheader(nitf_Writer * writer,
-                                nitf_ImageSubheader *subhdr,
+NITFPROT(NITF_BOOL)
+nitf_Writer_writeImageSubheader(nitf_Writer* writer,
+                                const nitf_ImageSubheader* subhdr,
                                 nitf_Version fver,
-                                nitf_Off *comratOff,
-                                nitf_Error * error)
+                                nitf_Off* comratOff,
+                                nitf_Error* error)
 {
     nitf_Uint32 bands;
     nitf_Uint32 i;
@@ -1346,11 +1344,11 @@ CATCH_ERROR:
 }
 
 
-NITFPRIV(NITF_BOOL) writeDESubheader(nitf_Writer * writer,
-                                     nitf_DESubheader * subhdr,
-                                     nitf_Uint32 *userSublen,
-                                     nitf_Version fver,
-                                     nitf_Error * error)
+NITFPROT(NITF_BOOL) nitf_Writer_writeDESubheader(nitf_Writer* writer,
+                                                 const nitf_DESubheader* subhdr,
+                                                 nitf_Uint32* userSublen,
+                                                 nitf_Version fver,
+                                                 nitf_Error* error)
 {
     nitf_Uint32 subLen;
 
@@ -1652,7 +1650,7 @@ NITFAPI(NITF_BOOL) nitf_Writer_write(nitf_Writer * writer,
 
     nitf_FileHeader* header = writer->record->header;
 
-    if (!writeHeader(writer, &fileLenOff, &hdrLen, error))
+    if (!nitf_Writer_writeHeader(writer, &fileLenOff, &hdrLen, error))
         return NITF_FAILURE;
 
     fver = nitf_Record_getVersion(writer->record);
@@ -1999,9 +1997,9 @@ NITFAPI(NITF_BOOL) nitf_Writer_write(nitf_Writer * writer,
         {
             nitf_DESegment *segment =
                 (nitf_DESegment *) nitf_ListIterator_get(&iter);
-            if (!writeDESubheader(writer,
-                                  segment->subheader,
-                                  &userSublen, fver, error))
+            if (!nitf_Writer_writeDESubheader(writer,
+                                              segment->subheader,
+                                              &userSublen, fver, error))
             {
                 NITF_FREE(deSubLens);
                 NITF_FREE(deDataLens);


### PR DESCRIPTION
Making some functions in `Writer` public so that you can write out only pieces of a NITF directly yourself rather than going through the normal `Writer` interface that takes care of this for you.  Only use this if you know what you're doing.

Full disclosure: this has only been tested in writing SICD NITFs.

@JonathanMeans 
@chvink 
