### PR TITLE
Upgrade openjpg from v2.0.0 to v2.3.0

### DIFF
--- a/modules/c/j2k/external/openjpeg/wscript
+++ b/modules/c/j2k/external/openjpeg/wscript
@@ -49,95 +49,60 @@ def configure(conf):
 
         # callback function to check for #defines used by the openjpg module
         def opj_private_callback(conf):
-            conf.check_cc(
-                    header_name='inttypes.h',
-                    define_name='OPJ_HAVE_INTTYPES_H',
-                    mandatory=False)
+            if conf.check_cc(function_name='fseeko', header_name='stdio.h',
+                             define_name='OPJ_HAVE_FSEEK0', mandatory=False):
+                conf.define('OPJ_HAVE_FSEEK0', 'ON', quote=False)
 
-            if conf.check_cc(
-                    function_name='fseeko',
-                    header_name='stdio.h',
-                    define_name='OPJ_HAVE_FSEEK0',
-                    mandatory=False):
-                conf.define('OPJ_HAVE_FSEEK0', '', quote=False)
-
-            if conf.check_cc(
-                    header_name='malloc.h',
-                    define_name='OPJ_HAVE_MALLOC_H',
-                    mandatory=False):
-                conf.define('OPJ_HAVE_MALLOC_H', '', quote=False)
-
-            if conf.check_cc(
-                    function_name='memalign',
-                    header_name='malloc.h',
-                    define_name='OPJ_HAVE_MEMALIGN',
-                    mandatory=False):
-                conf.define('OPJ_HAVE_MEMALIGN', '', quote=False)
-
-            if conf.check_cc(
-                    function_name='_aligned_malloc',
-                    header_name='malloc.h',
-                    define_name='OPJ_HAVE__ALIGNED_MALLOC',
-                    mandatory=False):
-                conf.define('OPJ_HAVE__ALIGNED', '', quote=False)
-
-            if conf.check_cc(
-                    function_name='posix_memalign',
-                    header_name='stdlib.h',
-                    define_name='OPJ_HAVE_POSIX_MEMALIGN',
-                    mandatory=False):
-                conf.define('OPJ_HAVE_POSIX_MEMALIGN', '', quote=False)
-
-            if conf.check_cc(header_name='string.h', mandatory=False):
-                conf.define('HAVE_STRING_H', '', quote=False)
-            if conf.check_cc(header_name='memory.h', mandatory=False):
-                conf.define('HAVE_MEMORY_H', '', quote=False)
-            if conf.check_cc(header_name='stdlib.h', mandatory=False):
-                conf.define('HAVE_STDLIB_H', '', quote=False)
-            if conf.check_cc(header_name='stdio.h', mandatory=False):
-                conf.define('HAVE_STDIO_H', '', quote=False)
-            if conf.check_cc(header_name='math.h', mandatory=False):
-                conf.define('HAVE_MATH_H', '', quote=False)
-            if conf.check_cc(header_name='float.h', mandatory=False):
-                conf.define('HAVE_FLOAT_H', '', quote=False)
-            if conf.check_cc(header_name='time.h', mandatory=False):
-                conf.define('HAVE_TIME_H', '', quote=False)
-            if conf.check_cc(header_name='stdarg.h', mandatory=False):
-                conf.define('HAVE_STDARG_H', '', quote=False)
-            if conf.check_cc(header_name='ctype.h', mandatory=False):
-                conf.define('HAVE_CTYPE_H', '', quote=False)
-            if conf.check_cc(header_name='assert.h', mandatory=False):
-                conf.define('HAVE_ASSERT_H', '', quote=False)
-
-            if conf.check_cc(header_name='strings.h', mandatory=False):
-                conf.define('HAVE_STRINGS_H', '', quote=False)
             if conf.check_cc(header_name='sys/stat.h', mandatory=False):
                 conf.define('HAVE_SYS_STAT_H', '', quote=False)
             if conf.check_cc(header_name='sys/types.h', mandatory=False):
                 conf.define('HAVE_SYS_TYPES_H', '', quote=False)
