### PR TITLE
Template nitf::Field cast operator

### DIFF
--- a/modules/c++/nitf/include/nitf/Field.hpp
+++ b/modules/c++/nitf/include/nitf/Field.hpp
@@ -23,15 +23,17 @@
 #ifndef __NITF_FIELD_HPP__
 #define __NITF_FIELD_HPP__
 
-#include "nitf/Field.h"
-#include "nitf/System.hpp"
-#include "nitf/NITFException.hpp"
-#include "nitf/Object.hpp"
-#include "nitf/HashTable.hpp"
-#include "nitf/List.hpp"
-#include "nitf/DateTime.hpp"
-#include <import/str.h>
 #include <string>
+#include <limits>
+
+#include <import/str.h>
+#include <nitf/Field.h>
+#include <nitf/System.hpp>
+#include <nitf/NITFException.hpp>
+#include <nitf/Object.hpp>
+#include <nitf/HashTable.hpp>
+#include <nitf/List.hpp>
+#include <nitf/DateTime.hpp>
 
 /*!
  *  \file Field.hpp
@@ -49,6 +51,39 @@ namespace nitf
  */
 class Field : public nitf::Object<nitf_Field>
 {
+private:
+    // Some template metaprogramming to allow us to provide a templated
+    // operator T() below - this'll get us the right numeric type and then we
+    // have an overloading for std::string below
+    template <bool IsIntegerT, bool IsSignedT>
+    struct GetConvType
+    {
+    };
+
+    template <>
+    struct GetConvType<true, true>
+    {
+        static const nitf_ConvType CONV_TYPE = NITF_CONV_INT;
+    };
+
+    template <>
+    struct GetConvType<true, false>
+    {
+        static const nitf_ConvType CONV_TYPE = NITF_CONV_UINT;
+    };
+
+    template <bool IsSignedT>
+    struct GetConvType<false, IsSignedT>
+    {
+        static const nitf_ConvType CONV_TYPE = NITF_CONV_REAL;
+    };
+
+    template <typename T>
+    nitf_ConvType getConvType() const
+    {
+        return GetConvType<std::numeric_limits<T>::is_integer,
+                           std::numeric_limits<T>::is_signed>::CONV_TYPE;
+    }
 
 public:
 enum FieldType
@@ -318,76 +353,16 @@ enum FieldType
         field->resizable = resizable;
     }
 
-    operator nitf::Uint8() const
+    //! Returns the field as any numeric type T
+    template <typename T>
+    operator T() const
     {
-        nitf::Uint8 data;
-        get(&data, NITF_CONV_UINT, sizeof(nitf::Uint8));
+        T data;
+        get(&data, getConvType<T>(), sizeof(T));
         return data;
     }
 
