### PR TITLE
Fixed bug in bufferSize calculation due to misplacing a parenthesis

### DIFF
--- a/modules/c++/nitf/include/nitf/BufferedReader.hpp
+++ b/modules/c++/nitf/include/nitf/BufferedReader.hpp
@@ -117,6 +117,7 @@ private:
     size_t mPartialBlocks;
     double mElapsedTime;
     mutable sys::File mFile;
+    const sys::Off_T mFileLen;
 };
 
 }


### PR DESCRIPTION
Ugh - in trying to make the ternary operator line that assigns `bufferSize` more legible in `readNextBuffer()` by adding some `()`s, I put the opening one in the wrong spot which broke the calculation.

Breaking this out into multiple lines now to make it more clear, and having one less call to `getCurrentOffset()` as I'm not sure if that's expensive or not.  Similarly, saving off the file length as this'll never change and we check it every time we call `readImpl()`.