### PR TITLE
Adding ImageBlocker

### DIFF
--- a/modules/c++/nitf/include/nitf/ImageBlocker.hpp
+++ b/modules/c++/nitf/include/nitf/ImageBlocker.hpp
@@ -1,0 +1,184 @@
+/* =========================================================================
+ * This file is part of NITRO
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2018, MDA Information Systems LLC
+ *
+ * NITRO is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __NITF_IMAGE_BLOCKER_HPP__
+#define __NITF_IMAGE_BLOCKER_HPP__
+
+#include <stddef.h>
+#include <string.h>
+#include <vector>
+
+#include <sys/Conf.h>
+
+namespace nitf
+{
+/*!
+ * \class ImageBlocker
+ * \brief Supports efficiently rearranging an image to fulfill NITF blocking
+ * conventions, including pad rows and columns (NITF spec specifies that full
+ * blocks will always be written).  Only supports layouts where image segments
+ * are stacked vertically.
+ */
+class ImageBlocker
+{
+public:
+    /*!
+     * Use when there's a single image segment
+     *
+     * \param numRows Number of rows
+     * \param numCols Number of columns
+     * \param numRowsPerBlock Number of rows per block
+     * \param numColsPerBlock Number of columns per block
+     */
+    ImageBlocker(size_t numRows,
+                 size_t numCols,
+                 size_t numRowsPerBlock,
+                 size_t numColsPerBlock);
+
+    /*!
+     * Use when there are multiple image segments
+     *
+     * \param numRowsPerSegment Number of rows in each segment
+     * \param numCols Number of columns
+     * \param numRowsPerBlock Number of rows per block
+     * \param numColsPerBlock Number of columns per block
+     */
+    ImageBlocker(const std::vector<size_t>& numRowsPerSegment,
+                 size_t numCols,
+                 size_t numRowsPerBlock,
+                 size_t numColsPerBlock);
+
+    /*!
+     * \tparam DataT Data type of image pixels
+     *
+     * \param startRow Start row.  This must start on a block boundary (within
+     * a segment).
+     * \param numRows Number of rows.  This must be a multiple of the block size
+     * unless it's at the end of a segment.
+     *
+     * \return The number of bytes required to store this AOI of the image in
+     * blocked format, including pad rows and columns
+     */
+    template <typename DataT>
+    size_t getNumBytesRequired(size_t startRow,
+                               size_t numRows) const
+    {
+        return getNumBytesRequired(startRow, numRows, sizeof(DataT));
+    }
+
+    /*!
+     * \param startRow Start row.  This must start on a block boundary (within
+     * a segment).
+     * \param numRows Number of rows.  This must be a multiple of the block size
+     * unless it's at the end of a segment.
+     * \param numBytesPerPixel Number of bytes per pixel of image pixels
+     *
+     * \return The number of bytes required to store this AOI of the image in
+     * blocked format, including pad rows and columns
+     */
+    size_t getNumBytesRequired(size_t startRow,
+                               size_t numRows,
+                               size_t numBytesPerPixel) const;
+
+    /*!
+     * \param input Input image of size 'numRows' x numCols (from constructor)
+     * \param startRow Start row in the global image that 'input' points to.
+     * This must start on a block boundary (within a segment).
+     * \param numRows Number of rows.  This must be a multiple of the block size
+     * unless it's at the end of a segment.
+     * \param numBytesPerPixel Number of bytes per pixel of 'input'
+     * \param[out] output Blocked representation of 'input', including pad rows
+     * and columns
+     */
+    void block(const void* input,
+               size_t startRow,
+               size_t numRows,
+               size_t numBytesPerPixel,
+               void* output) const;
+
+    /*!
+     * \tparam DataT Data type of 'input' and 'output'
+     *
+     * \param input Input image of size 'numRows' x numCols (from constructor)
+     * \param startRow Start row in the global image that 'input' points to.
+     * This must start on a block boundary (within a segment).
+     * \param numRows Number of rows.  This must be a multiple of the block size
+     * unless it's at the end of a segment.
+     * \param[out] output Blocked representation of 'input', including pad rows
+     * and columns
+     */
+    template <typename DataT>
+    void block(const DataT* input,
+               size_t startRow,
+               size_t numRows,
+               DataT* output) const
+    {
+        block(input, startRow, numRows, sizeof(DataT), output);
+    }
+
+private:
+    void findSegment(size_t row,
+                     size_t& segIdx,
+                     size_t& rowWithinSegment,
+                     size_t& blockWithinSegment) const;
+
+    bool isFirstRowInBlock(size_t rowWithinSeg) const
+    {
+        return (rowWithinSeg % mNumRowsPerBlock == 0);
+    }
+
+    void findSegmentRange(size_t startRow,
+                          size_t numRows,
+                          size_t& firstSegIdx,
+                          size_t& startBlockWithinFirstSeg,
+                          size_t& lastSegIdx,
+                          size_t& lastBlockWithinLastSeg) const;
+
+    void blockImpl(const sys::byte* input,
+                   size_t numValidRowsInBlock,
+                   size_t numValidColsInBlock,
+                   size_t numBytesPerPixel,
+                   sys::byte* output) const;
+
+    void blockAcrossRow(const sys::byte*& input,
+                        size_t numValidRowsInBlock,
+                        size_t numBytesPerPixel,
+                        sys::byte*& output) const;
+
+private:
+    // Vectors all indexed by segment
+    std::vector<size_t> mStartRow;
+    const std::vector<size_t> mNumRows;
+    const size_t mTotalNumRows;
+    const size_t mNumCols;
+    const size_t mNumRowsPerBlock;
+    const size_t mNumColsPerBlock;
+
+    std::vector<size_t> mNumBlocksDownRows;
+    std::vector<size_t> mNumPadRowsInFinalBlock;
+
+    size_t mNumBlocksAcrossCols;
+    size_t mNumPadColsInFinalBlock;
+};
+}
+
+#endif

