### PR TITLE
Adding static block() method that performs a single block operation

### DIFF
--- a/modules/c++/nitf/include/nitf/ImageBlocker.hpp
+++ b/modules/c++/nitf/include/nitf/ImageBlocker.hpp
@@ -138,6 +138,33 @@ public:
         block(input, startRow, numRows, sizeof(DataT), output);
     }
 
+    /*!
+     * \param input Input image of width 'numCols'
+     * \param numBytesPerPixel Number of bytes/pixel in 'input' and 'output'
+     * \param numCols Number of columns in 'input'
+     * \param numRowsPerBlock Number of rows per block
+     * \param numColsPerBlock Number of columns per block
+     * \param numValidRowsInBlock Number of valid rows in block (this is less
+     * than numRowsPerBlock for the bottom row of blocks if
+     * numRows % numRowsPerBlock != 0)
+     * \param numValidColsInBlock Number of valid columnss in block (this is
+     * less than numColsPerBlock for the rightmost column of blocks if
+     * numCols % numColsPerBlock != 0)
+     * \param[out] output Output image.  Will contain this single block of
+     * 'input'.  Must be at least numRowsPerBlock * numColsPerBlock pixels.
+     * If the number of valid rows/columns is less than the rows/columns in the
+     * block, these pixels will be zero-filled.
+     */
+    static
+    void block(const void* input,
+               size_t numBytesPerPixel,
+               size_t numCols,
+               size_t numRowsPerBlock,
+               size_t numColsPerBlock,
+               size_t numValidRowsInBlock,
+               size_t numValidColsInBlock,
+               void* output);
+
     //! \return The number of columns of blocks
     size_t getNumColsOfBlocks() const
     {
@@ -242,7 +269,12 @@ private:
                    size_t numValidRowsInBlock,
                    size_t numValidColsInBlock,
                    size_t numBytesPerPixel,
-                   sys::byte* output) const;
+                   sys::byte* output) const
+    {
+        block(input, numBytesPerPixel, mNumCols, mNumRowsPerBlock[seg],
+              mNumColsPerBlock, numValidRowsInBlock, numValidColsInBlock,
+              output);
+    }
 
     void blockAcrossRow(size_t seg,
                         const sys::byte*& input,


### PR DESCRIPTION
This makes it easier to perform blocking on the fly as part of another (likely threaded) operation