### PR TITLE
Moving image segment logic from SIX into NITRO

### DIFF
--- a/modules/c++/nitf/include/nitf/ImageSegmentComputer.h
+++ b/modules/c++/nitf/include/nitf/ImageSegmentComputer.h
@@ -1,0 +1,240 @@
+/* =========================================================================
+ * This file is part of NITRO
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2017, MDA Information Systems LLC
+ *
+ * NITRO is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __NITF_IMAGE_SEGMENT_COMPUTER_H__
+#define __NITF_IMAGE_SEGMENT_COMPUTER_H__
+
+#include <vector>
+#include <string>
+
+#include <nitf/System.hpp>
+
+namespace nitf
+{
+/*!
+ * \class ImageSegmentComputer
+ *
+ * \brief Contains logic to take a large image and determine the segmentation
+ * required in order to stay within the NITF limits for total image segment
+ * size (~10 GB) and max number of rows (because we will be creating multiple
+ * image segments all attached to each other, we'll use ILOC to relate them
+ * together, but ILOC only has five digits for row so multi-segment products
+ * can't be more than 99,999 rows).
+ *
+ * Currently only supports segmenting in the row direction.
+ */
+class ImageSegmentComputer
+{
+public:
+    /*!
+     * Max number of rows that can fit in an image segment and still be
+     * representable in the following image segment via the ILOC field
+     */
+    static const size_t ILOC_MAX;
+
+    /*!
+     * Max number of bytes for an image segment's data (per the NITF spec -
+     * this is due to the length field only being 10 digits)
+     */
+    static const Uint64 NUM_BYTES_MAX;
+
+    /*!
+     * \class Segment
+     *
+     * \brief Represents information about a segment in terms of its size and
+     * position with respect to the global image
+     */
+    struct Segment
+    {
+        //! First row in the image segment in real space
+        size_t firstRow;
+
+        /*!
+         * Row offset in the CCS (ILOC R)
+         * When you are attached to another segment, ILOC is with respect to
+         * that segment.  We will always attach to the previous segment,
+         * so this will simply be the number of rows in that previous segment.
+         */
+        size_t rowOffset;
+
+        //! Number of rows in this segment
+        size_t numRows;
+
+        //! \return The end row (exclusive) of the image segment
+        size_t endRow() const
+        {
+            return firstRow + numRows;
+        }
+
+        //! \return The proper population of ILOC for this segment
+        std::string getILOC() const;
+
+        /*!
+         * Given a global pixel range of
+         * [rangeStartRow, rangeStartRow + rangeNumRows), determines if this
+         * range overlaps with this segment and, if so, what rows overlap with
+         * it
+         *
+         * \param rangeStartRow The inclusive global start row of the range of
+         * interest
+         * \param rangeNumRows The number of rows in the range of interest
+         * \param[out] firstGlobalRowInThisSegment If the range does appear in
+         * this segment, the first global row of the range that's in the
+         * segment (if the range starts prior to this segment, it'll be the
+         * first row of the segment.  If the range starts inside the segment,
+         * it'll be the first row of the range).  If the range does not appear
+         * in this segment, this is set to numeric_limits<size_t>::max().
+         * \param[out] numRowsInThisSegment The number of rows of the range
+         * which appear in this segment
+         *
+         * \return True if the range overlaps with this segment, false
+         * otherwise
+         */
+        bool isInRange(size_t rangeStartRow,
+                       size_t rangeNumRows,
+                       size_t& firstGlobalRowInThisSegment,
+                       size_t& numRowsInThisSegment) const;
+
+        /*!
+         * Convenience static implementation
+         *
+         * \param firstRow First row (inclusive) of the segment of interest
+         * \param endRow End row (exclusive) of the segment of interest
+         * \param rangeStartRow The inclusive global start row of the range of
+         * interest
+         * \param rangeNumRows The number of rows in the range of interest
+         * \param[out] firstGlobalRowInThisSegment If the range does appear in
+         * this segment, the first global row of the range that's in the
+         * segment (if the range starts prior to this segment, it'll be the
+         * first row of the segment.  If the range starts inside the segment,
+         * it'll be the first row of the range).  If the range does not appear
+         * in this segment, this is set to numeric_limits<size_t>::max().
+         * \param[out] numRowsInThisSegment The number of rows of the range
+         * which appear in this segment
+         *
+         * \return True if the range overlaps with this segment, false
+         * otherwise
+         */
+        static
+        bool isInRange(size_t firstRow,
+                       size_t endRow,
+                       size_t rangeStartRow,
+                       size_t rangeNumRows,
+                       size_t& firstGlobalRowInThisSegment,
+                       size_t& numRowsInThisSegment);
+    };
+
+    /*!
+     * \param numRows Number of total rows in the image
+     * \param numCols Number of columns in the image
+     * \param numBytesPerPixel Number of bytes per pixel
+     * \param maxRows Maximum number of rows allowed in an image segment.
+     * Only applies when there is more than one image segment (we're ensuring
+     * that the 5 characters reserved for the row offset in ILOC don't
+     * overflow, so if there is only one image segment, there is no row offset
+     * and thus no restriction on the number of rows).  Defaults to ILOC_MAX.
+     * \param maxSize Maximum number of bytes allows in an image segment.
+     * Defaults to NUM_BYTES_MAX which is the ~10 GB NITF limit.
+     * \param rowsPerBlock The number of rows in a NITF block.  Set this to 0
+     * if the NITF is not blocked.  This needs to be taken into account as it'll
+     * affect segmentation since NITFs always write entire NITF blocks even
+     * when there are fewer rows than a multiple of the block size.  Defaults to
+     * 0 (no blocking).
+     * \param colsPerBlock The number of columns in a NITF block.  Set this to
+     * 0 if the NITF is not blocked.  This needs to be taken into account as
+     * it'll affect segmentation since NITFs always write entire NITF blocks
+     * even when there are fewer columns than a multiple of the block size.
+     * Defaults to 0 (no blocking).
+     */
+    ImageSegmentComputer(size_t numRows,
+                         size_t numCols,
+                         size_t numBytesPerPixel,
+                         size_t maxRows = ILOC_MAX,
+                         Uint64 maxSize = NUM_BYTES_MAX,
+                         size_t rowsPerBlock = 0,
+                         size_t colsPerBlock = 0);
+
+    //! \return Segment layout
+    const std::vector<Segment>& getSegments() const
+    {
+        return mSegments;
+    }
+
+    //! \return Number of total bytes in the image
+    Uint64 getNumBytesTotal() const
+    {
+        return mNumBytesTotal;
+    }
+
+    //! \return Total number of rows we can have in a NITF segment
+    size_t getNumRowsLimit() const
+    {
+        return mNumRowsLimit;
+    }
+
+    //! \return Max number of bytes that each image segment can be
+    Uint64 getMaxNumBytesPerSegment() const
+    {
+        return mMaxNumBytesPerSegment;
+    }
+
+private:
+    // This is the actual size of a dimension (row or column)
+    // taking into account the possible blocking (pixels)
+    static
+    size_t getActualDim(size_t dim, size_t numDimsPerBlock);
+
+    void computeImageInfo();
+
+    void computeSegmentInfo();
+
+private:
+    //! Total number of rows in the image
+    const size_t mNumRows;
+
+    //! Total number of columns in the image
+    const size_t mNumCols;
+
+    //! Number of bytes per pixel
+    const size_t mNumBytesPerPixel;
+
+    //! Total number of rows we can have in a NITF segment
+    size_t mNumRowsLimit;
+
+    //! Number of columns once blocking is taken into account
+    const size_t mNumColsPaddedForBlocking;
+
+    //! Block size in the row direction, pixels
+    const size_t mNumRowsPerBlock;
+
+    //! Total size in bytes that each product seg can be
+    const Uint64 mMaxNumBytesPerSegment;
+
+    //! Number of bytes in the product
+    const Uint64 mNumBytesTotal;
+
+    //! Segment layout
+    std::vector<Segment> mSegments;
+};
+}
+
+#endif

