### PR TITLE
Fixed bug in J2K reader that was causing errors reading last tile

### DIFF
--- a/modules/c/j2k/source/OpenJPEGImpl.c
+++ b/modules/c/j2k/source/OpenJPEGImpl.c
@@ -158,8 +158,19 @@ OpenJPEG_createIO(nrt_IOInterface* io,
         }
         else
         {
-            ioControl->length = nrt_IOInterface_getSize(io, error)
-                    - ioControl->offset;
+            /*
+             * nrt_IOInterface_getSize() returns the number of bytes *remaining*
+             * that could be read from this io object, not the *total* number of
+             * bytes this io object contains, so ioControl->offset doesn't need
+             * to be subtracted off here.
+             *
+             * TODO: Technically we should just report the number of bytes
+             *       remaining in this image segment, not in the whole NITF,
+             *       though if we somehow read beyond this image segment,
+             *       presumably we'd get OpenJPEG errors because the bytes
+             *       we'd be reading wouldn't be J2K tiles
+             */
+            ioControl->length = nrt_IOInterface_getSize(io, error);
         }
 
         opj_stream_set_user_data(stream, ioControl, NULL);


### PR DESCRIPTION
We were subtracting off an offset that we shouldn't have been, resulting in OpenJPEG erroring out reading the last tile thinking it didn't have enough bytes (unless the NITF happened to contain other content after the last image segment).