### PR TITLE
Fix IOStreamReader::getSizeImpl()

### DIFF
--- a/modules/c++/nitf/source/IOStreamReader.cpp
+++ b/modules/c++/nitf/source/IOStreamReader.cpp
@@ -79,7 +79,12 @@ nitf::Off IOStreamReader::tellImpl() const
 
 nitf::Off IOStreamReader::getSizeImpl() const
 {
-    return mStream.available();
+    // There's no way to ask a stream what its total size is, so need to seek
+    // to the end to find out
+    const nitf::Off origPos = mStream.tell();
+    const nitf::Off size = mStream.seek(0, io::Seekable::END);
+    mStream.seek(origPos, io::Seekable::START);
+    return size;
 }
 
 int IOStreamReader::getModeImpl() const

--- a/modules/c/j2k/source/OpenJPEGImpl.c
+++ b/modules/c/j2k/source/OpenJPEGImpl.c
@@ -159,18 +159,14 @@ OpenJPEG_createIO(nrt_IOInterface* io,
         else
         {
             /*
-             * nrt_IOInterface_getSize() returns the number of bytes *remaining*
-             * that could be read from this io object, not the *total* number of
-             * bytes this io object contains, so ioControl->offset doesn't need
-             * to be subtracted off here.
-             *
              * TODO: Technically we should just report the number of bytes
              *       remaining in this image segment, not in the whole NITF,
              *       though if we somehow read beyond this image segment,
              *       presumably we'd get OpenJPEG errors because the bytes
              *       we'd be reading wouldn't be J2K tiles
              */
-            ioControl->length = nrt_IOInterface_getSize(io, error);
+            ioControl->length =
+                    nrt_IOInterface_getSize(io, error) - ioControl->offset;
         }
 
         opj_stream_set_user_data(stream, ioControl, NULL);


### PR DESCRIPTION
Previous "fix" to OpenJPEG implementation broke using it with an IOHandle.  Tracked it down to actually a bug in IOStreamReader::getSizeImpl().  getSize() *is* intended to be the total size (that's how nrt_IOHandle_getSize() is implemented).