+            if conf.check_cc(header_name='memory.h', mandatory=False):
+                conf.define('HAVE_MEMORY_H', '', quote=False)
+
+            conf.check_cc(header_name='inttypes.h',
+                          define_name='OPJ_HAVE_INTTYPES_H',
+                          mandatory=False)
+
             if conf.check_cc(header_name='unistd.h', mandatory=False):
                 conf.define('HAVE_UNISTD_H', '', quote=False)
-
-            if conf.check_cc(
-                    type_name='ssize_t',
-                    header_name='sys/types.h',
-                    mandatory=False):
-                conf.define('HAVE_SSIZE_T', '', quote=False)
 
             if conf.check_cc(header_name='fcntl.h', mandatory=False):
                 conf.define('HAVE_FCNTL_H', '', quote=False)
 
-            if conf.check_cc(
-                    function_name='mmap',
-                    header_name='sys/mman.h',
-                    mandatory=False):
+            if conf.check_cc(function_name='mmap', header_name='sys/mman.h',
+                             mandatory=False):
                 conf.define('HAVE_MMAP', '', quote=False)
 
             if conf.check_cc(header_name='stdbool.h', mandatory=False):
                 conf.define('HAVE_STDBOOL_H', '', quote=False)
 
-            if 'HAVE_SSIZE_T=1' in conf.env['DEFINES']:
-                conf.define('HAVE_SSIZE_T', ' ', quote=False)
+            if conf.check_cc(header_name='malloc.h',
+                             define_name='OPJ_HAVE_MALLOC_H', mandatory=False):
+                conf.define('OPJ_HAVE_MALLOC_H', '', quote=False)
+
+            if conf.check_cc(function_name='memalign', header_name='malloc.h',
+                             define_name='OPJ_HAVE_MEMALIGN', mandatory=False):
+                conf.define('OPJ_HAVE_MEMALIGN', '', quote=False)
+
+            if conf.check_cc(function_name='_aligned_malloc',
+                             header_name='malloc.h',
+                             define_name='OPJ_HAVE__ALIGNED_MALLOC',
+                             mandatory=False):
+                conf.define('OPJ_HAVE__ALIGNED_MALLOC', '', quote=False)
+
+            if conf.check_cc(function_name='aligned_alloc',
+                             header_name='malloc.h',
+                             define_name='OPJ_HAVE_ALIGNED_ALLOC',
+                             mandatory=False):
+                conf.define('OPJ_HAVE_ALIGNED_ALLOC', '', quote=False)
+
+            if conf.check_cc(function_name='posix_memalign',
+                             header_name='stdlib.h',
+                             define_name='OPJ_HAVE_POSIX_MEMALIGN',
+                             mandatory=False):
+                conf.define('OPJ_HAVE_POSIX_MEMALIGN', '', quote=False)
+
             if '_LARGEFILE_SOURCE' in conf.env['DEFINES']:
                 conf.define('_LARGEFILE_SOURCE', ' ', quote=False)
             if '_LARGE_FILES' in conf.env['DEFINES']:

--- a/modules/c/j2k/external/openjpeg/wscript
+++ b/modules/c/j2k/external/openjpeg/wscript
@@ -111,7 +111,7 @@ def configure(conf):
                 conf.define('_FILE_OFFSET_BITS', '64', quote=False)
 
             if '_POSIX_C_SOURCE' not in conf.env['DEFINES']:
-                if 'OPJ_HAVE_FSEEKO=ON' in conf.env['DEFINES'] or \
+                if 'OPJ_HAVE_FSEEKO=' in conf.env['DEFINES'] or \
                    'OPJ_HAVE_POSIX_MEMALIGN=' in conf.env['DEFINES']:
                     conf.define('_POSIX_C_SOURCE', '200112L', quote=False)
 

--- a/modules/c/j2k/external/openjpeg/wscript
+++ b/modules/c/j2k/external/openjpeg/wscript
@@ -5,7 +5,7 @@ from waflib.TaskGen import feature, before, task_gen
 from build import untarFile
 from build import writeConfig
 
-SOURCE        = 'openjpeg-2.0.0'
+SOURCE        = 'openjpeg-2.3.0'
 
 options = lambda x : None
 