--- a/modules/c++/nitf/source/ImageSegmentComputer.cpp
+++ b/modules/c++/nitf/source/ImageSegmentComputer.cpp
@@ -1,0 +1,231 @@
+/* =========================================================================
+ * This file is part of NITRO
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2017, MDA Information Systems LLC
+ *
+ * NITRO is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <sstream>
+#include <limits>
+#include <cmath>
+#include <algorithm>
+
+#include <sys/Conf.h>
+#include <except/Exception.h>
+#include <nitf/ImageSegmentComputer.h>
+
+namespace nitf
+{
+const size_t ImageSegmentComputer::ILOC_MAX = 99999;
+const Uint64 ImageSegmentComputer::NUM_BYTES_MAX = 9999999998LL;
+
+std::string ImageSegmentComputer::Segment::getILOC() const
+{
+    static const size_t COL = 0;
+
+    std::ostringstream ostr;
+    ostr.fill('0');
+    ostr << std::setw(5) << rowOffset << std::setw(5) << COL;
+
+    return ostr.str();
+}
+
+bool ImageSegmentComputer::Segment::isInRange(
+        size_t firstRow,
+        size_t endRow,
+        size_t rangeStartRow,
+        size_t rangeNumRows,
+        size_t& firstGlobalRowInThisSegment,
+        size_t& numRowsInThisSegment)
+{
+    const size_t startGlobalRow = std::max(firstRow, rangeStartRow);
+    const size_t endGlobalRow =
+            std::min(endRow, rangeStartRow + rangeNumRows);
+
+    if (endGlobalRow > startGlobalRow)
+    {
+        firstGlobalRowInThisSegment = startGlobalRow;
+        numRowsInThisSegment = endGlobalRow - startGlobalRow;
+        return true;
+    }
+    else
+    {
+        firstGlobalRowInThisSegment = std::numeric_limits<size_t>::max();
+        numRowsInThisSegment = 0;
+        return false;
+    }
+}
+
+bool ImageSegmentComputer::Segment::isInRange(
+        size_t rangeStartRow,
+        size_t rangeNumRows,
+        size_t& firstGlobalRowInThisSegment,
+        size_t& numRowsInThisSegment) const
+{
+    return isInRange(firstRow, endRow(), rangeStartRow, rangeNumRows,
+                     firstGlobalRowInThisSegment, numRowsInThisSegment);
+}
+
+ImageSegmentComputer::ImageSegmentComputer(size_t numRows,
+                                           size_t numCols,
+                                           size_t numBytesPerPixel,
+                                           size_t maxRows,
+                                           Uint64 maxSize,
+                                           size_t rowsPerBlock,
+                                           size_t colsPerBlock) :
+    mNumRows(numRows),
+    mNumCols(numCols),
+    mNumBytesPerPixel(numBytesPerPixel),
+    mNumRowsLimit(maxRows),
+    mNumColsPaddedForBlocking(getActualDim(mNumCols, colsPerBlock)),
+    mNumRowsPerBlock(rowsPerBlock),
+    mMaxNumBytesPerSegment(maxSize),
+    mNumBytesTotal(static_cast<Uint64>(mNumBytesPerPixel) *
+                 getActualDim(mNumRows, rowsPerBlock) *
+                 mNumColsPaddedForBlocking)
+{
+    if (maxRows > ILOC_MAX)
+    {
+        std::ostringstream ostr;
+        ostr << "Max rows was set to " << maxRows
+             << " but it cannot be greater than " << ILOC_MAX
+             << " per the NITF spec";
+        throw except::Exception(Ctxt(ostr.str()));
+    }
+
+    if (maxSize > NUM_BYTES_MAX)
+    {
+        std::ostringstream ostr;
+        ostr << "Max image segment size was set to " << maxSize
+             << " but it cannot be greater than " << NUM_BYTES_MAX
+             << " per the NITF spec";
+        throw except::Exception(Ctxt(ostr.str()));
+    }
+
+    computeImageInfo();
+    computeSegmentInfo();
+}
+
+size_t ImageSegmentComputer::getActualDim(size_t dim, size_t numDimsPerBlock)
+{
+    if (numDimsPerBlock == 0)
+    {
+        return dim;
+    }
+    else
+    {
+        // If we're blocking then we'll always write full blocks due to how
+        // the NITF file layout works
+        const size_t numBlocks =
+                (dim / numDimsPerBlock) + (dim % numDimsPerBlock != 0);
+        return numBlocks * numDimsPerBlock;
+    }
+}
+
+void ImageSegmentComputer::computeImageInfo()
+{
+    // Consider possible blocking when determining the maximum number of rows
+    const Uint64 bytesPerRow =
+            static_cast<Uint64>(mNumBytesPerPixel) *
+            mNumColsPaddedForBlocking;
+
+    const Uint64 maxRowsUint64 =
+            static_cast<Uint64>(mMaxNumBytesPerSegment) / bytesPerRow;
+    if (maxRowsUint64 > std::numeric_limits<size_t>::max())
+    {
+        // This should not be possible
+        std::ostringstream ostr;
+        ostr << "Image would require " << maxRowsUint64
+             << " rows which is too many";
+        throw except::Exception(Ctxt(ostr.str()));
+    }
+    size_t maxRows(static_cast<size_t>(maxRowsUint64));
+
+    if (maxRows == 0)
+    {
+        std::ostringstream ostr;
+        ostr << "maxNumBytesPerSegment [" << mMaxNumBytesPerSegment
+             << "] < bytesPerRow [" << bytesPerRow << "]";
+        throw except::Exception(Ctxt(ostr.str()));
+    }
+
+    // Truncate back to a full block for the maxRows that will actually fit
+    if (mNumRowsPerBlock != 0)
+    {
+        const size_t numBlocksVert = maxRows / mNumRowsPerBlock;
+        maxRows = numBlocksVert * mNumRowsPerBlock;
+
+        if (maxRows == 0)
+        {
+            std::ostringstream ostr;
+            ostr << "With a max number of bytes per segment of "
+                 << mMaxNumBytesPerSegment
+                 << ", bytes per row of " << bytesPerRow
+                 << ", and rows per block of " << mNumRowsPerBlock
+                 << ", cannot fit an entire block into a segment";
+            throw except::Exception(Ctxt(ostr.str()));
+        }
+    }
+
+    if (mNumRowsLimit > maxRows)
+    {
+        mNumRowsLimit = maxRows;
+    }
+}
+
+void ImageSegmentComputer::computeSegmentInfo()
+{
+    // TODO: other conditions which should trigger segmentation:
+    //   NCOLS >= 10E8   column direction segmentation, no numColsLimit logic
+    //                   in place
+    //   NROWS >= 10E8   most likely would exceed mMaxNumBytesPerSegment
+    //                   (ncols < 100 unlikely)
+    //                   and segment to mNumRowsLimit anyway
+    if (mNumBytesTotal <= mMaxNumBytesPerSegment)
+    {
+        mSegments.resize(1);
+        mSegments[0].numRows = mNumRows;
+        mSegments[0].firstRow = 0;
+        mSegments[0].rowOffset = 0;
+    }
+
+    else
+    {
+        // NOTE: See header for why rowOffset is always set to mNumRowsLimit
+        //       for image segments 1 and above
+        const size_t numIS = static_cast<size_t>(std::ceil(
+                static_cast<double>(mNumRows) / mNumRowsLimit));
+
+        mSegments.resize(numIS);
+        mSegments[0].numRows = mNumRowsLimit;
+        mSegments[0].firstRow = 0;
+        mSegments[0].rowOffset = 0;
+        size_t ii;
+        for (ii = 1; ii < numIS - 1; ii++)
+        {
+            mSegments[ii].numRows = mNumRowsLimit;
+            mSegments[ii].firstRow = ii * mNumRowsLimit;
+            mSegments[ii].rowOffset = mNumRowsLimit;
+        }
+
+        mSegments[ii].firstRow = ii * mNumRowsLimit;
+        mSegments[ii].rowOffset = mNumRowsLimit;
+        mSegments[ii].numRows = mNumRows - (numIS - 1) * mNumRowsLimit;
+    }
+}
+}


### PR DESCRIPTION
This generalizes the logic in SIX which deals with breaking large images into multiple image segments per the NITF spec requirements.

FYI @JonathanMeans 