### PR TITLE
Fixing NITF subheader length for multiple DES writes

### DIFF
--- a/modules/c++/nitf/source/ByteProvider.cpp
+++ b/modules/c++/nitf/source/ByteProvider.cpp
@@ -243,14 +243,14 @@ void ByteProvider::getFileLayout(nitf::Record& inRecord,
 
     std::vector<size_t> desSubheaderLengths(numDESs);
     std::vector<size_t> desDataLengths(numDESs);
-
     for (size_t ii = 0; ii < numDESs; ++ii)
     {
         nitf::DESegment deSegment = record.getDataExtensions()[ii];
         nitf::DESubheader subheader = deSegment.getSubheader();
         nitf::Uint32 userSublen;
+        const size_t prevSize = byteStream->getSize();
         writer.writeDESubheader(subheader, userSublen, record.getVersion());
-        desSubheaderLengths[ii] = byteStream->getSize();
+        desSubheaderLengths[ii] = byteStream->getSize() - prevSize;
 
         // Write data
         const PtrAndLength& curData(desData[ii]);


### PR DESCRIPTION
ByteProvider interface already supports writing multiple DES buffers. Unfortunately, the subheader length is not correct because the ByteStream it uses to tally buffer size continues to increment.