### PR TITLE
Adding generalized ByteProvider

### DIFF
--- a/modules/c++/nitf/include/nitf/ByteProvider.hpp
+++ b/modules/c++/nitf/include/nitf/ByteProvider.hpp
@@ -1,0 +1,318 @@
+/* =========================================================================
+ * This file is part of NITRO
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2018, MDA Information Systems LLC
+ *
+ * NITRO is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <vector>
+#include <utility>
+#include <memory>
+
+#include <sys/Conf.h>
+#include <nitf/System.hpp>
+#include <nitf/Record.hpp>
+#include <nitf/ImageBlocker.hpp>
+#include <nitf/NITFBufferList.hpp>
+#include <nitf/ImageSegmentComputer.h>
+
+namespace nitf
+{
+/*!
+ * \class ByteProvider
+ * \brief Used to provide corresponding raw NITF bytes (including NITF headers)
+ * when provided with some AOI of the pixel data.  The idea is that if
+ * getBytes() is called multiple times, eventually for the entire image, the
+ * raw bytes provided back will be the entire NITF file.  This abstraction is
+ * useful if separate threads, processes, or even machines have only portions of
+ * the NITF pixel data and are all trying to write out a single file; in
+ * that scenario, this class provides all the raw bytes corresponding to the
+ * caller's AOI, including NITF headers if necessary.  The caller does not need
+ * to understand anything about the NITF file layout in order to write out the
+ * file.  The bytes are intentionally provided back as a series of pointers
+ * rather than one contiguous block of memory in order to minimize the number of
+ * copies.
+ *
+ * Limitations:
+ * - Graphics, labels, texts, and reserved extensions are not supported
+ * - Image segments and data extension segments are supported.
+ * - TREs are supported in the file header and/or image subheaders in either
+ * the user-defined or extended sections
+ * - Multiple image segments are supported, but only where the images are
+ * intended to be vertically stacked (so the number of columns must match and
+ * all indexing will be as if the image segments are intended to be vertically
+ * stacked in order.  ILOC and IALVL are not checked).
+ *
+ * The NITF layout is
+ * (lastSeg = mImageSubheaderFileOffsets.size() - 1):
+ *
+ * Offset 0
+ * ========
+ * fileHeader
+ *
+ * Offset mImageSubheaderFileOffsets[0]
+ * ===================================
+ * mImageSubheaders[0]
+ *
+ * Offset mImageSubheaderFileOffsets[0] + mImageSubheaders[0].size()
+ * ===============================================================
+ * <Raw pixel data for first image segment.  Must be written in Big Endian
+ * format.>
+ *
+ * ...
+ *
+ * Offset mImageSubheaderFileOffsets[lastSeg]
+ * ===================================
+ * mImageSubheaders[lastSeg]
+ *
+ * Offset mImageSubheaderFileOffsets[lastSeg] + mImageSubheaders[lastSeg].size()
+ * ===========================================================================
+ * <Raw pixel data for last image segment.  Must be written in Big Endian
+ * format.>
+ *
+ * Offset desSubheaderFileOffset
+ * =============================
+ * desSubheaderAndData
+ *
+ */
+class ByteProvider
+{
+public:
+    typedef std::pair<const void*, size_t> PtrAndLength;
+
+    /*!
+     * \param record Pre-populated NITF record.  All TREs, image subheader, and
+     * DES subheader information must be filled out.  Record won't be modified.
+     * \param desData Optional DES data (one per DES subheader).  These are
+     * pointers to the raw DES binary data itself (just data, not subheader).
+     * \param numRowsPerBlock The number of rows per block.  Defaults to no
+     * blocking.
+     * \param numColsPerBlock The number of columns per block.  Defaults to no
+     * blocking.
+     */
+    ByteProvider(Record& record,
+                 const std::vector<PtrAndLength>& desData =
+                            std::vector<PtrAndLength>(),
+                    size_t numRowsPerBlock = 0,
+                    size_t numColsPerBlock = 0);
+
+    /*!
+     * Destructor.  No virtual methods but this is virtual in case it's useful
+     * to inherit from this class and use it polymorphically.
+     */
+    virtual ~ByteProvider();
+
+    //! \return The total number of bytes in the NITF
+    nitf::Off getFileNumBytes() const
+    {
+        return mFileNumBytes;
+    }
+
+    //! \return The raw file header bytes
+    const std::vector<sys::byte>& getFileHeader() const
+    {
+        return mFileHeader;
+    }
+
+    /*!
+     * \return The raw bytes for each image subheader.  Vector size matches the
+     * number of image segments.
+     */
+    const std::vector<std::vector<sys::byte> >& getImageSubheaders() const
+    {
+        return mImageSubheaders;
+    }
+
+    /*!
+     * \return The raw bytes for each DES (subheader immediately followed by
+     * raw DES data).  Vector size matches the number of data extension segments.
+     */
+    const std::vector<sys::byte>& getDesSubheaderAndData() const
+    {
+        return mDesSubheaderAndData;
+    }
+
+    /*!
+     * \return The file offset for each image subheader.  Vector size matches
+     * the number of image segments.
+     */
+    const std::vector<nitf::Off>& getImageSubheaderFileOffsets() const
+    {
+        return mImageSubheaderFileOffsets;
+    }
+
+    /*!
+     * \return The file offset for the first DES subheader.
+     */
+    nitf::Off getDesSubheaderFileOffset() const
+    {
+        return mDesSubheaderFileOffset;
+    }
+
+    /*!
+     * Given a range of rows from [startRow, startRow + numRows), provide the
+     * number of bytes that will appear in the NITF on disk (including NITF
+     * file header, image subheader(s), and DES subheader(s) and data).  Calling
+     * this method repeatedly, eventually providing the entire range of the
+     * image, will produce the total number of bytes in the full NITF.
+     *
+     * \param startRow The global start row in pixels as to where these pixels
+     * are in the image.  If this is a multi-segment NITF, this is still simply
+     * the global pixel location.
+     * \param numRows The number of rows.
+     *
+     * \return The associated number of bytes in the NITF
+     */
+    nitf::Off getNumBytes(size_t startRow, size_t numRows) const;
+
+    /*!
+     * The caller provides an AOI of the pixel data.  This method provides back
+     * a list of contiguous buffers corresponding to the raw NITF bytes for
+     * this portion of the file.  If this AOI is in the middle of an image
+     * segment, this will be simply a buffer list of length 1 consisting of the
+     * input pointer (no copy occurs).  Otherwise, pointers to various headers
+     * (file header, image subheader(s), DES subheader and data) will
+     * be in the buffer list before, in the middle, and/or after the image
+     * data.  If this method is called multiple times with AOIs that
+     * eventually consist of the entire image, and the raw bytes are written
+     * out to disk in order with respect to the start pixel rows this method is
+     * called with (or out of order but seeking to the provided file offset
+     * each time), and in the order contained in the buffer list, it will form
+     * a valid NITF.
+     *
+     * \note This method does not perform byte swapping on the pixel data for
+     * efficiency reasons, but NITFs are written out in big endian order.  This
+     * means that on a little endian system, you must byte swap the pixel data
+     * prior to calling this method.
+     *
+     * \note This method does not perform any blocking on the pixel data.  If
+     * the NITF is blocked, the pixel data must already be in a contiguous
+     * blocked memory layout, including pad pixels for partial blocks.
+     *
+     * \param imageData The image data pixels to write.  The underlying type
+     * will be complex short or complex float based on the complex data sent
+     * in during initialize.  Must be in big endian order and blocked if the
+     * NITF is.
+     * \param startRow The global start row in pixels as to where these pixels
+     * are in the image.  If this is a multi-segment NITF, this is still simply
+     * the global pixel location.
+     * \param numRows The number of rows in the provided 'imageData'
+     * \param[out] fileOffset The offset in bytes in the NITF where these
+     * buffers should be written
+     * \param[out] buffers One or more pointers to raw bytes of data.  These
+     * should be written out in the order they are provided in the buffer list.
+     * The pointers point to the provided pixel data and, if required, one or
+     * more NITF headers.  No copies occur, so these buffers are only valid for
+     * the lifetime of this provider object (since this object owns the raw
+     * bytes for the NITF headers) and the lifetime of the passed-in image
+     * data.
+     */
+    void getBytes(const void* imageData,
+                  size_t startRow,
+                  size_t numRows,
+                  nitf::Off& fileOffset,
+                  NITFBufferList& buffers) const;
+
+    /*!
+     * \return ImageBlocker with settings in sync with how the image will be
+     * blocked in the NITF
+     */
+    std::auto_ptr<const ImageBlocker> getImageBlocker() const;
+
+protected:
+    /*!
+     * Default constructor.  Expectation is that if an inheriting class uses
+     * this constructor, the inheriting class will call initialize() later in
+     * its constructor.
+     */
+    ByteProvider();
+
+    /*!
+     * \param record Pre-populated NITF record.  All TREs, image subheader, and
+     * DES subheader information must be filled out.  Record won't be modified.
+     * \param desData Optional DES data (one per DES subheader).  These are
+     * pointers to the raw DES binary data itself (just data, not subheader).
+     * \param numRowsPerBlock The number of rows per block.  Defaults to no
+     * blocking.
+     * \param numColsPerBlock The number of columns per block.  Defaults to no
+     * blocking.
+     */
+    void initialize(Record& record,
+                    const std::vector<PtrAndLength>& desData =
+                            std::vector<PtrAndLength>(),
+                    size_t numRowsPerBlock = 0,
+                    size_t numColsPerBlock = 0);
+
+private:
+    void getFileLayout(nitf::Record& inRecord,
+                       const std::vector<PtrAndLength>& desData);
+
+    void checkBlocking(size_t seg,
+                       size_t startGlobalRowToWrite,
+                       size_t numRowsToWrite) const;
+
+private:
+    // Represents the row information for a NITF image segment
+    struct SegmentInfo
+    {
+        SegmentInfo() :
+            firstRow(0),
+            numRows(0)
+        {
+        }
+
+        size_t endRow() const
+        {
+            return (firstRow + numRows);
+        }
+
+        bool isInRange(size_t rangeStartRow,
+                       size_t rangeNumRows,
+                       size_t& firstGlobalRowInThisSegment,
+                       size_t& numRowsInThisSegment) const
+        {
+            return ImageSegmentComputer::Segment::isInRange(
+                    firstRow, endRow(), rangeStartRow, rangeNumRows,
+                    firstGlobalRowInThisSegment, numRowsInThisSegment);
+        }
+
+        size_t firstRow;
+        size_t numRows;
+    };
+
+    size_t mNumCols;
+    size_t mOverallNumRowsPerBlock;
+
+    std::vector<size_t> mNumRowsPerBlock; // Per segment
+    size_t mNumColsPerBlock;
+    size_t mNumBytesPerRow;
+    size_t mNumBytesPerPixel;
+
+    std::vector<SegmentInfo> mImageSegmentInfo; // Per segment
+
+    std::vector<sys::byte> mFileHeader;
+    std::vector<std::vector<sys::byte> > mImageSubheaders; // Per segment
+
+    // All DES subheaders and data together contiguously
+    std::vector<sys::byte> mDesSubheaderAndData;
+
+    std::vector<nitf::Off> mImageSubheaderFileOffsets; // Per segment
+    nitf::Off mDesSubheaderFileOffset;
+    nitf::Off mFileNumBytes;
+};
+}

