### PR TITLE
Fixed a bug when the offset into an image segment was > 4 GB

### DIFF
--- a/modules/c/nitf/source/ImageIO.c
+++ b/modules/c/nitf/source/ImageIO.c
@@ -4767,9 +4767,9 @@ NITFPRIV(void) nitf_ImageIO_commonBlockInit(_nitf_ImageIOControl * cntl,
 {
     _nitf_ImageIO *nitf;             /* Parent _nitf_ImageIO object */
     nitf_Uint32 bytes;               /* Bytes per pixel */
-    nitf_Uint32 modeBlockBaseOffset; /* Block pixel offset based on mode*/
-    nitf_Uint32 maskOffset;          /* Mask offset based on mode */
-    nitf_Uint32 markOffset;          /* Mark offset based on mode */
+    nitf_Uint64 modeBlockBaseOffset; /* Block pixel offset based on mode*/
+    nitf_Uint64 maskOffset;          /* Mask offset based on mode */
+    nitf_Uint64 markOffset;          /* Mark offset based on mode */
     nitf_Uint32 numColsFR;           /* Number of columns at full resolution */
     nitf_Uint32 startRowThisBlock;   /* Row of this block to start at */
 
@@ -4815,8 +4815,8 @@ NITFPRIV(void) nitf_ImageIO_commonBlockInit(_nitf_ImageIOControl * cntl,
          *  In diagram, all rows between vertical lines are stored contiguously
          *  So the goal is to jump between entire sections
          */
-        modeBlockBaseOffset =
-            band * nitf->numColumnsPerBlock * nitf->numRowsPerBlock;
+        modeBlockBaseOffset = (nitf_Uint64)band *
+                nitf->numColumnsPerBlock * nitf->numRowsPerBlock;
     }
     else if (nitf->blockingMode == NITF_IMAGE_IO_BLOCKING_MODE_R)
     {
@@ -4826,7 +4826,7 @@ NITFPRIV(void) nitf_ImageIO_commonBlockInit(_nitf_ImageIOControl * cntl,
          * 00000 11111 22222
          * For band 1, jump to pixel 1 * 5 = 5
          */
-        modeBlockBaseOffset = band * nitf->numColumnsPerBlock;
+        modeBlockBaseOffset = (nitf_Uint64)band * nitf->numColumnsPerBlock;
     }
 
     blockIO->blockOffset.orig = (modeBlockBaseOffset + startColumn) * bytes;
@@ -4838,7 +4838,7 @@ NITFPRIV(void) nitf_ImageIO_commonBlockInit(_nitf_ImageIOControl * cntl,
     }
 
     /* Advance to starting row*/
-    markOffset = startRowThisBlock * nitf->numColumnsPerBlock * bytes;
+    markOffset = (nitf_Uint64)startRowThisBlock * nitf->numColumnsPerBlock * bytes;
     if (nitf->blockingMode == NITF_IMAGE_IO_BLOCKING_MODE_R ||
         nitf->blockingMode == NITF_IMAGE_IO_BLOCKING_MODE_P)
     {
@@ -4850,7 +4850,8 @@ NITFPRIV(void) nitf_ImageIO_commonBlockInit(_nitf_ImageIOControl * cntl,
     maskOffset = 0;
     if (nitf->blockingMode == NITF_IMAGE_IO_BLOCKING_MODE_S)
     {
-        maskOffset = band * nitf->nBlocksPerRow * nitf->nBlocksPerColumn;
+        maskOffset = (nitf_Uint64)band *
+                nitf->nBlocksPerRow * nitf->nBlocksPerColumn;
     }
 
     blockIO->blockMask = nitf->blockMask + maskOffset;
@@ -5157,7 +5158,7 @@ int nitf_ImageIO_setup_SBR(_nitf_ImageIOControl * cntl, nitf_Error * error)
     myResidual = 0;
     blockNumber = startBlock;
 
-    if (nitf_ImageIO_setup_common(cntl, nBlockCols, error) == NULL)
+    if (nitf_ImageIO_setup_common(cntl, nBlockCols, error) == NITF_FAILURE)
     {
         return NITF_FAILURE;
     }
@@ -5440,7 +5441,7 @@ int nitf_ImageIO_setup_P(_nitf_ImageIOControl * cntl, nitf_Error * error)
     myResidual = 0;
     blockNumber = startBlock;
 
-    if (nitf_ImageIO_setup_common(cntl, nBlockCols, error) == NULL)
+    if (nitf_ImageIO_setup_common(cntl, nBlockCols, error) == NITF_FAILURE)
     {
         return NITF_FAILURE;
     }

--- a/modules/c/nitf/source/Writer.c
+++ b/modules/c/nitf/source/Writer.c
@@ -568,9 +568,9 @@ CATCH_ERROR:
 
 
 /* This function writes the IGEOLO field */
-NITFPRIV(NITF_BOOL) writeCorners(nitf_Writer * writer,
-                                 nitf_ImageSubheader * subhdr,
-                                 nitf_Version fver, nitf_Error * error)
+NITFPRIV(NITF_BOOL) writeCorners(nitf_Writer* writer,
+                                 const nitf_ImageSubheader* subhdr,
+                                 nitf_Version fver, nitf_Error* error)
 {
     if ((IS_NITF21(fver) &&
             (subhdr->NITF_ICORDS->raw[0] == 'U' ||


### PR DESCRIPTION
Though the underlying structures all kept 64-bit offsets, there was a spot in our calculations where we used a 32-bit value to calculate the offset into an image segment, so if the caller requested a start row that ended up being > 4 GB into the image segment, the correct file offset was not used in the eventual read.

Fixed a few compiler warnings while I was in the code too.

FYI @JonathanMeans 