### PR TITLE
CompressedByteProvider can return a single image buffer

### DIFF
--- a/modules/c++/nitf/source/ByteProvider.cpp
+++ b/modules/c++/nitf/source/ByteProvider.cpp
@@ -31,21 +31,6 @@
 #include <nitf/IOStreamWriter.hpp>
 #include <io/ByteStream.h>
 
-namespace
-{
-void copyFromStreamAndClear(io::ByteStream& stream,
-                            std::vector<sys::byte>& rawBytes)
-{
-    rawBytes.resize(stream.getSize());
-    if (!rawBytes.empty())
-    {
-        ::memcpy(&rawBytes[0], stream.get(), stream.getSize());
-    }
-
-    stream.clear();
-}
-}
-
 namespace nitf
 {
 ByteProvider::ByteProvider() :

--- a/modules/c++/nitf/source/CompressedByteProvider.cpp
+++ b/modules/c++/nitf/source/CompressedByteProvider.cpp
@@ -160,15 +160,17 @@ size_t CompressedByteProvider::addImageData(
     }
 
     // Copy the image data into the buffer
-    size_t bytesWritten = 0;
-    for (size_t ii = blockRange.mStartElement;
-            ii < blockRange.mStartElement + blockRange.mNumElements;
-            ++ii)
+    // Since we have it in contiguous memory, this can be added as one buffer
+    size_t numBufferBytes(0);
+    for (size_t ii = blockRange.mStartElement, end = blockRange.endElement();
+         ii < end;
+         ++ii)
     {
-        buffers.pushBack(imageData + bytesWritten, bytesPerBlock[ii]);
-        bytesWritten += bytesPerBlock[ii];
+        numBufferBytes += bytesPerBlock[ii];
     }
-    return bytesWritten;
+    buffers.pushBack(imageData, numBufferBytes);
+
+    return numBufferBytes;
 }
 
 nitf::Off CompressedByteProvider::getNumBytes(size_t startRow, size_t numRows) const


### PR DESCRIPTION
The memory's all contiguous so can return this as a single buffer

Removing unused standalone function in unnamed namespace (it had gotten moved to a member function)