### PR TITLE
Updates to support gcc on Windows

### DIFF
--- a/modules/c++/nitf/source/IOHandle.cpp
+++ b/modules/c++/nitf/source/IOHandle.cpp
@@ -46,14 +46,14 @@ IOHandle::open(const char* fname,
                nitf::CreationFlags creation) throw (nitf::NITFException)
 {
     nitf_Error error;
-    nitf_IOInterface* const interface =
+    nitf_IOInterface* const ioInterface =
             nitf_IOHandleAdapter_open(fname, access, creation, &error);
 
-    if (!interface)
+    if (!ioInterface)
     {
         throw nitf::NITFException(&error);
     }
 
-    return interface;
+    return ioInterface;
 }
 }

--- a/modules/c++/nitf/source/MemoryIO.cpp
+++ b/modules/c++/nitf/source/MemoryIO.cpp
@@ -29,10 +29,10 @@ nitf_IOInterface* MemoryIO::create(void* buffer,
                                    bool adopt) throw(nitf::NITFException)
 {
     nitf_Error error;
-    nitf_IOInterface* const interface = nitf_BufferAdapter_construct(
+    nitf_IOInterface* const ioInterface = nitf_BufferAdapter_construct(
             static_cast<char*>(buffer), size, adopt, &error);
 
-    if (!interface)
+    if (!ioInterface)
     {
         if (adopt)
         {
@@ -42,7 +42,7 @@ nitf_IOInterface* MemoryIO::create(void* buffer,
         throw nitf::NITFException(&error);
     }
 
-    return interface;
+    return ioInterface;
 }
 
 MemoryIO::MemoryIO(size_t capacity) throw(nitf::NITFException) :

--- a/modules/c/nitf/source/BandSource.c
+++ b/modules/c/nitf/source/BandSource.c
@@ -423,17 +423,17 @@ NITFAPI(nitf_BandSource *) nitf_FileSource_construct(nitf_IOHandle handle,
         &IOSource_setSize
     };
 
-    nitf_IOInterface *interface = NULL;
+    nitf_IOInterface* ioInterface = NULL;
     nitf_BandSource* bandSource = NULL;
 
-    interface = nitf_IOHandleAdapter_construct(handle, NRT_ACCESS_READONLY,
-                                               error);
-    if (interface == NULL)
+    ioInterface = nitf_IOHandleAdapter_construct(handle, NRT_ACCESS_READONLY,
+                                                 error);
+    if (ioInterface == NULL)
     {
         return NULL;
     }
 
-    bandSource = nitf_IOSource_construct(interface, start, numBytesPerPixel,
+    bandSource = nitf_IOSource_construct(ioInterface, start, numBytesPerPixel,
                                          pixelSkip, error);
     if (bandSource == NULL)
     {
@@ -461,17 +461,17 @@ NITFAPI(nitf_BandSource *) nitf_FileSource_constructFile(const char* fname,
         &IOSource_setSize
     };
 
-    nitf_IOInterface* interface = NULL;
+    nitf_IOInterface* ioInterface = NULL;
     nitf_BandSource* bandSource = NULL;
 
-    interface = nitf_IOHandleAdapter_open(fname, NRT_ACCESS_READONLY,
-                                          NRT_OPEN_EXISTING, error);
-    if (interface == NULL)
+    ioInterface = nitf_IOHandleAdapter_open(fname, NRT_ACCESS_READONLY,
+                                            NRT_OPEN_EXISTING, error);
+    if (ioInterface == NULL)
     {
         return NULL;
     }
 
-    bandSource = nitf_IOSource_construct(interface, start, numBytesPerPixel,
+    bandSource = nitf_IOSource_construct(ioInterface, start, numBytesPerPixel,
                                          pixelSkip, error);
     if (bandSource == NULL)
     {

--- a/modules/c/nitf/source/ImageIO.c
+++ b/modules/c/nitf/source/ImageIO.c
@@ -7408,7 +7408,7 @@ int nitf_ImageIO_cachedReader(_nitf_ImageIOBlock * blockIO,
             else
             {
                 /* Decompression interface structure */
-                nitf_DecompressionInterface *interface;
+                nitf_DecompressionInterface* decompInterface;
 
                 /* No plugin */
                 if (nitf->decompressor == NULL)
@@ -7419,14 +7419,16 @@ int nitf_ImageIO_cachedReader(_nitf_ImageIOBlock * blockIO,
                     return NITF_FAILURE;
                 }
 
-                interface = nitf->decompressor;
+                decompInterface = nitf->decompressor;
                 if (nitf->blockControl.block != NULL)
-                    (*(interface->freeBlock)) (nitf->decompressionControl,
-                                               nitf->blockControl.block,
-                                               error);
+                    (*(decompInterface->freeBlock)) (nitf->decompressionControl,
+                                                     nitf->blockControl.block,
+                                                     error);
                 nitf->blockControl.block =
-                    (*(interface->readBlock)) (nitf->decompressionControl,
-                                               blockIO->number, &blockSize, error);
+                    (*(decompInterface->readBlock)) (nitf->decompressionControl,
+                                                     blockIO->number,
+                                                     &blockSize,
+                                                     error);
                 if (nitf->blockControl.block == NULL)
                     return NITF_FAILURE;
             }
@@ -7528,7 +7530,7 @@ NITFPROT(nitf_Uint8*) nitf_ImageIO_readBlockDirect(nitf_ImageIO* nitf,
         else
         {
             /* Decompression interface structure */
-            nitf_DecompressionInterface *interface;
+            nitf_DecompressionInterface* decompInterface;
 
             /* No plugin */
             if (nitfI->decompressor == NULL)
@@ -7539,15 +7541,15 @@ NITFPROT(nitf_Uint8*) nitf_ImageIO_readBlockDirect(nitf_ImageIO* nitf,
                 return NULL;
             }
 
-            interface = nitfI->decompressor;
+            decompInterface = nitfI->decompressor;
             if (nitfI->blockControl.block != NULL)
-                (*(interface->freeBlock)) (nitfI->decompressionControl,
-                                           nitfI->blockControl.block,
-                                           error);
+                (*(decompInterface->freeBlock)) (nitfI->decompressionControl,
+                                                 nitfI->blockControl.block,
+                                                 error);
             nitfI->blockControl.block =
-                (*(interface->readBlock)) (nitfI->decompressionControl,
-                                           blockNumber, blockSize,
-                                           error);
+                (*(decompInterface->readBlock)) (nitfI->decompressionControl,
+                                                 blockNumber, blockSize,
+                                                 error);
             if (nitfI->blockControl.block == NULL)
             {
                 return NULL;

--- a/modules/c/nrt/include/nrt/Types.h
+++ b/modules/c/nrt/include/nrt/Types.h
@@ -73,7 +73,11 @@ typedef nrt_Int64 nrt_Off;
 #      define  NRT_ACCESS_READWRITE GENERIC_READ|GENERIC_WRITE
 
 /* type suffixes */
+#if defined(__GNUC__)
+#      define  NRT_INT64(x) x##LL
+#else
 #      define  NRT_INT64(x) x##i64
+#endif
 
 #else
 /*


### PR DESCRIPTION
* There is a `#define` we need to look for if we have gnu or not
* The `interface` keyword is reserved on Windows... not sure why VS doesn't care but gcc does

FYI @JonathanMeans 