### PR TITLE
OSX fixes

### DIFF
--- a/modules/c++/nitf/tests/test_buffered_read.cpp
+++ b/modules/c++/nitf/tests/test_buffered_read.cpp
@@ -62,7 +62,7 @@ void doRead(const std::string& inFile,
         subWindow.setBandList(&bandList[0]);
 
         // Read in the image
-        const size_t numBitsPerPixel((nitf::Uint64)subheader.getActualBitsPerPixel());
+        const size_t numBitsPerPixel(static_cast<nitf::Uint64>(subheader.getActualBitsPerPixel()));
         const size_t numBytesPerPixel = NITF_NBPP_TO_BYTES(numBitsPerPixel);
 
         const size_t numBytesPerBand =

--- a/modules/c++/nitf/tests/test_buffered_read.cpp
+++ b/modules/c++/nitf/tests/test_buffered_read.cpp
@@ -62,7 +62,7 @@ void doRead(const std::string& inFile,
         subWindow.setBandList(&bandList[0]);
 
         // Read in the image
-        const size_t numBitsPerPixel(subheader.getActualBitsPerPixel());
+        const size_t numBitsPerPixel((nitf::Uint64)subheader.getActualBitsPerPixel());
         const size_t numBytesPerPixel = NITF_NBPP_TO_BYTES(numBitsPerPixel);
 
         const size_t numBytesPerBand =

--- a/modules/c/nrt/include/nrt/DLL.h
+++ b/modules/c/nrt/include/nrt/DLL.h
@@ -31,6 +31,9 @@
 #ifdef WIN32
 /*  Under windows, a dynamic shared object is a DLL  */
 #    define  NRT_DLL_EXTENSION ".dll"
+#elif defined(__APPLE__)
+/*  Under OSX, a dynamic shared object has a .dylib extension  */
+#    define  NRT_DLL_EXTENSION ".dylib"
 #else
 /*
  *  BE WARY: Under Unix, we expect a DSO to have a .so extension,


### PR DESCRIPTION
Fix ambiguous cast on clang.
Use .dylib instead of .so for plugins on OSX.