--- a/modules/c++/nitf/source/ByteProvider.cpp
+++ b/modules/c++/nitf/source/ByteProvider.cpp
@@ -1,0 +1,503 @@
+/* =========================================================================
+ * This file is part of NITRO
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2018, MDA Information Systems LLC
+ *
+ * NITRO is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string.h>
+#include <sstream>
+#include <algorithm>
+#include <limits>
+
+#include <except/Exception.h>
+#include <nitf/Writer.hpp>
+#include <nitf/ByteProvider.hpp>
+#include <nitf/IOStreamWriter.hpp>
+#include <io/ByteStream.h>
+
+namespace
+{
+void copyFromStreamAndClear(io::ByteStream& stream,
+                            std::vector<sys::byte>& rawBytes)
+{
+    rawBytes.resize(stream.getSize());
+    if (!rawBytes.empty())
+    {
+        ::memcpy(&rawBytes[0], stream.get(), stream.getSize());
+    }
+
+    stream.clear();
+}
+}
+
+namespace nitf
+{
+ByteProvider::ByteProvider() :
+    mNumCols(0),
+    mOverallNumRowsPerBlock(0),
+    mNumColsPerBlock(0),
+    mNumBytesPerRow(0),
+    mNumBytesPerPixel(0)
+{
+}
+
+ByteProvider::ByteProvider(Record& record,
+                           const std::vector<PtrAndLength>& desData,
+                           size_t numRowsPerBlock,
+                           size_t numColsPerBlock) :
+    mNumCols(0),
+    mOverallNumRowsPerBlock(0),
+    mNumColsPerBlock(0),
+    mNumBytesPerRow(0),
+    mNumBytesPerPixel(0)
+{
+    initialize(record, desData, numRowsPerBlock, numColsPerBlock);
+}
+
+ByteProvider::~ByteProvider()
+{
+}
+
+void ByteProvider::initialize(Record& record,
+                              const std::vector<PtrAndLength>& desData,
+                              size_t numRowsPerBlock,
+                              size_t numColsPerBlock)
+{
+    // Get all the file headers and offsets
+    getFileLayout(record, desData);
+    mOverallNumRowsPerBlock = numRowsPerBlock;
+
+    size_t numColsWithPad;
+    if (numColsPerBlock != 0)
+    {
+        mNumColsPerBlock = numColsPerBlock;
+        numColsWithPad = ImageSubheader::getActualImageDim(
+                mNumCols, mNumColsPerBlock);
+    }
+    else
+    {
+        numColsWithPad = mNumCols;
+    }
+
+    mNumBytesPerRow = numColsWithPad * mNumBytesPerPixel;
+    if (mOverallNumRowsPerBlock == 0)
+    {
+        mNumRowsPerBlock.resize(record.getNumImages());
+        std::fill(mNumRowsPerBlock.begin(), mNumRowsPerBlock.end(), 0);
+    }
+    else
+    {
+        mNumRowsPerBlock = getImageBlocker()->getNumRowsPerBlock();
+    }
+}
+
+void ByteProvider::getFileLayout(nitf::Record& inRecord,
+                                 const std::vector<PtrAndLength>& desData)
+{
+    mem::SharedPtr<io::ByteStream> byteStream(new io::ByteStream());
+
+    nitf::IOStreamWriter io(byteStream);
+
+    // Make a copy just to make sure we don't corrupt anything since the
+    // methods are non-const
+    nitf::Record record = inRecord.clone();
+
+    // This stuff is low priority so not supported yet
+    if (record.getNumGraphics() > 0 ||
+        record.getNumLabels() > 0 ||
+        record.getNumTexts() > 0 ||
+        record.getNumReservedExtensions() > 0)
+    {
+        throw except::NotImplementedException(Ctxt(
+                "Graphics, labels, text, and reserved extensions not yet "
+                "supported"));
+    }
+
+    nitf::Writer writer;
+    writer.prepareIO(io, record);
+
+    //--------------------------------------------------------------------------
+    // Write image subheaders
+    //--------------------------------------------------------------------------
+
+    const size_t numImages = record.getNumImages();
+    mImageSubheaders.resize(numImages);
+    mImageSegmentInfo.resize(numImages);
+    std::vector<nitf::Off> imageDataLens(numImages);
+    nitf::Off imageSegmentsTotalNumBytes(0);
+
+    for (size_t ii = 0; ii < numImages; ++ii)
+    {
+        nitf::ImageSegment imageSegment = record.getImages()[ii];
+        nitf::ImageSubheader subheader = imageSegment.getSubheader();
+
+        nitf::Off comratOff(0);
+        writer.writeImageSubheader(subheader,
+                                   record.getVersion(),
+                                   comratOff);
+        copyFromStreamAndClear(*byteStream, mImageSubheaders[ii]);
+
+        imageDataLens[ii] = subheader.getNumBytesOfImageData();
+
+        imageSegmentsTotalNumBytes +=
+                mImageSubheaders[ii].size() + imageDataLens[ii];
+
+        const size_t numCols = subheader.getNumCols();
+        const size_t numBands = subheader.getNumImageBands();
+        const size_t numBytesPerPixel =
+                NITF_NBPP_TO_BYTES(subheader.getActualBitsPerPixel()) *
+                numBands;
+        if (ii == 0)
+        {
+            mNumCols = numCols;
+            mNumBytesPerPixel = numBytesPerPixel;
+        }
+        else
+        {
+            if (numCols != mNumCols)
+            {
+                std::ostringstream ostr;
+                ostr << "First image segment had " << mNumCols
+                     << " columns but image segment " << ii << " has "
+                     << numCols;
+                throw except::Exception(Ctxt(ostr.str()));
+            }
+
+            if (numBytesPerPixel != mNumBytesPerPixel)
+            {
+                std::ostringstream ostr;
+                ostr << "First image segment had " << mNumBytesPerPixel
+                     << " bytes/pxeil but image segment " << ii << " has "
+                     << numBytesPerPixel;
+                throw except::Exception(Ctxt(ostr.str()));
+            }
+        }
+
+        mImageSegmentInfo[ii].firstRow = (ii == 0) ?
+                0 : mImageSegmentInfo[ii - 1].endRow();
+
+        mImageSegmentInfo[ii].numRows = subheader.getNumRows();
+    }
+
+    //--------------------------------------------------------------------------
+    // Write data extension segment(s) (subheader + data)
+    //--------------------------------------------------------------------------
+
+    const size_t numDESs = record.getNumDataExtensions();
+    if (numDESs != desData.size())
+    {
+        std::ostringstream ostr;
+        ostr << "Record has " << numDESs << " DESs but "
+             << desData.size() << " DES data was sent in";
+        throw except::Exception(Ctxt(ostr.str()));
+    }
+
+    std::vector<size_t> desSubheaderLengths(numDESs);
+    std::vector<size_t> desDataLengths(numDESs);
+
+    for (size_t ii = 0; ii < numDESs; ++ii)
+    {
+        nitf::DESegment deSegment = record.getDataExtensions()[ii];
+        nitf::DESubheader subheader = deSegment.getSubheader();
+        nitf::Uint32 userSublen;
+        writer.writeDESubheader(subheader, userSublen, record.getVersion());
+        desSubheaderLengths[ii] = byteStream->getSize();
+
+        // Write data
+        const PtrAndLength& curData(desData[ii]);
+        byteStream->write(curData.first, curData.second);
+        desDataLengths[ii] = curData.second;
+    }
+
+    copyFromStreamAndClear(*byteStream, mDesSubheaderAndData);
+
+    //--------------------------------------------------------------------------
+    // Write the file header
+    //--------------------------------------------------------------------------
+
+    // This initial write won't set a number of the lengths, so we'll seek
+    // around to set those ourselves
+    nitf_Off fileLenOff;
+    nitf_Uint32 hdrLen;
+    record.setComplexityLevelIfUnset();
+    writer.writeHeader(fileLenOff, hdrLen);
+    const nitf::Off fileHeaderNumBytes = byteStream->getSize();
+
+    // Overall file length and header length
+    mFileNumBytes =
+            fileHeaderNumBytes + imageSegmentsTotalNumBytes +
+            mDesSubheaderAndData.size();
+
+    byteStream->seek(fileLenOff, io::Seekable::START);
+    writer.writeInt64Field(mFileNumBytes, NITF_FL_SZ, '0', NITF_WRITER_FILL_LEFT);
+    writer.writeInt64Field(hdrLen, NITF_HL_SZ, '0', NITF_WRITER_FILL_LEFT);
+
+    // Image segments
+    byteStream->seek(NITF_NUMI_SZ, io::Seekable::CURRENT);
+    for (size_t ii = 0; ii < numImages; ++ii)
+    {
+        writer.writeInt64Field(mImageSubheaders[ii].size(), NITF_LISH_SZ, '0',
+                                NITF_WRITER_FILL_LEFT);
+
+        writer.writeInt64Field(imageDataLens[ii], NITF_LI_SZ, '0',
+                                NITF_WRITER_FILL_LEFT);
+    }
+
+    // Seek past all the 3 byte lengths for the various other types that we
+    // don't have in our file (graphics, NUMX, text, plus the number of DESs
+    // that we've already written to the file anyhow)
+    byteStream->seek(NITF_NUMS_SZ + NITF_NUMX_SZ + NITF_NUMT_SZ + NITF_NUMDES_SZ,
+                     io::Seekable::CURRENT);
+
+    // Data extension segments
+    for (size_t ii = 0; ii < numDESs; ++ii)
+    {
+        writer.writeInt64Field(desSubheaderLengths[ii], NITF_LDSH_SZ, '0',
+                               NITF_WRITER_FILL_LEFT);
+
+        writer.writeInt64Field(desDataLengths[ii], NITF_LD_SZ, '0',
+                               NITF_WRITER_FILL_LEFT);
+    }
+
+    copyFromStreamAndClear(*byteStream, mFileHeader);
+
+    // Figure out where the image subheader offsets are
+    mImageSubheaderFileOffsets.resize(numImages);
+    nitf::Off offset = mFileHeader.size();
+    for (size_t ii = 0; ii < numImages; ++ii)
+    {
+         mImageSubheaderFileOffsets[ii] = offset;
+         offset += static_cast<nitf::Off>(mImageSubheaders[ii].size()) +
+                 imageDataLens[ii];
+    }
+
+    // DES is right after that
+    mDesSubheaderFileOffset = offset;
+}
+
+std::auto_ptr<const ImageBlocker> ByteProvider::getImageBlocker() const
+{
+    std::vector<size_t> numRowsPerSegment(mImageSegmentInfo.size());
+    for (size_t ii = 0; ii < mImageSegmentInfo.size(); ++ii)
+    {
+        numRowsPerSegment[ii] = mImageSegmentInfo[ii].numRows;
+    }
+
+    std::auto_ptr<const ImageBlocker> blocker(new ImageBlocker(
+            numRowsPerSegment,
+            mNumCols,
+            mOverallNumRowsPerBlock,
+            mNumColsPerBlock));
+
+    return blocker;
+}
+
+void ByteProvider::checkBlocking(size_t seg,
+                                 size_t startGlobalRowToWrite,
+                                 size_t numRowsToWrite) const
+{
+    if (mOverallNumRowsPerBlock != 0)
+    {
+        const SegmentInfo& imageSegmentInfo(mImageSegmentInfo[seg]);
+        const size_t segStartRow = imageSegmentInfo.firstRow;
+
+        // Need to start on a block boundary
+        const size_t segStartRowToWrite =
+                startGlobalRowToWrite - segStartRow;
+        const size_t numRowsPerBlock(mNumRowsPerBlock[seg]);
+        if (segStartRowToWrite % numRowsPerBlock != 0)
+        {
+            std::ostringstream ostr;
+            ostr << "Trying to write starting at segment " << seg
+                 << "'s row " << segStartRowToWrite
+                 << " which is not a multiple of " << numRowsPerBlock;
+            throw except::Exception(Ctxt(ostr.str()));
+        }
+
+        // Need to end on a block boundary or the end of the segment
+        if (numRowsToWrite % numRowsPerBlock != 0 &&
+            segStartRowToWrite + numRowsToWrite < imageSegmentInfo.numRows)
+        {
+            std::ostringstream ostr;
+            ostr << "Trying to write " << numRowsToWrite
+                 << " rows at global start row " << startGlobalRowToWrite
+                 << " starting at segment " << seg
+                 << " which is not a multiple of " << numRowsPerBlock
+                 << " (segment has start = " << imageSegmentInfo.firstRow
+                 << ", num = " << imageSegmentInfo.numRows << ")";
+            throw except::Exception(Ctxt(ostr.str()));
+        }
+    }
+}
+
+nitf::Off ByteProvider::getNumBytes(size_t startRow, size_t numRows) const
+{
+    nitf::Off numBytes(0);
+
+    const size_t imageDataEndRow = startRow + numRows;
+
+    for (size_t seg = 0; seg < mImageSegmentInfo.size(); ++seg)
+    {
+        // See if we're in this segment
+        const SegmentInfo& imageSegmentInfo(mImageSegmentInfo[seg]);
+
+        size_t startGlobalRowToWrite;
+        size_t numRowsToWrite;
+        if (imageSegmentInfo.isInRange(startRow, numRows,
+                                       startGlobalRowToWrite,
+                                       numRowsToWrite))
+        {
+            checkBlocking(seg, startGlobalRowToWrite, numRowsToWrite);
+            const size_t segStartRow = imageSegmentInfo.firstRow;
+
+            if (startRow <= segStartRow)
+            {
+                // We have the first row of this image segment, so we're
+                // responsible for the image subheader
+                if (seg == 0)
+                {
+                    // For the very first image segment, we're responsible for
+                    // the file header too
+                    numBytes += mFileHeader.size();
+                }
+
+                numBytes += mImageSubheaders[seg].size();
+            }
+
+            const size_t numRowsPerBlock(mNumRowsPerBlock[seg]);
+            if (numRowsPerBlock != 0 &&
+                imageDataEndRow >= imageSegmentInfo.endRow())
+            {
+                const size_t numLeftovers =
+                        imageSegmentInfo.numRows % numRowsPerBlock;
+                if (numLeftovers != 0)
+                {
+                    // We need to finish the block
+                    const size_t numPadRows = numRowsPerBlock - numLeftovers;
+                    numRowsToWrite += numPadRows;
+                }
+            }
+
+            numBytes += numRowsToWrite * mNumBytesPerRow;
+
+            if (seg == mImageSegmentInfo.size() - 1 &&
+                imageSegmentInfo.endRow() == imageDataEndRow)
+            {
+                // When we write out the last row of the last image segment, we
+                // tack on the DES(s)
+                numBytes += mDesSubheaderAndData.size();
+            }
+        }
+    }
+
+    return numBytes;
+}
+
+void ByteProvider::getBytes(const void* imageData,
+                            size_t startRow,
+                            size_t numRows,
+                            nitf::Off& fileOffset,
+                            NITFBufferList& buffers) const
+{
+    fileOffset = std::numeric_limits<nitf::Off>::max();
+    buffers.clear();
+
+    const size_t imageDataEndRow = startRow + numRows;
+
+    size_t numPadRowsSoFar(0);
+
+    for (size_t seg = 0; seg < mImageSegmentInfo.size(); ++seg)
+    {
+        // See if we're in this segment
+        const SegmentInfo& imageSegmentInfo(mImageSegmentInfo[seg]);
+
+        size_t startGlobalRowToWrite;
+        size_t numRowsToWrite;
+        if (imageSegmentInfo.isInRange(startRow, numRows,
+                                       startGlobalRowToWrite,
+                                       numRowsToWrite))
+        {
+            checkBlocking(seg, startGlobalRowToWrite, numRowsToWrite);
+            const size_t segStartRow = imageSegmentInfo.firstRow;
+
+            if (startRow <= segStartRow)
+            {
+                // We have the first row of this image segment, so we're
+                // responsible for the image subheader
+                if (seg == 0)
+                {
+                    // For the very first image segment, we're responsible for
+                    // the file header too
+                    fileOffset = 0;
+                    buffers.pushBack(mFileHeader);
+                }
+
+                if (buffers.empty())
+                {
+                    fileOffset = mImageSubheaderFileOffsets[seg];
+                }
+                buffers.pushBack(mImageSubheaders[seg]);
+            }
+
+            // Figure out what offset of 'imageData' we're writing from
+            const size_t startLocalRowToWrite =
+                    startGlobalRowToWrite - startRow + numPadRowsSoFar;
+            const sys::byte* imageDataPtr =
+                    static_cast<const sys::byte*>(imageData) +
+                    startLocalRowToWrite * mNumBytesPerRow;
+
+            if (buffers.empty())
+            {
+                const size_t rowsInSegmentSkipped =
+                        startRow - segStartRow;
+
+                fileOffset = mImageSubheaderFileOffsets[seg] +
+                        mImageSubheaders[seg].size() +
+                        rowsInSegmentSkipped * mNumBytesPerRow;
+            }
+
+            const size_t numRowsPerBlock(mNumRowsPerBlock[seg]);
+            if (numRowsPerBlock != 0 &&
+                imageDataEndRow >= imageSegmentInfo.endRow())
+            {
+                const size_t numLeftovers =
+                        imageSegmentInfo.numRows % numRowsPerBlock;
+                if (numLeftovers != 0)
+                {
+                    // We need to finish the block
+                    // This is already accounted for in the incoming image
+                    const size_t numPadRows = numRowsPerBlock - numLeftovers;
+                    numRowsToWrite += numPadRows;
+                    numPadRowsSoFar += numPadRows;
+                }
+            }
+
+            buffers.pushBack(imageDataPtr, numRowsToWrite * mNumBytesPerRow);
+
+            if (seg == mImageSegmentInfo.size() - 1 &&
+                imageSegmentInfo.endRow() == imageDataEndRow)
+            {
+                // When we write out the last row of the last image segment, we
+                // tack on the DES(s)
+                buffers.pushBack(mDesSubheaderAndData);
+            }
+        }
+    }
+}
+}


### PR DESCRIPTION
Generalized the SIX ByteProvider - this makes it easy to ask NITRO for a portion of the NITF in terms of raw bytes so you can write it yourself.

See https://github.com/ngageoint/six-library/pull/220/ for more details.

FYI @JonathanMeans @christianwhite1193 