--- a/modules/c++/nitf/source/ImageBlocker.cpp
+++ b/modules/c++/nitf/source/ImageBlocker.cpp
@@ -331,8 +331,6 @@ void ImageBlocker::block(const void* input,
     findSegmentRange(startRow, numRows, firstSegIdx, startBlockWithinFirstSeg,
                      lastSegIdx, lastBlockWithinLastSeg);
 
-    // TODO: Think implementation is complete but need to look closer at all this
-
     const sys::byte* inputPtr = static_cast<const sys::byte*>(input);
     sys::byte* outputPtr = static_cast<sys::byte*>(output);
 

--- a/modules/c++/nitf/source/ImageBlocker.cpp
+++ b/modules/c++/nitf/source/ImageBlocker.cpp
@@ -1,0 +1,368 @@
+/* =========================================================================
+ * This file is part of NITRO
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2018, MDA Information Systems LLC
+ *
+ * NITRO is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <sstream>
+#include <numeric>
+#include <limits>
+
+#include <sys/Conf.h>
+#include <except/Exception.h>
+#include <nitf/ImageBlocker.hpp>
+
+namespace
+{
+void getBlockInfo(size_t numElements,
+                  size_t numElementsPerBlock,
+                  size_t& numBlocks,
+                  size_t& numPadElementsInFinalBlock)
+{
+    numBlocks = (numElements / numElementsPerBlock);
+    const size_t numLeftovers = numElements % numElementsPerBlock;
+
+    if (numLeftovers == 0)
+    {
+        numPadElementsInFinalBlock = 0;
+    }
+    else
+    {
+        numPadElementsInFinalBlock = numElementsPerBlock - numLeftovers;
+        ++numBlocks;
+    }
+}
+}
+
+namespace nitf
+{
+ImageBlocker::ImageBlocker(size_t numRows,
+                           size_t numCols,
+                           size_t numRowsPerBlock,
+                           size_t numColsPerBlock) :
+    mStartRow(1, 0),
+    mNumRows(1, numRows),
+    mTotalNumRows(numRows),
+    mNumCols(numCols),
+    mNumRowsPerBlock(numRowsPerBlock),
+    mNumColsPerBlock(numColsPerBlock),
+    mNumBlocksDownRows(1),
+    mNumPadRowsInFinalBlock(1)
+{
+    if (numRowsPerBlock == 0 || numColsPerBlock == 0)
+    {
+        throw except::Exception(Ctxt("Dimensions per block must be positive"));
+    }
+
+    getBlockInfo(numRows, mNumRowsPerBlock,
+                 mNumBlocksDownRows[0], mNumPadRowsInFinalBlock[0]);
+
+    getBlockInfo(mNumCols, mNumColsPerBlock,
+                 mNumBlocksAcrossCols, mNumPadColsInFinalBlock);
+}
+
+ImageBlocker::ImageBlocker(const std::vector<size_t>& numRowsPerSegment,
+                           size_t numCols,
+                           size_t numRowsPerBlock,
+                           size_t numColsPerBlock) :
+    mStartRow(numRowsPerSegment.size()),
+    mNumRows(numRowsPerSegment),
+    mTotalNumRows(std::accumulate(numRowsPerSegment.begin(),
+                                  numRowsPerSegment.end(),
+                                  static_cast<size_t>(0))),
+    mNumCols(numCols),
+    mNumRowsPerBlock(numRowsPerBlock),
+    mNumColsPerBlock(numColsPerBlock),
+    mNumBlocksDownRows(numRowsPerSegment.size()),
+    mNumPadRowsInFinalBlock(numRowsPerSegment.size())
+{
+    if (numRowsPerSegment.empty())
+    {
+        throw except::Exception(Ctxt("Must provide at least one segment"));
+    }
+
+    if (numRowsPerBlock == 0 || numColsPerBlock == 0)
+    {
+        throw except::Exception(Ctxt("Dimensions per block must be positive"));
+    }
+
+    mStartRow[0] = 0;
+    for (size_t seg = 1; seg < mNumRows.size(); ++seg)
+    {
+        mStartRow[seg] = mStartRow[seg - 1] + mNumRows[seg - 1];
+    }
+
+    for (size_t seg = 0; seg < mNumRows.size(); ++seg)
+    {
+        getBlockInfo(mNumRows[seg], mNumRowsPerBlock,
+                     mNumBlocksDownRows[seg], mNumPadRowsInFinalBlock[seg]);
+    }
+
+    getBlockInfo(mNumCols, mNumColsPerBlock,
+                 mNumBlocksAcrossCols, mNumPadColsInFinalBlock);
+}
+
+void ImageBlocker::findSegment(size_t row,
+                               size_t& segIdx,
+                               size_t& rowWithinSegment,
+                               size_t& blockWithinSegment) const
+{
+    for (size_t seg = 0; seg < mStartRow.size(); ++seg)
+    {
+        const size_t endRowOfSeg = mStartRow[seg] + mNumRows[seg];
+
+        if (row < endRowOfSeg)
+        {
+            segIdx = seg;
+            rowWithinSegment = row - mStartRow[seg];
+            blockWithinSegment = rowWithinSegment / mNumRowsPerBlock;
+            return;
+        }
+    }
+
+    std::ostringstream ostr;
+    ostr << "Row " << row << " is out of bounds";
+    throw except::Exception(Ctxt(ostr.str()));
+}
+
+void ImageBlocker::findSegmentRange(size_t startRow,
+                                    size_t numRows,
+                                    size_t& firstSegIdx,
+                                    size_t& startBlockWithinFirstSeg,
+                                    size_t& lastSegIdx,
+                                    size_t& lastBlockWithinLastSeg) const
+{
+    if (numRows == 0)
+    {
+        firstSegIdx = startBlockWithinFirstSeg =
+                lastSegIdx = lastBlockWithinLastSeg =
+                std::numeric_limits<size_t>::max();
+    }
+    else
+    {
+        // Figure out which segment we're starting in
+        size_t startRowWithinFirstSeg;
+        findSegment(startRow, firstSegIdx, startRowWithinFirstSeg,
+                    startBlockWithinFirstSeg);
+
+        if (!isFirstRowInBlock(startRowWithinFirstSeg))
+        {
+            std::ostringstream ostr;
+            ostr << "Start row " << startRow << " is local row "
+                 << startRowWithinFirstSeg << " within segment " << firstSegIdx
+                 << ".  The local row must be a multiple of "
+                 << mNumRowsPerBlock << ".";
+            throw except::Exception(Ctxt(ostr.str()));
+        }
+
+        // Figure out which segment we're ending in
+        const size_t lastRow = startRow + numRows - 1;
+
+        size_t lastRowWithinLastSeg;
+        findSegment(lastRow, lastSegIdx, lastRowWithinLastSeg,
+                    lastBlockWithinLastSeg);
+        const size_t endRowWithinLastSeg = lastRowWithinLastSeg + 1;
+
+        // Make sure we're ending on a full block
+        if (!(endRowWithinLastSeg == mNumRows[lastSegIdx] ||
+              isFirstRowInBlock(endRowWithinLastSeg)))
+        {
+            std::ostringstream ostr;
+            ostr << "Last row " << lastRow << " is local row "
+                 << lastRowWithinLastSeg << " within segment " << lastSegIdx
+                 << ".  This must land on a full block.";
+            throw except::Exception(Ctxt(ostr.str()));
+        }
+    }
+}
+
+size_t ImageBlocker::getNumBytesRequired(size_t startRow,
+                                         size_t numRows,
+                                         size_t numBytesPerPixel) const
+{
+    if (numRows == 0)
+    {
+        return 0;
+    }
+
+    // Find which segments we're in
+    size_t firstSegIdx;
+    size_t startBlockWithinFirstSeg;
+    size_t lastSegIdx;
+    size_t lastBlockWithinLastSeg;
+    findSegmentRange(startRow, numRows, firstSegIdx, startBlockWithinFirstSeg,
+                     lastSegIdx, lastBlockWithinLastSeg);
+
+    // Now count up the blocks
+    size_t numRowBlocks;
+    if (lastSegIdx == firstSegIdx)
+    {
+        numRowBlocks = lastBlockWithinLastSeg - startBlockWithinFirstSeg + 1;
+    }
+    else
+    {
+        // First seg
+        numRowBlocks =
+                mNumBlocksDownRows[firstSegIdx] - startBlockWithinFirstSeg;
+
+        // Middle segs
+        for (size_t seg = firstSegIdx + 1; seg < lastSegIdx; ++seg)
+        {
+            numRowBlocks += mNumBlocksDownRows[seg];
+        }
+
+        // Last seg
+        numRowBlocks += lastBlockWithinLastSeg + 1;
+    }
+
+    const size_t numBytes =
+            numRowBlocks * mNumRowsPerBlock *
+            mNumBlocksAcrossCols * mNumColsPerBlock *
+            numBytesPerPixel;
+
+    return numBytes;
+}
+
+void ImageBlocker::blockImpl(const sys::byte* input,
+                             size_t numValidRowsInBlock,
+                             size_t numValidColsInBlock,
+                             size_t numBytesPerPixel,
+                             sys::byte* output) const
+{
+    const size_t inStride = mNumCols * numBytesPerPixel;
+    const size_t outNumValidBytes = numValidColsInBlock * numBytesPerPixel;
+
+    if (numValidColsInBlock == mNumColsPerBlock)
+    {
+        for (size_t row = 0;
+             row < numValidRowsInBlock;
+             ++row, input += inStride, output += outNumValidBytes)
+        {
+            ::memcpy(output, input, outNumValidBytes);
+        }
+    }
+    else
+    {
+        // Have to deal with pad columns
+        const size_t outNumInvalidBytes =
+                (mNumColsPerBlock - numValidColsInBlock) * numBytesPerPixel;
+
+        for (size_t row = 0;
+             row < numValidRowsInBlock;
+             ++row, input += inStride)
+        {
+            ::memcpy(output, input, outNumValidBytes);
+            output += outNumValidBytes;
+
+            ::memset(output, 0, outNumInvalidBytes);
+            output += outNumInvalidBytes;
+        }
+    }
+
+    // Pad rows on the bottom of the block
+    if (numValidRowsInBlock < mNumRowsPerBlock)
+    {
+        const size_t numPadRows = mNumRowsPerBlock - numValidRowsInBlock;
+
+        ::memset(output, 0,
+                 numPadRows * mNumColsPerBlock * numBytesPerPixel);
+    }
+}
+
+void ImageBlocker::blockAcrossRow(const sys::byte*& input,
+                                  size_t numValidRowsInBlock,
+                                  size_t numBytesPerPixel,
+                                  sys::byte*& output) const
+{
+    const size_t outStride =
+            mNumRowsPerBlock * mNumColsPerBlock * numBytesPerPixel;
+    const size_t lastColBlock = mNumBlocksAcrossCols - 1;
+
+    for (size_t colBlock = 0;
+         colBlock < mNumBlocksAcrossCols;
+         ++colBlock, output += outStride)
+    {
+        const size_t numPadColsInBlock = (colBlock == lastColBlock) ?
+                mNumPadColsInFinalBlock : 0;
+
+        const size_t numValidColsInBlock = mNumColsPerBlock - numPadColsInBlock;
+
+        blockImpl(input,
+                  numValidRowsInBlock,
+                  numValidColsInBlock,
+                  numBytesPerPixel,
+                  output);
+
+        input += numValidColsInBlock * numBytesPerPixel;
+    }
+
+    // At the end of this, we've incremented the input pointer an entire row
+    // We need to increment it the remaining rows in the block
+    input += mNumCols * numBytesPerPixel * (numValidRowsInBlock - 1);
+}
+
+void ImageBlocker::block(const void* input,
+                         size_t startRow,
+                         size_t numRows,
+                         size_t numBytesPerPixel,
+                         void* output) const
+{
+    // Find which segments we're in
+    size_t firstSegIdx;
+    size_t startBlockWithinFirstSeg;
+    size_t lastSegIdx;
+    size_t lastBlockWithinLastSeg;
+    findSegmentRange(startRow, numRows, firstSegIdx, startBlockWithinFirstSeg,
+                     lastSegIdx, lastBlockWithinLastSeg);
+
+    // TODO: Think implementation is complete but need to look closer at all this
+
+    const sys::byte* inputPtr = static_cast<const sys::byte*>(input);
+    sys::byte* outputPtr = static_cast<sys::byte*>(output);
+
+    for (size_t seg = firstSegIdx; seg <= lastSegIdx; ++seg)
+    {
+        const size_t overallLastRowBlockOfSegment = mNumBlocksDownRows[seg] - 1;
+
+        const size_t startRowBlockOfSegment = (seg == firstSegIdx) ?
+                startBlockWithinFirstSeg : 0;
+
+        const size_t lastRowBlockOfSegment = (seg == lastSegIdx) ?
+                lastBlockWithinLastSeg : overallLastRowBlockOfSegment;
+
+        for (size_t rowBlock = startRowBlockOfSegment;
+             rowBlock <= lastRowBlockOfSegment;
+             ++rowBlock)
+        {
+            const size_t numPadRowsInBlock =
+                    (rowBlock == overallLastRowBlockOfSegment) ?
+                            mNumPadRowsInFinalBlock[seg] : 0;
+
+            const size_t numValidRowsInBlock =
+                    mNumRowsPerBlock - numPadRowsInBlock;
+
+            // This increments both pointers
+            blockAcrossRow(inputPtr,
+                           numValidRowsInBlock,
+                           numBytesPerPixel,
+                           outputPtr);
+        }
+    }
+}
+}

--- a/modules/c++/nitf/unittests/test_image_blocker.cpp
+++ b/modules/c++/nitf/unittests/test_image_blocker.cpp
@@ -1,0 +1,491 @@
+/* =========================================================================
+ * This file is part of NITRO
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2018, MDA Information Systems LLC
+ *
+ * NITRO is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <vector>
+#include <sstream>
+
+#include <nitf/ImageBlocker.hpp>
+
+#include "TestCase.h"
+
+namespace
+{
+TEST_CASE(testSingleSegmentNoLeftovers)
+{
+    // 4 rows of blocks and 5 cols of blocks
+    static const size_t NUM_ROWS = 12;
+    static const size_t NUM_COLS = 20;
+    static const size_t NUM_ROWS_PER_BLOCK = 3;
+    static const size_t NUM_COLS_PER_BLOCK = 4;
+
+    // 1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20
+    // 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40
+    // ...
+    // 220 ...                                                  240
+    std::vector<size_t> input(NUM_ROWS * NUM_COLS);
+    for (size_t ii = 0; ii < input.size(); ++ii)
+    {
+        input[ii] = ii + 1;
+    }
+
+    const nitf::ImageBlocker blocker(NUM_ROWS,
+                                     NUM_COLS,
+                                     NUM_ROWS_PER_BLOCK,
+                                     NUM_COLS_PER_BLOCK);
+
+    static const size_t NUM_OUTPUT_PIXELS = NUM_ROWS * NUM_COLS;
+    TEST_ASSERT_EQ(blocker.getNumBytesRequired<size_t>(0, NUM_ROWS),
+                   NUM_OUTPUT_PIXELS * sizeof(size_t));
+
+    std::vector<size_t> output(NUM_OUTPUT_PIXELS, 99999);
+    blocker.block(&input[0], 0, NUM_ROWS, &output[0]);
+
+    for (size_t rowBlock = 0, idx = 0, rowOffset = 1;
+         rowBlock < 4;
+         ++rowBlock, rowOffset += NUM_COLS * NUM_ROWS_PER_BLOCK)
+    {
+        for (size_t colBlock = 0, colOffset = 0;
+             colBlock < 5;
+             ++colBlock, colOffset += NUM_COLS_PER_BLOCK)
+        {
+            for (size_t row = 0; row < NUM_ROWS_PER_BLOCK; ++row)
+            {
+                for (size_t col = 0; col < NUM_COLS_PER_BLOCK; ++col, ++idx)
+                {
+                    std::ostringstream ostr;
+                    ostr << "Row block " << rowBlock << ", col block "
+                         << colBlock << ", row " << row << ", col " << col;
+
+                    const size_t expectedVal =
+                            rowOffset + row * NUM_COLS + colOffset + col;
+
+                    TEST_ASSERT_EQ_MSG(ostr.str(), output[idx], expectedVal);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE(testSingleSegmentPadCols)
+{
+    // 4 rows of blocks and 3 cols of blocks with 1 pad col
+    static const size_t NUM_ROWS = 12;
+    static const size_t NUM_COLS = 20;
+    static const size_t NUM_ROWS_PER_BLOCK = 3;
+    static const size_t NUM_COLS_PER_BLOCK = 7;
+
+    // 1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20
+    // 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40
+    // ...
+    // 220 ...                                                  240
+    std::vector<size_t> input(NUM_ROWS * NUM_COLS);
+    for (size_t ii = 0; ii < input.size(); ++ii)
+    {
+        input[ii] = ii + 1;
+    }
+
+    const nitf::ImageBlocker blocker(NUM_ROWS,
+                                     NUM_COLS,
+                                     NUM_ROWS_PER_BLOCK,
+                                     NUM_COLS_PER_BLOCK);
+
+    static const size_t NUM_OUTPUT_PIXELS = NUM_ROWS * (NUM_COLS + 1);
+    TEST_ASSERT_EQ(blocker.getNumBytesRequired<size_t>(0, NUM_ROWS),
+                   NUM_OUTPUT_PIXELS * sizeof(size_t));
+
+    std::vector<size_t> output(NUM_OUTPUT_PIXELS, 99999);
+    blocker.block(&input[0], 0, NUM_ROWS, &output[0]);
+
+    for (size_t rowBlock = 0, idx = 0, rowOffset = 1;
+         rowBlock < 4;
+         ++rowBlock, rowOffset += NUM_COLS * NUM_ROWS_PER_BLOCK)
+    {
+        for (size_t colBlock = 0, colOffset = 0;
+             colBlock < 3;
+             ++colBlock, colOffset += NUM_COLS_PER_BLOCK)
+        {
+            for (size_t row = 0; row < NUM_ROWS_PER_BLOCK; ++row)
+            {
+                for (size_t col = 0; col < NUM_COLS_PER_BLOCK; ++col, ++idx)
+                {
+                    std::ostringstream ostr;
+                    ostr << "Row block " << rowBlock << ", col block "
+                         << colBlock << ", row " << row << ", col " << col;
+
+                    const size_t expectedVal = (colOffset + col >= NUM_COLS) ?
+                            0 : rowOffset + row * NUM_COLS + colOffset + col;
+
+                    TEST_ASSERT_EQ_MSG(ostr.str(), output[idx], expectedVal);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE(testSingleSegmentPadRowsAndPadCols)
+{
+    // 2 rows of blocks and 3 cols of blocks with 4 pad rows and 1 pad col
+    static const size_t NUM_ROWS = 12;
+    static const size_t NUM_COLS = 20;
+    static const size_t NUM_ROWS_PER_BLOCK = 8;
+    static const size_t NUM_COLS_PER_BLOCK = 7;
+
+    // 1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20
+    // 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40
+    // ...
+    // 220 ...                                                  240
+    std::vector<size_t> input(NUM_ROWS * NUM_COLS);
+    for (size_t ii = 0; ii < input.size(); ++ii)
+    {
+        input[ii] = ii + 1;
+    }
+
+    const nitf::ImageBlocker blocker(NUM_ROWS,
+                                     NUM_COLS,
+                                     NUM_ROWS_PER_BLOCK,
+                                     NUM_COLS_PER_BLOCK);
+
+    static const size_t NUM_OUTPUT_PIXELS = (NUM_ROWS + 4) * (NUM_COLS + 1);
+    TEST_ASSERT_EQ(blocker.getNumBytesRequired<size_t>(0, NUM_ROWS),
+                   NUM_OUTPUT_PIXELS * sizeof(size_t));
+
+    std::vector<size_t> output(NUM_OUTPUT_PIXELS, 99999);
+    blocker.block(&input[0], 0, NUM_ROWS, &output[0]);
+
+    for (size_t rowBlock = 0, idx = 0, rowOffset = 1;
+         rowBlock < 2;
+         ++rowBlock, rowOffset += NUM_COLS * NUM_ROWS_PER_BLOCK)
+    {
+        for (size_t colBlock = 0, colOffset = 0;
+             colBlock < 3;
+             ++colBlock, colOffset += NUM_COLS_PER_BLOCK)
+        {
+            for (size_t row = 0; row < NUM_ROWS_PER_BLOCK; ++row)
+            {
+                for (size_t col = 0; col < NUM_COLS_PER_BLOCK; ++col, ++idx)
+                {
+                    std::ostringstream ostr;
+                    ostr << "Row block " << rowBlock << ", col block "
+                         << colBlock << ", row " << row << ", col " << col;
+
+                    const size_t expectedVal =
+                            (rowBlock * NUM_ROWS_PER_BLOCK + row >= NUM_ROWS ||
+                             colOffset + col >= NUM_COLS) ?
+                                    0 :
+                                    rowOffset + row * NUM_COLS + colOffset + col;
+
+                    TEST_ASSERT_EQ_MSG(ostr.str(), output[idx], expectedVal);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE(testMultipleSegmentsNoLeftovers)
+{
+    // 4 rows of blocks and 5 cols of blocks
+    static const size_t NUM_ROWS = 12;
+    static const size_t NUM_COLS = 20;
+    static const size_t NUM_ROWS_PER_BLOCK = 3;
+    static const size_t NUM_COLS_PER_BLOCK = 4;
+
+    // 1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20
+    // 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40
+    // ...
+    // 220 ...                                                  240
+    std::vector<size_t> input(NUM_ROWS * NUM_COLS);
+    for (size_t ii = 0; ii < input.size(); ++ii)
+    {
+        input[ii] = ii + 1;
+    }
+
+    // Want these to hit block boundaries
+    std::vector<size_t> numRowsPerSegment(2);
+    numRowsPerSegment[0] = 3;
+    numRowsPerSegment[1] = 9;
+
+    const nitf::ImageBlocker blocker(numRowsPerSegment,
+                                     NUM_COLS,
+                                     NUM_ROWS_PER_BLOCK,
+                                     NUM_COLS_PER_BLOCK);
+
+    static const size_t NUM_OUTPUT_PIXELS = NUM_ROWS * NUM_COLS;
+    TEST_ASSERT_EQ(blocker.getNumBytesRequired<size_t>(0, NUM_ROWS),
+                   NUM_OUTPUT_PIXELS * sizeof(size_t));
+
+    std::vector<size_t> output(NUM_OUTPUT_PIXELS, 99999);
+    blocker.block(&input[0], 0, NUM_ROWS, &output[0]);
+
+    for (size_t rowBlock = 0, idx = 0, rowOffset = 1;
+         rowBlock < 4;
+         ++rowBlock, rowOffset += NUM_COLS * NUM_ROWS_PER_BLOCK)
+    {
+        for (size_t colBlock = 0, colOffset = 0;
+             colBlock < 5;
+             ++colBlock, colOffset += NUM_COLS_PER_BLOCK)
+        {
+            for (size_t row = 0; row < NUM_ROWS_PER_BLOCK; ++row)
+            {
+                for (size_t col = 0; col < NUM_COLS_PER_BLOCK; ++col, ++idx)
+                {
+                    std::ostringstream ostr;
+                    ostr << "Row block " << rowBlock << ", col block "
+                         << colBlock << ", row " << row << ", col " << col;
+
+                    const size_t expectedVal =
+                            rowOffset + row * NUM_COLS + colOffset + col;
+
+                    TEST_ASSERT_EQ_MSG(ostr.str(), output[idx], expectedVal);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE(testMultipleSegmentsPartialRowsOnSegmentBoundaries)
+{
+    // 5 rows of blocks (because of segment layout) and 5 cols of blocks
+    static const size_t NUM_ROWS = 12;
+    static const size_t NUM_COLS = 20;
+    static const size_t NUM_ROWS_PER_BLOCK = 3;
+    static const size_t NUM_COLS_PER_BLOCK = 4;
+
+    // 1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20
+    // 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40
+    // ...
+    // 220 ...                                                  240
+    std::vector<size_t> input(NUM_ROWS * NUM_COLS);
+    for (size_t ii = 0; ii < input.size(); ++ii)
+    {
+        input[ii] = ii + 1;
+    }
+
+    // First segment will get one pad row
+    // Second segment will get two pad rows
+    std::vector<size_t> numRowsPerSegment(2);
+    numRowsPerSegment[0] = 5;
+    numRowsPerSegment[1] = 7;
+
+    const nitf::ImageBlocker blocker(numRowsPerSegment,
+                                     NUM_COLS,
+                                     NUM_ROWS_PER_BLOCK,
+                                     NUM_COLS_PER_BLOCK);
+
+    static const size_t NUM_OUTPUT_PIXELS = (NUM_ROWS + 3) * NUM_COLS;
+    TEST_ASSERT_EQ(blocker.getNumBytesRequired<size_t>(0, NUM_ROWS),
+                   NUM_OUTPUT_PIXELS * sizeof(size_t));
+
+    std::vector<size_t> output(NUM_OUTPUT_PIXELS, 99999);
+    blocker.block(&input[0], 0, NUM_ROWS, &output[0]);
+
+    for (size_t rowBlock = 0, idx = 0, imageRowBase = 0;
+         rowBlock < 5;
+         ++rowBlock)
+    {
+        size_t imageRow;
+        for (size_t colBlock = 0, colOffset = 0;
+             colBlock < 5;
+             ++colBlock, colOffset += NUM_COLS_PER_BLOCK)
+        {
+            imageRow = imageRowBase;
+
+            for (size_t row = 0; row < NUM_ROWS_PER_BLOCK; ++row)
+            {
+                const bool padRow = (rowBlock == 1 && row >= 2 ) ||
+                        (rowBlock >= 4 && row >= 1);
+
+                for (size_t col = 0; col < NUM_COLS_PER_BLOCK; ++col, ++idx)
+                {
+                    std::ostringstream ostr;
+                    ostr << "Row block " << rowBlock << ", col block "
+                         << colBlock << ", row " << row << ", col " << col;
+
+                    const size_t expectedVal = padRow ?
+                            0 : 1 + imageRow * NUM_COLS + colOffset + col;
+
+                    TEST_ASSERT_EQ_MSG(ostr.str(), output[idx], expectedVal);
+                }
+
+                if (!padRow)
+                {
+                    ++imageRow;
+                }
+            }
+        }
+
+        imageRowBase = imageRow;
+    }
+}
+
+TEST_CASE(testMultipleSegmentsPartialRowsOnSegmentBoundariesWithPadCols)
+{
+    // 5 rows of blocks (because of segment layout) and 3 cols of blocks with 1
+    // pad col
+    static const size_t NUM_ROWS = 12;
+    static const size_t NUM_COLS = 20;
+    static const size_t NUM_ROWS_PER_BLOCK = 3;
+    static const size_t NUM_COLS_PER_BLOCK = 7;
+
+    // 1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20
+    // 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40
+    // ...
+    // 220 ...                                                  240
+    std::vector<size_t> input(NUM_ROWS * NUM_COLS);
+    for (size_t ii = 0; ii < input.size(); ++ii)
+    {
+        input[ii] = ii + 1;
+    }
+
+    // First segment will get one pad row
+    // Second segment will get two pad rows
+    std::vector<size_t> numRowsPerSegment(2);
+    numRowsPerSegment[0] = 5;
+    numRowsPerSegment[1] = 7;
+
+    const nitf::ImageBlocker blocker(numRowsPerSegment,
+                                     NUM_COLS,
+                                     NUM_ROWS_PER_BLOCK,
+                                     NUM_COLS_PER_BLOCK);
+
+    static const size_t NUM_OUTPUT_PIXELS = (NUM_ROWS + 3) * (NUM_COLS + 1);
+    TEST_ASSERT_EQ(blocker.getNumBytesRequired<size_t>(0, NUM_ROWS),
+                   NUM_OUTPUT_PIXELS * sizeof(size_t));
+
+    std::vector<size_t> output(NUM_OUTPUT_PIXELS, 99999);
+    blocker.block(&input[0], 0, NUM_ROWS, &output[0]);
+
+    for (size_t rowBlock = 0, idx = 0, imageRowBase = 0;
+         rowBlock < 5;
+         ++rowBlock)
+    {
+        size_t imageRow;
+        for (size_t colBlock = 0, colOffset = 0;
+             colBlock < 3;
+             ++colBlock, colOffset += NUM_COLS_PER_BLOCK)
+        {
+            imageRow = imageRowBase;
+
+            for (size_t row = 0; row < NUM_ROWS_PER_BLOCK; ++row)
+            {
+                const bool padRow = (rowBlock == 1 && row >= 2 ) ||
+                        (rowBlock >= 4 && row >= 1);
+
+                for (size_t col = 0; col < NUM_COLS_PER_BLOCK; ++col, ++idx)
+                {
+                    std::ostringstream ostr;
+                    ostr << "Row block " << rowBlock << ", col block "
+                         << colBlock << ", row " << row << ", col " << col;
+
+                    const size_t expectedVal =
+                            (padRow || colOffset + col >= NUM_COLS) ?
+                                    0 :
+                                    1 + imageRow * NUM_COLS + colOffset + col;
+
+                    TEST_ASSERT_EQ_MSG(ostr.str(), output[idx], expectedVal);
+                }
+
+                if (!padRow)
+                {
+                    ++imageRow;
+                }
+            }
+        }
+
+        imageRowBase = imageRow;
+    }
+}
+
+TEST_CASE(testBlockPartialImage)
+{
+    // 7 rows of blocks and 5 cols of blocks
+    static const size_t NUM_ROWS = 21;
+    static const size_t NUM_COLS = 20;
+    static const size_t NUM_ROWS_PER_BLOCK = 3;
+    static const size_t NUM_COLS_PER_BLOCK = 4;
+
+    // 1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20
+    // 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40
+    // ...
+    // 220 ...                                                  240
+
+    // But only do the middle three blocks - must land on block boundary
+    static const size_t START_ROW = 6;
+    static const size_t NUM_ROWS_TO_BLOCK = 9;
+    std::vector<size_t> input(NUM_ROWS_TO_BLOCK * NUM_COLS);
+    static const size_t BASE_VAL = 1 + START_ROW * NUM_COLS;
+    for (size_t ii = 0; ii < input.size(); ++ii)
+    {
+        input[ii] = ii + BASE_VAL;
+    }
+
+    const nitf::ImageBlocker blocker(NUM_ROWS,
+                                     NUM_COLS,
+                                     NUM_ROWS_PER_BLOCK,
+                                     NUM_COLS_PER_BLOCK);
+
+    static const size_t NUM_OUTPUT_PIXELS = NUM_ROWS_TO_BLOCK * NUM_COLS;
+    TEST_ASSERT_EQ(blocker.getNumBytesRequired<size_t>(START_ROW,
+                                                       NUM_ROWS_TO_BLOCK),
+                   NUM_OUTPUT_PIXELS * sizeof(size_t));
+
+    std::vector<size_t> output(NUM_OUTPUT_PIXELS, 99999);
+    blocker.block(&input[0], START_ROW, NUM_ROWS_TO_BLOCK, &output[0]);
+
+    for (size_t rowBlock = 0, idx = 0, rowOffset = BASE_VAL;
+         rowBlock < 3;
+         ++rowBlock, rowOffset += NUM_COLS * NUM_ROWS_PER_BLOCK)
+    {
+        for (size_t colBlock = 0, colOffset = 0;
+             colBlock < 5;
+             ++colBlock, colOffset += NUM_COLS_PER_BLOCK)
+        {
+            for (size_t row = 0; row < NUM_ROWS_PER_BLOCK; ++row)
+            {
+                for (size_t col = 0; col < NUM_COLS_PER_BLOCK; ++col, ++idx)
+                {
+                    std::ostringstream ostr;
+                    ostr << "Row block " << rowBlock << ", col block "
+                         << colBlock << ", row " << row << ", col " << col;
+
+                    const size_t expectedVal =
+                            rowOffset + row * NUM_COLS + colOffset + col;
+
+                    TEST_ASSERT_EQ_MSG(ostr.str(), output[idx], expectedVal);
+                }
+            }
+        }
+    }
+}
+}
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    TEST_CHECK(testSingleSegmentNoLeftovers);
+    TEST_CHECK(testSingleSegmentPadCols);
+    TEST_CHECK(testSingleSegmentPadRowsAndPadCols);
+    TEST_CHECK(testMultipleSegmentsNoLeftovers);
+    TEST_CHECK(testMultipleSegmentsPartialRowsOnSegmentBoundaries);
+    TEST_CHECK(testMultipleSegmentsPartialRowsOnSegmentBoundariesWithPadCols);
+    TEST_CHECK(testBlockPartialImage);
+
+    return 0;
+}


### PR DESCRIPTION
This logic is buried in the C layer inside the image writer somewhere in terms of the blocking itself.  This exposes the blocking functionality in a modular way and allows you to provide an arbitrary portion of the image (as a multiple of blocks) which we'll eventually use in a SIDDByteProvider.