-    operator nitf::Uint16() const
-    {
-        nitf::Uint16 data;
-        get(&data, NITF_CONV_UINT, sizeof(nitf::Uint16));
-        return data;
-    }
-
-    operator nitf::Uint32() const
-    {
-        nitf::Uint32 data;
-        get(&data, NITF_CONV_UINT, sizeof(nitf::Uint32));
-        return data;
-    }
-
-    operator nitf::Uint64() const
-    {
-        nitf::Uint64 data;
-        get(&data, NITF_CONV_UINT, sizeof(nitf::Uint64));
-        return data;
-    }
-
-    operator nitf::Int8() const
-    {
-        nitf::Int8 data;
-        get(&data, NITF_CONV_INT, sizeof(nitf::Int8));
-        return data;
-    }
-
-    operator nitf::Int16() const
-    {
-        nitf::Int16 data;
-        get(&data, NITF_CONV_INT, sizeof(nitf::Int16));
-        return data;
-    }
-
-    operator nitf::Int32() const
-    {
-        nitf::Int32 data;
-        get(&data, NITF_CONV_INT, sizeof(nitf::Int32));
-        return data;
-    }
-
-    operator nitf::Int64() const
-    {
-        nitf::Int64 data;
-        get(&data, NITF_CONV_INT, sizeof(nitf::Int64));
-        return data;
-    }
-
-    operator float() const
-    {
-        float data;
-        get(&data, NITF_CONV_REAL, sizeof(float));
-        return data;
-    }
-
-    operator double() const
-    {
-        double data;
-        get(&data, NITF_CONV_REAL, sizeof(double));
-        return data;
-    }
-
+    //! Returns the field as a string
     operator std::string() const
     {
         return toString();

--- a/modules/c++/nitf/unittests/test_field++.cpp
+++ b/modules/c++/nitf/unittests/test_field++.cpp
@@ -20,6 +20,7 @@
  *
  */
 
+#include <sys/sys_config.h>
 #include <nitf/Field.hpp>
 #include "TestCase.h"
 
@@ -42,10 +43,19 @@ TEST_CASE(testCastOperator)
     field.set(1234567890);
     const nitf::Uint32 valUint32 = field;
     TEST_ASSERT_EQ(valUint32, 1234567890);
+#if SIZEOF_SIZE_T == 4
+    const size_t valSizeT = field;
+    TEST_ASSERT_EQ(valSizeT, 1234567890);
+#endif
 
     field.set(nitf::Uint64(1234567890987));
     const nitf::Uint64 valUint64 = field;
     TEST_ASSERT_EQ(valUint64, 1234567890987);
+
+#if SIZEOF_SIZE_T == 8
+    const size_t valSizeT = field;
+    TEST_ASSERT_EQ(valSizeT, 1234567890987);
+#endif
 
     // Test signed values
     field.set(-123);
@@ -59,12 +69,20 @@ TEST_CASE(testCastOperator)
     field.set(-1234567890);
     const nitf::Int32 valInt32 = field;
     TEST_ASSERT_EQ(valInt32, -1234567890);
+#if SIZEOF_SIZE_T == 4
+    const size_t valSSizeT = field;
+    TEST_ASSERT_EQ(valSSizeT, -1234567890);
+#endif
 
     // TODO: I think the %lld isn't working, at least in VS, in
     //       nitf_Field_setInt64(), so need to do this via string
     field.set("-1234567890987");
     const nitf::Int64 valInt64 = field;
     TEST_ASSERT_EQ(valInt64, -1234567890987);
+#if SIZEOF_SIZE_T == 8
+    const size_t valSSizeT = field;
+    TEST_ASSERT_EQ(valSSizeT, -1234567890987);
+#endif
 
     // Test float values
     field.set(-123.45f);

--- a/modules/c++/nitf/unittests/test_field++.cpp
+++ b/modules/c++/nitf/unittests/test_field++.cpp
@@ -1,0 +1,89 @@
+/* =========================================================================
+ * This file is part of NITRO
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * NITRO is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <nitf/Field.hpp>
+#include "TestCase.h"
+
+namespace
+{
+TEST_CASE(testCastOperator)
+{
+    nitf_Error error;
+    nitf::Field field(nitf_Field_construct(20, NITF_BCS_A, &error));
+
+    // Test unsigned values
+    field.set(123);
+    const nitf::Uint8 valUint8 = field;
+    TEST_ASSERT_EQ(valUint8, 123);
+
+    field.set(12345);
+    const nitf::Uint16 valUint16 = field;
+    TEST_ASSERT_EQ(valUint16, 12345);
+
+    field.set(1234567890);
+    const nitf::Uint32 valUint32 = field;
+    TEST_ASSERT_EQ(valUint32, 1234567890);
+
+    field.set(nitf::Uint64(1234567890987));
+    const nitf::Uint64 valUint64 = field;
+    TEST_ASSERT_EQ(valUint64, 1234567890987);
+
+    // Test signed values
+    field.set(-123);
+    const nitf::Int8 valInt8 = field;
+    TEST_ASSERT_EQ(valInt8, -123);
+
+    field.set(-12345);
+    const nitf::Int16 valInt16 = field;
+    TEST_ASSERT_EQ(valInt16, -12345);
+
+    field.set(-1234567890);
+    const nitf::Int32 valInt32 = field;
+    TEST_ASSERT_EQ(valInt32, -1234567890);
+
+    // TODO: I think the %lld isn't working, at least in VS, in
+    //       nitf_Field_setInt64(), so need to do this via string
+    field.set("-1234567890987");
+    const nitf::Int64 valInt64 = field;
+    TEST_ASSERT_EQ(valInt64, -1234567890987);
+
+    // Test float values
+    field.set(-123.45f);
+    const float valFloat = field;
+    TEST_ASSERT_EQ(valFloat, -123.45f);
+
+    field.set(-567.89);
+    const double valDouble = field;
+    TEST_ASSERT_EQ(valDouble, -567.89);
+
+    // Test arbitrary string
+    field.set("ABCxyz");
+    const std::string valStr = field;
+    TEST_ASSERT_EQ(valStr, "ABCxyz              ");
+}
+}
+
+int main(int , char** )
+{
+    TEST_CHECK(testCastOperator);
+    return 0;
+}

--- a/modules/c/nitf/source/Field.c
+++ b/modules/c/nitf/source/Field.c
@@ -311,7 +311,7 @@ NITFAPI(NITF_BOOL) nitf_Field_setInt64(nitf_Field * field,
         return (NITF_FAILURE);
     }
 
-    /*  Convert thte number to a string */
+    /*  Convert the number to a string */
 
     NITF_SNPRINTF(numberBuffer, 20, "%lld", (long long)number);
     numberLen = strlen(numberBuffer);
@@ -811,6 +811,12 @@ NITFPRIV(NITF_BOOL) fromStringToInt(nitf_Field * field,
     buffer[field->length] = 0;
     switch (length)
     {
+        case 1:
+        {
+            nitf_Int8 *int8 = (nitf_Int8 *) outData;
+            *int8 = (nitf_Int8) NITF_ATO32(buffer);
+        }
+        break;
         case 2:
         {
             nitf_Int16 *int16 = (nitf_Int16 *) outData;
@@ -858,6 +864,12 @@ NITFPRIV(NITF_BOOL) fromStringToUint(nitf_Field * field,
     buffer[field->length] = 0;
     switch (length)
     {
+        case 1:
+        {
+            nitf_Uint8 *int8 = (nitf_Uint8 *) outData;
+            *int8 = (nitf_Uint8) NITF_ATO32(buffer);
+        }
+        break;
         case 2:
         {
             nitf_Uint16 *int16 = (nitf_Uint16 *) outData;


### PR DESCRIPTION
This gets rid of some duplicate code at the cost of some template metaprogramming complication.  The main motivation is to address cases like described in https://github.com/ngageoint/six-library/pull/191 where the compiler (OS X in this case) doesn't figure out to use the `nitf::Uint64` cast operator for `size_t`.  Now it's just templated so it should auto-magically find it.

Also added conversions in the base C layer for 1 byte signed/unsigned ints... apparently this never worked in the past.

Added a unittest to make sure all conversions still work.