### PR TITLE
BufferedReader did not handle seeking to end of file properly

### DIFF
--- a/modules/c++/nitf/include/nitf/BufferedReader.hpp
+++ b/modules/c++/nitf/include/nitf/BufferedReader.hpp
@@ -58,7 +58,7 @@ public:
      *  \param adopt If this is true BufferedReader will own 'buffer'.
      */
     BufferedReader(const std::string& pathname,
-                   char* buffer,
+                   void* buffer,
                    size_t size,
                    bool adopt = false);
 
@@ -106,11 +106,12 @@ protected:
 private:
     void readNextBuffer();
 
-    const size_t mBufferSize;
+    const size_t mMaxBufferSize;
     const mem::ScopedArray<char> mScopedBuffer;
     char* const mBuffer;
 
     size_t mPosition;
+    size_t mBufferSize;
     size_t mTotalRead;
     size_t mBlocksRead;
     size_t mPartialBlocks;

--- a/modules/c++/nitf/source/BufferedReader.cpp
+++ b/modules/c++/nitf/source/BufferedReader.cpp
@@ -149,13 +149,13 @@ nitf::Off BufferedReader::seekImpl(nitf::Off offset, int whence)
     nitf::Off desiredPos;
     switch (whence)
     {
-    case SEEK_SET:
+    case sys::File::FROM_START:
         desiredPos = offset;
         break;
-    case SEEK_CUR:
+    case sys::File::FROM_CURRENT:
         desiredPos = bufferStart + mPosition + offset;
         break;
-    case SEEK_END:
+    case sys::File::FROM_END:
         desiredPos = mFile.length() + offset;
         break;
     default:


### PR DESCRIPTION
Previously `BufferedReader` only kept a single constant `mBufferSize` value which was the allocated size of the buffer.  When the file position was updated to be near enough the end of the file that `readNextBuffer()` couldn't read in `mBufferSize` bytes, that method correctly read in fewer bytes, but subsequent spots like `readImpl()` and `tellImpl()` treated it as if it had been a full `mBufferSize` bytes that were read in.  We need to use two variables to keep track of this.

Also improved `seekImpl()` - if you are seeking to a spot you already read in, there's no reason to trigger a read yet.

FYI to @msciaramitaro and @clydestanfield... I guess we didn't have code using `BufferedReader` or else we would have hit this a long time ago.

@JonathanMeans double-check my pointer arithmetic everywhere to make sure I didn't goof anything up.