@@ -13,50 +13,20 @@ def configure(conf):
     #conf.env['BUILD_PATH'] = conf.bldnode.abspath()
     
     j2kLayer = Options.options.j2k_layer
-
-    if j2kLayer == 'openjpeg' :
+    if j2kLayer == 'openjpeg':
         
         # callback function to check for all #defines used by the openjpg module
         def opj_callback(conf):            
             # check functionality
-            if conf.check_cc(function_name='fseeko', header_name="stdio.h", mandatory=False):
-                conf.define('HAVE_FSEEKO', '', quote=False)
-            if conf.check_cc(header_name="stdint.h", mandatory=False):
-                conf.define('HAVE_STDINT_H', '', quote=False)
-            if conf.check_cc(header_name="sys/stat.h", mandatory=False):
-                conf.define('HAVE_SYS_STAT_H', '', quote=False)
-            if conf.check_cc(header_name="sys/types.h", mandatory=False):
-                conf.define('HAVE_SYS_TYPES_H', '', quote=False)
-            if conf.check_cc(header_name="memory.h", mandatory=False):
-                conf.define('HAVE_MEMORY_H', '', quote=False)
-            
-            if conf.check_cc(header_name="inttypes.h", mandatory=False):
-                conf.define('HAVE_INTTYPES_H', '', quote=False)
-            if conf.check_cc(type_name='ssize_t', header_name='sys/types.h', mandatory=False):
-                conf.define('HAVE_SSIZE_T', '', quote=False)
-            if conf.check_cc(header_name="unistd.h", mandatory=False):
-                conf.define('HAVE_UNISTD_H', '', quote=False)
-            if conf.check_cc(header_name="fcntl.h", mandatory=False):
-                conf.define('HAVE_FCNTL_H', '', quote=False)
-            if conf.check_cc(function_name='mmap', header_name="sys/mman.h", mandatory=False):
-                conf.define('HAVE_MMAP', '', quote=False)
-            if conf.check_cc(header_name="stdbool.h", mandatory=False):
-                conf.define('HAVE_STDBOOL_H', '', quote=False)
-            
-            if 'HAVE_SSIZE_T=1' in conf.env['DEFINES']:
-                conf.define('HAVE_SSIZE_T', ' ', quote=False)
-            if '_LARGEFILE_SOURCE' in conf.env['DEFINES']:
-                conf.define('_LARGEFILE_SOURCE', ' ', quote=False)
-            if '_LARGEFILES' in conf.env['DEFINES']:
-                conf.define('_LARGEFILES', ' ', quote=False)
-            if '_FILE_OFFSET_BITS=64' in conf.env['DEFINES']:
-                conf.define('_FILE_OFFSET_BITS', '64', quote=False)
-            if 'HAVE_FSEEKO=1' in conf.env['DEFINES']:
-                conf.define('HAVE_FSEEKO', ' ', quote=False)
-            conf.define('OPJ_PACKAGE_VERSION',  '"2.0.0"', quote=False)
-            if sys.byteorder != 'little':
-                conf.define('OPJ_BIG_ENDIAN', ' ', quote=False)
-            
+            conf.check_cc(
+                    header_name='stdint.h',
+                    define_name='OPJ_HAVE_STDINT_H',
+                    mandatory=False)
+
+            conf.define('OPJ_VERSION_MAJOR', '2', quote=False)
+            conf.define('OPJ_VERSION_MINOR', '3', quote=False)
+            conf.define('OPJ_VERSION_BUILD', '0', quote=False)
+
         # check for the source tarball
         if not exists(join(conf.path.abspath(), SOURCE + '.tar')):
             conf.fatal('Missing OpenJPEG tarfile')
@@ -67,12 +37,125 @@ def configure(conf):
         conf.env['HAVE_J2K']      = True
         conf.msg('Building local lib', j2kLayer)
         untarFile(path=conf.path, fname=SOURCE + '.tar')
-        
-        # make opj_config.h
-        openjpegNode = conf.path.make_node(join(SOURCE, 'src', 'lib', 'openjp2'))
-        writeConfig(conf, opj_callback, 'opj', infile=None, outfile='opj_config.h', 
-                    path=openjpegNode, feature='makeHeader')
 
