### PR TITLE
Python should be able to read NITF with size_t bytes

### DIFF
--- a/modules/python/nitf/samples/strip_invisible_segments.py
+++ b/modules/python/nitf/samples/strip_invisible_segments.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+"""
+ * =========================================================================
+ * This file is part of NITRO
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2017, MDA Information Systems LLC
+ *
+ * NITRO is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ *
+"""
+
+
+import argparse
+import os
+
+import nitf
+
+
+def copyHeader(src, dest):
+    for field in src.header.fieldMap:
+        dest.header[field] = src.header[field]
+
+
+def copyImage(reader, image, record):
+    segment = record.newImageSegment()
+    segment.subheader.fieldMap = image.subheader.fieldMap.copy()
+    segment.subheader.ref = image.subheader.ref
+    print(dir(segment.subheader))
+
+    print('Metadata copied()')
+    print(type(segment.subheader.fieldMap))
+
+    imageSource = nitf.ImageSource()
+    window = nitf.SubWindow()
+    window.numRows = image.subheader['numRows'].intValue()
+    window.numCols = image.subheader['numCols'].intValue()
+    window.bandList = list(range(image.subheader.getBandCount()))
+    bandData = reader.read(window)
+    for ii in window.bandList:
+        imageSource.addBand(nitf.MemoryBandSource(bandData, bandData.shape[1],
+                                                  ii, 1, bandData.shape[0] - 1))
+    print(segment.subheader.fieldMap['pixelvaluetype'])
+    return imageSource
+
+
+def stripSegments(source, output):
+    handle = nitf.IOHandle(source)
+    reader = nitf.Reader()
+    record = reader.read(handle)
+
+    headerLength = int(record.header['HL'])
+    numImages = int(record.header['NUMI'])
+    print(dir(record.header))
+    imageLengths = []
+    for ii in xrange(numImages):
+        subheaderLength = record.header['LISH{:03d}'.format(ii + 1)]
+        imageLength = record.header['LI{:02d}'.format(ii + 1)]
+        print(subheaderLength)
+    '''
+    # imagesOmitted = 0
+    sources = []
+    for ii, image in enumerate(record.getImages()):
+        # if str(image['IREP']).strip() == 'NODISPLY':
+            # imagesOmitted += 1
+            # continue
+
+        sources.append(
+            copyImage(reader.newImageReader(ii), image, outRecord))
+    handle = nitf.IOHandle(output, nitf.IOHandle.ACCESS_WRITEONLY)
+    copyHeader(record, outRecord)
+    writer.prepare(outRecord, handle)
+    for ii, source in enumerate(sources):
+        imageWriter = writer.newImageWriter(ii)
+        imageWriter.attachSource(source)
+    writer.write()
+    '''
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser('Round trip a NITF, stripping segments '
+                                     'that should not be displayed')
+    parser.add_argument('source')
+    parser.add_argument('output')
+    args = parser.parse_args()
+    if not os.path.isfile(args.source):
+        raise IOError('{} is not a file'.format(args.source))
+    stripSegments(args.source, args.output)
+

