### PR TITLE
Add check for no rows

### DIFF
--- a/modules/c++/nitf/source/ImageBlocker.cpp
+++ b/modules/c++/nitf/source/ImageBlocker.cpp
@@ -339,6 +339,11 @@ void ImageBlocker::block(const void* input,
                          size_t numBytesPerPixel,
                          void* output) const
 {
+    if (numRows == 0)
+    {
+        return;
+    }
+
     // Find which segments we're in
     size_t firstSegIdx;
     size_t startBlockWithinFirstSeg;


### PR DESCRIPTION
Need one more spot to check for this... otherwise `findSegmentRange()` sets all its output values to the numeric max value but we still incorrectly end up in the following `for` loop