+        # make opj_config.h
+        openjpegNode = conf.path.make_node(
+                join(SOURCE, 'src', 'lib', 'openjp2'))
+
+        writeConfig(conf, opj_callback, 'opj', infile=None,
+                    outfile='opj_config.h', path=openjpegNode,
+                    feature='makeHeader')
+
+        def opj_private_callback(conf):
+            conf.check_cc(
+                    header_name='inttypes.h',
+                    define_name='OPJ_HAVE_INTTYPES_H',
+                    mandatory=False)
+
+            if conf.check_cc(
+                    function_name='fseeko',
+                    header_name='stdio.h',
+                    define_name='OPJ_HAVE_FSEEK0',
+                    mandatory=False):
+                conf.define('OPJ_HAVE_FSEEK0', 'ON', quote=False)
+
+            if conf.check_cc(
+                    header_name='malloc.h',
+                    define_name='OPJ_HAVE_MALLOC_H',
+                    mandatory=False):
+                conf.define('OPJ_HAVE_MALLOC_H', '', quote=False)
+
+            if conf.check_cc(
+                    function_name='memalign',
+                    header_name='malloc.h',
+                    define_name='OPJ_HAVE_MEMALIGN',
+                    mandatory=False):
+                conf.define('OPJ_HAVE_MEMALIGN', '', quote=False)
+
+            if conf.check_cc(
+                    function_name='_aligned_malloc',
+                    header_name='malloc.h',
+                    define_name='OPJ_HAVE__ALIGNED_MALLOC',
+                    mandatory=False):
+                conf.define('OPJ_HAVE__ALIGNED', '', quote=False)
+
+            if conf.check_cc(
+                    function_name='posix_memalign',
+                    header_name='stdlib.h',
+                    define_name='OPJ_HAVE_POSIX_MEMALIGN',
+                    mandatory=False):
+                conf.define('OPJ_HAVE_POSIX_MEMALIGN', '', quote=False)
+
+            if conf.check_cc(header_name='string.h', mandatory=False):
+                conf.define('HAVE_STRING_H', '', quote=False)
+            if conf.check_cc(header_name='memory.h', mandatory=False):
+                conf.define('HAVE_MEMORY_H', '', quote=False)
+            if conf.check_cc(header_name='stdlib.h', mandatory=False):
+                conf.define('HAVE_STDLIB_H', '', quote=False)
+            if conf.check_cc(header_name='stdio.h', mandatory=False):
+                conf.define('HAVE_STDIO_H', '', quote=False)
+            if conf.check_cc(header_name='math.h', mandatory=False):
+                conf.define('HAVE_MATH_H', '', quote=False)
+            if conf.check_cc(header_name='float.h', mandatory=False):
+                conf.define('HAVE_FLOAT_H', '', quote=False)
+            if conf.check_cc(header_name='time.h', mandatory=False):
+                conf.define('HAVE_TIME_H', '', quote=False)
+            if conf.check_cc(header_name='stdarg.h', mandatory=False):
+                conf.define('HAVE_STDARG_H', '', quote=False)
+            if conf.check_cc(header_name='ctype.h', mandatory=False):
+                conf.define('HAVE_CTYPE_H', '', quote=False)
+            if conf.check_cc(header_name='assert.h', mandatory=False):
+                conf.define('HAVE_ASSERT_H', '', quote=False)
+
+            if conf.check_cc(header_name='strings.h', mandatory=False):
+                conf.define('HAVE_STRINGS_H', '', quote=False)
+            if conf.check_cc(header_name='sys/stat.h', mandatory=False):
+                conf.define('HAVE_SYS_STAT_H', '', quote=False)
+            if conf.check_cc(header_name='sys/types.h', mandatory=False):
+                conf.define('HAVE_SYS_TYPES_H', '', quote=False)
+            if conf.check_cc(header_name='unistd.h', mandatory=False):
+                conf.define('HAVE_UNISTD_H', '', quote=False)
+
+            if conf.check_cc(
+                    type_name='ssize_t',
+                    header_name='sys/types.h',
+                    mandatory=False):
+                conf.define('HAVE_SSIZE_T', '', quote=False)
+
+            if conf.check_cc(header_name='fcntl.h', mandatory=False):
+                conf.define('HAVE_FCNTL_H', '', quote=False)
+
+            if conf.check_cc(
+                    function_name='mmap',
+                    header_name='sys/mman.h',
+                    mandatory=False):
+                conf.define('HAVE_MMAP', '', quote=False)
+
+            if conf.check_cc(header_name='stdbool.h', mandatory=False):
+                conf.define('HAVE_STDBOOL_H', '', quote=False)
+
+            if 'HAVE_SSIZE_T=1' in conf.env['DEFINES']:
+                conf.define('HAVE_SSIZE_T', ' ', quote=False)
+            if '_LARGEFILE_SOURCE' in conf.env['DEFINES']:
+                conf.define('_LARGEFILE_SOURCE', ' ', quote=False)
+            if '_LARGE_FILES' in conf.env['DEFINES']:
+                conf.define('_LARGE_FILES', ' ', quote=False)
+            if '_FILE_OFFSET_BITS=64' in conf.env['DEFINES']:
+                conf.define('_FILE_OFFSET_BITS', '64', quote=False)
+
+            if '_POSIX_C_SOURCE' not in conf.env['DEFINES']:
+                if 'OPJ_HAVE_FSEEKO=ON' in conf.env['DEFINES'] or \
+                   'OPJ_HAVE_POSIX_MEMALIGN=' in conf.env['DEFINES']:
+                    conf.define('_POSIX_C_SOURCE', '200112L', quote=False)
+
+            conf.define('OPJ_PACKAGE_VERSION',  '"2.3.0"', quote=False)
+            if sys.byteorder != 'little':
+                conf.define('OPJ_BIG_ENDIAN', ' ', quote=False)
+
+        # make opj_config_private.h
+        writeConfig(conf, opj_private_callback, 'opj_private', infile=None,
+                    outfile='opj_config_private.h', path=openjpegNode,
+                    feature='makeHeader')
 def build(bld):
     env = bld.get_env()
 