--- a/modules/python/nitf/source/generated/nitropy_wrap.cxx
+++ b/modules/python/nitf/source/generated/nitropy_wrap.cxx
@@ -3263,6 +3263,7 @@ namespace swig {
 #include <import/nitf.h>
 #include <numpyutils/numpyutils.h>
 #include <iostream>
+#include <limits>
 
 
 SWIGINTERN swig_type_info*

--- a/modules/python/nitf/source/generated/nitropy_wrap.cxx
+++ b/modules/python/nitf/source/generated/nitropy_wrap.cxx
@@ -4181,18 +4181,20 @@ SWIG_AsVal_long_SS_long (PyObject *obj, long long *val)
         nitf_Uint8 *pyArrayBuffer = NULL;
         PyObject* result = Py_None;
         int padded, rowSkip, colSkip;
-        size_t subimageSize;
+        nitf_Uint64 subimageSize;
         nitf_Uint32 i;
         types::RowCol<size_t> dims;
 
         rowSkip = window->downsampler ? window->downsampler->rowSkip : 1;
         colSkip = window->downsampler ? window->downsampler->colSkip : 1;
-        subimageSize = static_cast<size_t>(window->numRows/rowSkip) *
+        subimageSize = static_cast<nitf_Uint64>(window->numRows/rowSkip) *
                 (window->numCols/colSkip) *
                 nitf_ImageIO_pixelSize(reader->imageDeblocker);
-        if (subimageSize < window->numRows / rowSkip)
+        if (subimageSize > std::numeric_limits<size_t>::max())
         {
-            std::cerr << "Image is too large for this system\n";
+            nitf_Error_print(error, stderr,
+                             "Image is too large for this system\n");
+            PyErr_SetString(PyExc_MemoryError, "");
             goto CATCH_ERROR;
         }
 

--- a/modules/python/nitf/source/generated/nitropy_wrap.cxx
+++ b/modules/python/nitf/source/generated/nitropy_wrap.cxx
@@ -4180,13 +4180,21 @@ SWIG_AsVal_long_SS_long (PyObject *obj, long long *val)
         nitf_Uint8 **buf = NULL;
         nitf_Uint8 *pyArrayBuffer = NULL;
         PyObject* result = Py_None;
-        int padded, rowSkip, colSkip, subimageSize;
+        int padded, rowSkip, colSkip;
+        size_t subimageSize;
         nitf_Uint32 i;
         types::RowCol<size_t> dims;
 
         rowSkip = window->downsampler ? window->downsampler->rowSkip : 1;
         colSkip = window->downsampler ? window->downsampler->colSkip : 1;
-        subimageSize = (window->numRows/rowSkip) * (window->numCols/colSkip) * nitf_ImageIO_pixelSize(reader->imageDeblocker);
+        subimageSize = static_cast<size_t>(window->numRows/rowSkip) *
+                (window->numCols/colSkip) *
+                nitf_ImageIO_pixelSize(reader->imageDeblocker);
+        if (subimageSize < window->numRows / rowSkip)
+        {
+            std::cerr << "Image is too large for this system\n";
+            goto CATCH_ERROR;
+        }
 
         dims.row = window->numBands;
         dims.col = subimageSize;

--- a/modules/python/nitf/source/nitro.i
+++ b/modules/python/nitf/source/nitro.i
@@ -594,13 +594,21 @@
         nitf_Uint8 **buf = NULL;
         nitf_Uint8 *pyArrayBuffer = NULL;
         PyObject* result = Py_None;
-        int padded, rowSkip, colSkip, subimageSize;
+        int padded, rowSkip, colSkip;
+        size_t subimageSize;
         nitf_Uint32 i;
         types::RowCol<size_t> dims;
 
         rowSkip = window->downsampler ? window->downsampler->rowSkip : 1;
         colSkip = window->downsampler ? window->downsampler->colSkip : 1;
-        subimageSize = (window->numRows/rowSkip) * (window->numCols/colSkip) * nitf_ImageIO_pixelSize(reader->imageDeblocker);
+        subimageSize = static_cast<size_t>(window->numRows/rowSkip) *
+                (window->numCols/colSkip) *
+                nitf_ImageIO_pixelSize(reader->imageDeblocker);
+        if (subimageSize < window->numRows / rowSkip)
+        {
+            std::cerr << "Image is too large for this system\n";
+            goto CATCH_ERROR;
+        }
 
         dims.row = window->numBands;
         dims.col = subimageSize;

--- a/modules/python/nitf/source/nitro.i
+++ b/modules/python/nitf/source/nitro.i
@@ -26,6 +26,7 @@
 #include <import/nitf.h>
 #include <numpyutils/numpyutils.h>
 #include <iostream>
+#include <limits>
 %}
 
 #define NITF_LIST_TO_PYTHON_LIST(_type) \

--- a/modules/python/nitf/source/nitro.i
+++ b/modules/python/nitf/source/nitro.i
@@ -595,18 +595,20 @@
         nitf_Uint8 *pyArrayBuffer = NULL;
         PyObject* result = Py_None;
         int padded, rowSkip, colSkip;
-        size_t subimageSize;
+        nitf_Uint64 subimageSize;
         nitf_Uint32 i;
         types::RowCol<size_t> dims;
 
         rowSkip = window->downsampler ? window->downsampler->rowSkip : 1;
         colSkip = window->downsampler ? window->downsampler->colSkip : 1;
-        subimageSize = static_cast<size_t>(window->numRows/rowSkip) *
+        subimageSize = static_cast<nitf_Uint64>(window->numRows/rowSkip) *
                 (window->numCols/colSkip) *
                 nitf_ImageIO_pixelSize(reader->imageDeblocker);
-        if (subimageSize < window->numRows / rowSkip)
+        if (subimageSize > std::numeric_limits<size_t>::max())
         {
-            std::cerr << "Image is too large for this system\n";
+            nitf_Error_print(error, stderr,
+                             "Image is too large for this system\n");
+            PyErr_SetString(PyExc_MemoryError, "");
             goto CATCH_ERROR;
         }
 


### PR DESCRIPTION
Someone wants to use Python to read in a NITF image of size > 2^32 - 1 bytes. A size_t should be able to handle it on a 64-bit system. 