### PR TITLE
Setting maxRowsPerSegment is problematic - should be inferring it

### DIFF
--- a/modules/c++/nitf/include/nitf/CompressedByteProvider.hpp
+++ b/modules/c++/nitf/include/nitf/CompressedByteProvider.hpp
@@ -71,15 +71,13 @@ public:
      * blocking.
      * \param numColsPerBlock The number of columns per block.  Defaults to no
      * blocking.
-     * \param maxRowsPerSegment The maximum rows allowed in an image segment
      */
     CompressedByteProvider(Record& record,
             const std::vector<std::vector<size_t> >& bytesPerBlock,
             const std::vector<PtrAndLength>& desData =
                     std::vector<PtrAndLength>(),
             size_t numRowsPerBlock = 0,
-            size_t numColsPerBlock = 0,
-            size_t maxRowsPerSegment = 0);
+            size_t numColsPerBlock = 0);
 
     /*!
      * Given a range of rows from [startRow, startRow + numRows), provide the
@@ -160,15 +158,13 @@ protected:
      * blocking.
      * \param numColsPerBlock The number of columns per block.  Defaults to no
      * blocking.
-     * \param maxRowsPerSegment The maximum rows allowed in an image segment
      */
     void initialize(Record& record,
             const std::vector<std::vector<size_t> >& bytesPerBlock,
             const std::vector<PtrAndLength>& desData =
                     std::vector<PtrAndLength>(),
             size_t numRowsPerBlock = 0,
-            size_t numColsPerBlock = 0,
-            size_t maxRowsPerSegment = 0);
+            size_t numColsPerBlock = 0);
 
     size_t countBytesForCompressedImageData(
             size_t seg, size_t startRow, size_t numRowsToWrite) const;
@@ -182,12 +178,11 @@ protected:
             NITFBufferList& buffers) const;
 
 private:
-    types::Range findBlocksToWrite(size_t seg, size_t startRow,
+    types::Range findBlocksToWrite(size_t seg, size_t globalStartRow,
             size_t numRowsToWrite) const;
 
 private:
     std::vector<std::vector<size_t> > mBytesInEachBlock;
-    size_t mMaxRowsPerSegment;
 };
 }
 

--- a/modules/c++/nitf/source/CompressedByteProvider.cpp
+++ b/modules/c++/nitf/source/CompressedByteProvider.cpp
@@ -44,20 +44,18 @@ CompressedByteProvider::CompressedByteProvider(Record& record,
         const std::vector<std::vector<size_t> >& bytesPerBlock,
         const std::vector<PtrAndLength>& desData,
         size_t numRowsPerBlock,
-        size_t numColsPerBlock,
-        size_t maxRowsPerSegment) :
+        size_t numColsPerBlock) :
     ByteProvider()
 {
-    initialize(record, bytesPerBlock, desData, numRowsPerBlock, numColsPerBlock,
-            maxRowsPerSegment);
+    initialize(record, bytesPerBlock, desData,
+               numRowsPerBlock, numColsPerBlock);
 }
 
 void CompressedByteProvider::initialize(Record& record,
         const std::vector<std::vector<size_t> >& bytesPerBlock,
         const std::vector<PtrAndLength>& desData,
         size_t numRowsPerBlock,
-        size_t numColsPerBlock,
-        size_t maxRowsPerSegment)
+        size_t numColsPerBlock)
 {
     // Get all the file headers and offsets
     const size_t numImages = record.getNumImages();
@@ -80,7 +78,6 @@ void CompressedByteProvider::initialize(Record& record,
         }
     }
     mBytesInEachBlock = bytesPerBlock;
-    mMaxRowsPerSegment = maxRowsPerSegment;
     initializeImpl(record, desData, numRowsPerBlock, numColsPerBlock);
 }
 
@@ -90,8 +87,17 @@ size_t CompressedByteProvider::countBytesForCompressedImageData(
     // If we've already compressed, we don't care about padding.
     // We just need to figure out -which- blocks we're writing, and then grab
     // that from the member vector
-    const std::vector<size_t>& bytesPerBlock = mBytesInEachBlock[seg];
-    types::Range blockRange = findBlocksToWrite(seg, startRow, numRowsToWrite);
+    const std::vector<size_t>& bytesPerBlock = mBytesInEachBlock.at(seg);
+    const types::Range blockRange =
+            findBlocksToWrite(seg, startRow, numRowsToWrite);
+    if (blockRange.endElement() > bytesPerBlock.size())
+    {
+        std::ostringstream ostr;
+        ostr << "Trying to get bytes from blocks [" << blockRange.mStartElement
+             << ", " << blockRange.endElement() << ") but seg " << seg
+             << " only has " << bytesPerBlock.size() << " blocks";
+        throw except::Exception(Ctxt(ostr.str()));
+    }
 
     size_t numBytes = 0;
     for (size_t ii = blockRange.mStartElement;
@@ -103,23 +109,29 @@ size_t CompressedByteProvider::countBytesForCompressedImageData(
 }
 
 types::Range CompressedByteProvider::findBlocksToWrite(
-        size_t seg, size_t startRow, size_t numRowsToWrite) const
+        size_t seg, size_t globalStartRow, size_t numRowsToWrite) const
 {
-    size_t firstRowOfImage = 0;
-    size_t firstBlockOfImage = 0;
-    for (size_t ii = 0; ii < seg; ++ii)
+    const SegmentInfo& segmentInfo(mImageSegmentInfo.at(seg));
+    if (globalStartRow < segmentInfo.firstRow ||
+        globalStartRow + numRowsToWrite > segmentInfo.endRow())
     {
-        firstRowOfImage += mMaxRowsPerSegment;
-        firstBlockOfImage += mBytesInEachBlock[ii].size();
+        std::ostringstream ostr;
+        ostr << "Asking for global rows [" << globalStartRow << ", "
+              << (globalStartRow + numRowsToWrite) << ") from seg " << seg
+              << " which contains global rows [" << segmentInfo.firstRow
+              << ", " << segmentInfo.endRow() << ")";
+        throw except::Exception(Ctxt(ostr.str()));
     }
-    startRow -= firstRowOfImage;
+
+    const size_t startRow = globalStartRow - segmentInfo.firstRow;
+    const size_t numRowsPerBlock(mNumRowsPerBlock[seg]);
 
     const size_t numHorizontalBlocks = math::ceilingDivide(mNumCols,
                                                            mNumColsPerBlock);
     const size_t firstRowOfBlocks = math::ceilingDivide(startRow,
-                                                        mNumRowsPerBlock[0]);
+                                                        numRowsPerBlock);
     const size_t numRowsOfBlocks = math::ceilingDivide(numRowsToWrite,
-                                                       mNumRowsPerBlock[0]);
+                                                       numRowsPerBlock);
     const size_t numBlocks = numRowsOfBlocks * numHorizontalBlocks;
     const size_t firstBlock = firstRowOfBlocks * numHorizontalBlocks;
 


### PR DESCRIPTION
This fixes a bug that occurred when writing NITFs > 10 GB that were splitting into multiple image segments but this maxNumRowsPerSegment was just defaulting to 0 which was causing incorrect rows to be computed.  This always has to be in sync with the Record, so we can just infer this.