@@ -82,10 +165,11 @@ def build(bld):
         openjpegNode = bld.path.make_node(join(SOURCE, 'src', 'lib', 'openjp2'))
         
         # build the lib
-        sources = ['bio.c', 'cio.c', 'dwt.c', 'event.c', 'image.c', 
-                   'invert.c', 'j2k.c', 'jp2.c', 'mct.c', 'mqc.c', 
-                   'openjpeg.c', 'opj_clock.c', 'pi.c', 'raw.c', 
-                   't1.c', 't2.c', 'tcd.c', 'tgt.c', 'function_list.c']
+        sources = ['bio.c', 'cio.c', 'dwt.c', 'event.c', 'image.c', 'invert.c',
+                   'j2k.c', 'jp2.c', 'mct.c', 'mqc.c', 'openjpeg.c',
+                   'opj_clock.c', 'opj_malloc.c', 'pi.c' , 'sparse_array.c',
+                   't1.c', 't2.c', 'tcd.c', 'thread.c', 'tgt.c',
+                   'function_list.c']
         
         libType = env['LIB_TYPE'] or 'stlib'
         openjpeg = bld(features='c c%s ' % libType, 
@@ -104,7 +188,7 @@ def build(bld):
         if env['install_headers']:
             openjpeg.features += 'add_targets'
             openjpeg.targets_to_add=[bld(features='install_tgt', 
-                    includes='openjpeg.h opj_stdint.h opj_config.h',
+                    includes='openjpeg.h opj_config.h opj_stdint.h opj_config_private.h',
                     dir=openjpegNode, install_path=env['install_includedir'],
                     name='J2K_INCLUDES_INSTALL')]
 

--- a/modules/c/j2k/external/openjpeg/wscript
+++ b/modules/c/j2k/external/openjpeg/wscript
@@ -59,7 +59,7 @@ def configure(conf):
                     header_name='stdio.h',
                     define_name='OPJ_HAVE_FSEEK0',
                     mandatory=False):
-                conf.define('OPJ_HAVE_FSEEK0', 'ON', quote=False)
+                conf.define('OPJ_HAVE_FSEEK0', '', quote=False)
 
             if conf.check_cc(
                     header_name='malloc.h',

--- a/modules/c/j2k/external/openjpeg/wscript
+++ b/modules/c/j2k/external/openjpeg/wscript
@@ -15,7 +15,8 @@ def configure(conf):
     j2kLayer = Options.options.j2k_layer
     if j2kLayer == 'openjpeg':
         
-        # callback function to check for all #defines used by the openjpg module
+        # callback function to check for opj_config.h #defines used by the
+        # openjpg module
         def opj_callback(conf):            
             # check functionality
             conf.check_cc(
@@ -46,6 +47,7 @@ def configure(conf):
                     outfile='opj_config.h', path=openjpegNode,
                     feature='makeHeader')
 
+        # callback function to check for #defines used by the openjpg module
         def opj_private_callback(conf):
             conf.check_cc(
                     header_name='inttypes.h',

--- a/modules/c/j2k/external/openjpeg/wscript
+++ b/modules/c/j2k/external/openjpeg/wscript
@@ -15,14 +15,12 @@ def configure(conf):
     j2kLayer = Options.options.j2k_layer
     if j2kLayer == 'openjpeg':
         
-        # callback function to check for opj_config.h #defines used by the
-        # openjpg module
-        def opj_callback(conf):            
+        # callback function to check for #defines used by the openjpg module
+        def opj_callback(conf):
+
             # check functionality
-            conf.check_cc(
-                    header_name='stdint.h',
-                    define_name='OPJ_HAVE_STDINT_H',
-                    mandatory=False)
+            conf.check_cc(header_name='stdint.h', define_name='OPJ_HAVE_STDINT_H',
+                          mandatory=False)
 
             conf.define('OPJ_VERSION_MAJOR', '2', quote=False)
             conf.define('OPJ_VERSION_MINOR', '3', quote=False)
@@ -49,9 +47,11 @@ def configure(conf):
 
         # callback function to check for #defines used by the openjpg module
         def opj_private_callback(conf):
+
+            # check functionality
             if conf.check_cc(function_name='fseeko', header_name='stdio.h',
-                             define_name='OPJ_HAVE_FSEEK0', mandatory=False):
-                conf.define('OPJ_HAVE_FSEEK0', 'ON', quote=False)
+                             define_name='OPJ_HAVE_FSEEKO', mandatory=False):
+                conf.define('OPJ_HAVE_FSEEKO', '', quote=False)
 
             if conf.check_cc(header_name='sys/stat.h', mandatory=False):
                 conf.define('HAVE_SYS_STAT_H', '', quote=False)

--- a/modules/c/j2k/source/OpenJPEGImpl.c
+++ b/modules/c/j2k/source/OpenJPEGImpl.c
@@ -158,7 +158,7 @@ OpenJPEG_createIO(nrt_IOInterface* io,
             ioControl->length = nrt_IOInterface_getSize(io, error)
                     - ioControl->offset;
 
-        opj_stream_set_user_data(stream, ioControl);
+        opj_stream_set_user_data(stream, ioControl, NULL);
         opj_stream_set_read_function(stream, implStreamRead);
         opj_stream_set_seek_function(stream, implStreamSeek);
         opj_stream_set_skip_function(stream, implStreamSkip);

--- a/modules/c/j2k/wscript
+++ b/modules/c/j2k/wscript
@@ -20,11 +20,11 @@ def configure(conf):
     j2kLayer = Options.options.j2k_layer
 
     def j2k_callback(conf):
-        if j2kLayer is 'openjpeg':
+        if j2kLayer == 'openjpeg':
             conf.define('HAVE_OPENJPEG_H', '', quote=False)
             conf.define('J2K_MODULE_EXPORTS', '', quote=False)
         else:
-            #j2kLayer is 'jasper':
+            #j2kLayer == 'jasper':
             conf.define('HAVE_JASPER_H', '', quote=False)
             conf.define('J2K_MODULE_EXPORTS', '', quote=False)
     writeConfig(conf, j2k_callback, 'j2k')


### PR DESCRIPTION
Updates include modifications to the openjpg wscript which now produces two configuration files to reflect the use of both opj_config.h and opj_config_private.h in the openjp2 module.