### PR TITLE
Added a check to see if we are on the last block and see if any block…

### DIFF
--- a/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
+++ b/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
@@ -26,7 +26,7 @@ extern "C"{
 }
 const nitf::Int64 BLOCK_LENGTH = 1024;
 const nitf::Int64 ILOC_MAX     = 99999;
-std::string generateILOC(const types::RowCol<nitf::Int64> &offset)
+std::string generateILOC(const types::RowCol<nitf::Int64>& offset)
 {
    std::ostringstream oss;
 

--- a/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
+++ b/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
@@ -1,0 +1,331 @@
+#include <cstdlib>
+#include <ctime>
+#include <memory>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <sstream>
+#include <import/nitf.h>
+#include <import/types.h>
+#include <nitf/ImageSegmentComputer.h>
+#include <nitf/ImageSubheader.hpp>
+#include <nitf/Record.hpp>
+#include <nitf/Writer.hpp>
+#include <nitf/Reader.hpp>
+#include <math/Round.h>
+#include <io/FileInputStream.h>
+#include <io/TempFile.h>
+#include "TestCase.h"
+
+extern "C"{
+   NITF_BOOL nitf_ImageIO_getMaskInfo(nitf_ImageIO *nitf,
+                                      nitf_Uint32 *imageDataOffset, nitf_Uint32 *blockRecordLength,
+                                      nitf_Uint32 *padRecordLength, nitf_Uint32 *padPixelValueLength,
+                                      nitf_Uint8 **padValue, nitf_Uint64 **blockMask, nitf_Uint64 **padMask);
+                     
+}
+const int BLOCK_LENGTH = 1024;
+const int64_t ILOC_MAX = 99999;
+std::string generateILOC(const types::RowCol<size_t> &offset)
+{
+   std::ostringstream oss;
+
+   oss.fill('0');
+   oss << std::setw(5) << offset.row << std::setw(5) << offset.col;
+
+   return oss.str();
+}
+
+nitf::ImageSubheader setImageSubHeader(
+    nitf::Record &record,
+    size_t imageIndex,
+    const types::RowCol<size_t> &fullDims,
+    const types::RowCol<size_t> &segmentDims,
+    const types::RowCol<size_t> &segmentOffset,
+    const types::RowCol<size_t> &globalSegmentOffset,
+    bool fileSeparate)
+{
+   nitf::ImageSegment   imageSegment = record.newImageSegment();
+   nitf::ImageSubheader imgSubHdr = imageSegment.getSubheader();
+   imgSubHdr.getFilePartType().set("IM");
+   std::string iidTag = "TEST";
+   std::string imgSrc = "TEST";
+   std::string imgDateTime;
+   std::string IID = "TEST";
+   std::string tgtId = "TEST";
+   const char* compressionType = "NM";
+
+   imgSubHdr.getEncrypted().set(0);
+   imgSubHdr.getNumRows().set((nitf::Int64)segmentDims.row);
+   imgSubHdr.getNumCols().set((nitf::Int64)segmentDims.col);
+   imgSubHdr.getNumImageComments().set(0);
+   imgSubHdr.getImageCompression().set(compressionType);
+   imgSubHdr.getCompressionRate().set("    ");
+   imgSubHdr.insertImageComment("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 0);
+   std::vector<nitf::BandInfo> bands;
+   nitf::BandInfo bandI;
+   bandI.getRepresentation().set("M ");
+   bandI.getSubcategory().set("      ");
+   bandI.getImageFilterCondition().set("N");
+   bandI.getImageFilterCode().set("   ");
+   bandI.getNumLUTs().set(0);
+   bands.push_back(bandI);
+   size_t numBands;
+   std::string pixelValueType;
+   size_t numBitsPerPixel;
+   size_t actualBitsPerPixel;
+   std::string pixelJustification;
+   std::string imageRepresentation;
+   std::string imageCategory;
+
+   numBands = 1;
+   pixelValueType = "INT";
+   numBitsPerPixel = 8;
+   actualBitsPerPixel = 8;
+   pixelJustification = "R";
+   imageRepresentation = "MONO";
+   imageCategory = "SOS";
+   imgSubHdr.setPixelInformation(
+      pixelValueType,
+      numBitsPerPixel,
+      actualBitsPerPixel,
+      pixelJustification,
+      imageRepresentation,
+      imageCategory,
+      bands);
+   imgSubHdr.getImageSyncCode().set("0");
+   imgSubHdr.getImageMode().set("B");
+   nitf::Int64 blocksPerRow = (segmentDims.col + (BLOCK_LENGTH - 1)) / BLOCK_LENGTH;
+   nitf::Int64 blocksPerCol = (segmentDims.row + (BLOCK_LENGTH - 1)) / BLOCK_LENGTH;
+
+   imgSubHdr.getNumBlocksPerRow().set(blocksPerRow);
+   imgSubHdr.getNumPixelsPerHorizBlock().set(BLOCK_LENGTH);
+   imgSubHdr.getNumBlocksPerCol().set(blocksPerCol);
+   imgSubHdr.getNumPixelsPerVertBlock().set(BLOCK_LENGTH);
+
+   imgSubHdr.getImageDisplayLevel().set((nitf::Int64)imageIndex+1);
+   imgSubHdr.getImageAttachmentLevel().set((nitf::Int64)imageIndex);
+
+   imgSubHdr.getImageLocation().set(generateILOC(segmentOffset));
+
+   return imgSubHdr;
+}
+
+size_t getNumberBlocksPresent(const nitf_Uint64 *mask,
+                              size_t numRows,
+                              size_t numCols)
+{
+   size_t numBlocksPresent = 0;
+   size_t row;
+   size_t col;
+   size_t idx;
+   for (row = 0, idx = 0; row < numRows; ++row)
+   {
+      for (col = 0; col < numCols; ++col, ++idx)
+      {
+         if (mask[idx] != 0xFFFFFFFF)
+         {
+            ++numBlocksPresent;
+         }
+      }
+   }
+
+   return numBlocksPresent;
+}
+void createSingleBandBuffer(std::vector<uint8_t>& buffer,                                     
+                  nitf::ImageSegmentComputer &segmentComputer,
+                  const types::RowCol<size_t> &fullDims,
+                  const int segmentIdxToMakeEmpty)
+{
+   size_t bytes = fullDims.row * fullDims.col;
+   size_t segmentSizeInBytes = 0;
+   const std::vector<nitf::ImageSegmentComputer::Segment> &segments = segmentComputer.getSegments();
+   buffer.resize(bytes);
+   segmentSizeInBytes = segments[0].numRows * fullDims.col;
+
+   memset(&buffer.front(), '0xff', bytes);
+   memset(&buffer.front() + (segmentSizeInBytes * segmentIdxToMakeEmpty),
+          '\0', segmentSizeInBytes);
+}
+
+void createBuffers(std::vector<std::vector<uint8_t> > &buffers,
+                   nitf::ImageSegmentComputer &imageSegmentComputer,
+                   const types::RowCol<size_t> &fullDims)
+{
+   int64_t nSegments = imageSegmentComputer.getSegments().size();
+   /*
+   * Create the memory images single band and then make the
+   * segment blank for each one at different segments.
+   */
+   buffers.resize(nSegments);
+   for (int64_t idx = 0; idx < nSegments; ++idx)
+   {
+      createSingleBandBuffer(buffers[idx],
+                             imageSegmentComputer,
+                             fullDims,
+                             idx);
+   }
+}
+
+TEST_CASE(testBlankSegmentsValid)
+{
+   // This is rather lengthy but will allocate 3 segments 
+   // then write them to a temp NITF file.
+   // will read those files and then verify that the Masks are proper size
+   // there should be 0 blocks written for blank segments
+   //
+   //
+   // Create 3 segments for testing
+   nitf_Error error; /* Pointer to the error object */
+   int64_t numberLines     = BLOCK_LENGTH * 3;
+   int64_t numberElements  = BLOCK_LENGTH * 2;
+   int64_t bytesPerSegment = BLOCK_LENGTH * BLOCK_LENGTH * 2;
+   int64_t elementSize     = 1;
+   int32_t numberOfTests   = 0;
+   uint32_t idx            = 0;
+   const types::RowCol<size_t> fullDims(numberLines, numberElements);
+   nitf::ImageSubheader img;
+   nitf::Writer writer;
+   std::vector<std::vector<uint8_t> > buffers;
+   nitf::ImageSegmentComputer imageSegmentComputer(numberLines,
+                                                   numberElements,
+                                                   elementSize,
+                                                   ILOC_MAX,
+                                                   bytesPerSegment,
+                                                   BLOCK_LENGTH);
+
+   const int64_t numSegments = imageSegmentComputer.getSegments().size();
+   const std::vector<nitf::ImageSegmentComputer::Segment> &segments = imageSegmentComputer.getSegments();
+
+   numberOfTests = numSegments;
+   TEST_ASSERT_EQ(numSegments, 3);
+   createBuffers(buffers, imageSegmentComputer, fullDims);
+   for (size_t testIdx = 0; testIdx < numberOfTests; ++testIdx)
+   {
+      nitf::Record record(NITF_VER_21);
+      io::TempFile tempNitf;
+      nitf::ImageSubheader img;
+      nitf::Writer writer;
+      nitf::IOHandle output_io(tempNitf.pathname(),
+                               NITF_ACCESS_WRITEONLY,
+                               NITF_CREATE);
+      std::vector<types::RowCol<size_t> > segmentDims(numSegments);
+      std::vector<types::RowCol<size_t> > segmentOffsets(numSegments);
+      for (size_t ii = 0; ii < numSegments; ++ii)
+      {
+         types::RowCol<size_t> dims;
+         types::RowCol<size_t> offset;
+         int64_t numRows = segments[ii].numRows;
+         dims = types::RowCol<size_t>(numRows, numberElements);
+         offset = types::RowCol<size_t>(segments[ii].rowOffset, 0);
+         segmentOffsets[ii] = types::RowCol<size_t>(segments[ii].firstRow, 0);
+
+         img = setImageSubHeader(record, ii, fullDims, dims, offset, segmentOffsets[ii], false);
+      }
+      writer.prepare(output_io, record);
+
+      for (size_t ii = 0; ii < numSegments; ++ii)
+      {
+         uint8_t *buf = &buffers[testIdx].front() + (ii * bytesPerSegment);
+         nitf::ImageWriter imageWriter = writer.newImageWriter(ii);
+         imageWriter.setWriteCaching(1);
+         nitf::ImageSource iSource;
+         nitf::MemorySource memSource(buf,
+                                      bytesPerSegment,
+                                      0, 1, 0);
+         iSource.addBand(memSource);
+         imageWriter.attachSource(iSource);
+      }
+      writer.write();
+      output_io.close();
+
+      {
+         nitf_Reader *reader=NULL;         /* Reader object */
+         nitf_Record *record = NULL;       /* Record used for input and output */
+         nitf_IOHandle in;            /* Input I/O handle */
+         nitf_ListIterator imgIter;   /* Image segment list iterator */
+         nitf_ListIterator imgEnd;    /* Image segment list iterator */
+         nitf_ImageSegment *seg = NULL; /* Image segment object */
+         nitf_ImageSubheader *subhdr = NULL; /* Image subheader object */
+         nitf_ImageReader *iReader = NULL;   /* Image reader */
+         nitf_BlockingInfo *blkInfo = NULL;  /* Blocking information */
+
+         /*  Image information */
+
+         char imageMode[NITF_IMODE_SZ + 1]; /* Image (blocking) mode */
+
+         /*  Mask structure and mask components */
+
+         nitf_Uint32 imageDataOffset;     /* Offset to actual image data past masks */
+         nitf_Uint32 blockRecordLength;   /* Block mask record length */
+         nitf_Uint32 padRecordLength;     /* Pad mask record length */
+         nitf_Uint32 padPixelValueLength; /* Pad pixel value length in bytes */
+         nitf_Uint8 *padValue;            /* Pad value */
+         nitf_Uint64 *blockMask;          /* Block mask array */
+         nitf_Uint64 *padMask;            /* Pad mask array */
+         size_t imgCtr = 0;
+
+         in = nitf_IOHandle_create(tempNitf.pathname().c_str(),
+                                   NITF_ACCESS_READONLY, NITF_OPEN_EXISTING, &error);
+         TEST_ASSERT_TRUE( (NITF_INVALID_HANDLE(in)!=true) );
+         reader = nitf_Reader_construct(&error);
+         record = nitf_Reader_read(reader, in, &error);
+
+         /* Loop through the image segments */
+         imgIter = nitf_List_begin(record->images);
+         imgEnd = nitf_List_end(record->images);
+         while (nitf_ListIterator_notEqualTo(&imgIter, &imgEnd))
+         {
+            /*  Get information from the image subheader */
+            seg = (nitf_ImageSegment *)nitf_ListIterator_get(&imgIter);
+            TEST_ASSERT_TRUE((seg!=NULL));
+            subhdr = seg->subheader;
+
+            nitf_Field_get(subhdr->imageMode,
+                           imageMode, NITF_CONV_STRING, NITF_IMODE_SZ + 1, &error);
+            imageMode[NITF_IMODE_SZ] = 0;
+
+            /*  Get an image reader which creates the nitf_ImageIO were the masks are */
+
+            iReader = nitf_Reader_newImageReader(reader, imgCtr, NULL, &error);
+            TEST_ASSERT_TRUE( (iReader!=NULL) );
+
+            blkInfo = nitf_ImageReader_getBlockingInfo(iReader, &error);
+            TEST_ASSERT_TRUE( (blkInfo!=NULL) );
+            TEST_ASSERT_TRUE(nitf_ImageIO_getMaskInfo(iReader->imageDeblocker,
+                                       &imageDataOffset, &blockRecordLength,
+                                       &padRecordLength, &padPixelValueLength,
+                                       &padValue, &blockMask, &padMask) != 0);
+            size_t nBlocksPresent = 0;
+            size_t totalBlocks = blkInfo->numBlocksPerRow * blkInfo->numBlocksPerCol;
+            TEST_ASSERT_GREATER(blockRecordLength, 0);
+            
+            nBlocksPresent = getNumberBlocksPresent(blockMask,
+                                                      blkInfo->numBlocksPerRow,
+                                                      blkInfo->numBlocksPerCol);
+
+            if (imgCtr == testIdx)
+            {
+               TEST_ASSERT_EQ(nBlocksPresent, 0);
+            }
+            else
+            {
+               TEST_ASSERT_EQ(nBlocksPresent, totalBlocks);
+            }
+
+            nitf_ImageReader_destruct(&iReader);
+            nrt_ListIterator_increment(&imgIter);
+            ++imgCtr;
+         }
+         /*    Clean-up */
+         nitf_Reader_destruct(&reader);
+         nitf_IOHandle_close(in);
+         nitf_Record_destruct(&record);
+      }
+   }
+}
+
+int main(int argc, char *argv[])
+{
+   TEST_CHECK(testBlankSegmentsValid);
+}

--- a/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
+++ b/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
@@ -284,7 +284,7 @@ TEST_CASE(testBlankSegmentsValid)
    }
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
    TEST_CHECK(testBlankSegmentsValid);
 

--- a/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
+++ b/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
@@ -283,6 +283,7 @@ TEST_CASE(testBlankSegmentsValid)
             }
             ++imgCtr;
          }
+         input_io.close();
       }
    }
 }

--- a/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
+++ b/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
@@ -37,12 +37,12 @@ std::string generateILOC(const types::RowCol<nitf::Int64> &offset)
 }
 
 nitf::ImageSubheader setImageSubHeader(
-    nitf::Record &record,
-    nitf::Int64 imageIndex,
-    const types::RowCol<nitf::Int64> &fullDims,
-    const types::RowCol<nitf::Int64> &segmentDims,
-    const types::RowCol<nitf::Int64> &segmentOffset,
-    const types::RowCol<nitf::Int64> &globalSegmentOffset,
+    nitf::Record&                     record,
+    nitf::Int64                       imageIndex,
+    const types::RowCol<nitf::Int64>& fullDims,
+    const types::RowCol<nitf::Int64>& segmentDims,
+    const types::RowCol<nitf::Int64>& segmentOffset,
+    const types::RowCol<nitf::Int64>& globalSegmentOffset,
     bool fileSeparate)
 {
    nitf::ImageSegment   imageSegment = record.newImageSegment();
@@ -103,9 +103,9 @@ nitf::ImageSubheader setImageSubHeader(
    return imgSubHdr;
 }
 
-nitf::Int64 getNumberBlocksPresent(const nitf_Uint64 *mask,
-                                   const nitf::Int64 numRows,
-                                   const nitf::Int64 numCols)
+nitf::Int64 getNumberBlocksPresent(const nitf_Uint64* mask,
+                                   const nitf::Int64  numRows,
+                                   const nitf::Int64  numCols)
 {
    nitf::Int64 numBlocksPresent = 0;
    for (nitf::Int64 row = 0, idx = 0; row < numRows; ++row)
@@ -122,9 +122,9 @@ nitf::Int64 getNumberBlocksPresent(const nitf_Uint64 *mask,
    return numBlocksPresent;
 }
 
-void createSingleBandBuffer(std::vector<nitf::Uint8> &buffer,
-                            const nitf::ImageSegmentComputer &segmentComputer,
-                            const types::RowCol<nitf::Int64> &fullDims,
+void createSingleBandBuffer(std::vector<nitf::Uint8>& buffer,
+                            const nitf::ImageSegmentComputer& segmentComputer,
+                            const types::RowCol<nitf::Int64>& fullDims,
                             const nitf::Int64 segmentIdxToMakeEmpty)
 {
    const nitf::Int64 bytes = fullDims.area();
@@ -138,9 +138,9 @@ void createSingleBandBuffer(std::vector<nitf::Uint8> &buffer,
           '\0', segmentSizeInBytes);
 }
 
-void createBuffers(std::vector<std::vector<nitf::Uint8> > &buffers,
-                   const nitf::ImageSegmentComputer &imageSegmentComputer,
-                   const types::RowCol<nitf::Int64> &fullDims)
+void createBuffers(std::vector<std::vector<nitf::Uint8> >& buffers,
+                   const nitf::ImageSegmentComputer& imageSegmentComputer,
+                   const types::RowCol<nitf::Int64>& fullDims)
 {
    const nitf::Int64 nSegments = imageSegmentComputer.getSegments().size();
    /*
@@ -239,12 +239,10 @@ TEST_CASE(testBlankSegmentsValid)
          nitf_Uint32 blockRecordLength=0;      /* Block mask record length */
          nitf_Uint32 padRecordLength=0;        /* Pad mask record length */
          nitf_Uint32 padPixelValueLength=0;    /* Pad pixel value length in bytes */
-         nitf_Uint8 *padValue = NULL;        /* Pad value */
-         nitf_Uint64 *blockMask=NULL;             /* Block mask array */
-         nitf_Uint64 *padMask=NULL;               /* Pad mask array */
+         nitf_Uint8  *padValue = NULL;         /* Pad value */
+         nitf_Uint64 *blockMask=NULL;          /* Block mask array */
+         nitf_Uint64 *padMask=NULL;            /* Pad mask array */
          nitf::Int64 imgCtr = 0;
-         /*  Image information */
-         // char imageMode[NITF_IMODE_SZ + 1]; /* Image (blocking) mode */
          nitf::IOHandle input_io(tempNitf.pathname(),
                                  NITF_ACCESS_READONLY,
                                  NITF_OPEN_EXISTING);
@@ -282,7 +280,6 @@ TEST_CASE(testBlankSegmentsValid)
             }
             ++imgCtr;
          }
-         input_io.close();
       }
    }
 }

--- a/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
+++ b/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
@@ -257,7 +257,6 @@ TEST_CASE(testBlankSegmentsValid)
          {
             nitf::ImageSegment seg(static_cast<nitf_ImageSegment *>((*imageIterator)));
             nitf::ImageSubheader subhdr     = seg.getSubheader();
-            std::string imageMode           = subhdr.getImageMode().toString();
             nitf::ImageReader imageReader   = reader.newImageReader(imgCtr);
             nitf::BlockingInfo blockingInfo = imageReader.getBlockingInfo();
             nitf_ImageReader *iReader       = static_cast<nitf_ImageReader *>(imageReader.getNativeOrThrow());

--- a/modules/c/nitf/source/ImageIO.c
+++ b/modules/c/nitf/source/ImageIO.c
@@ -7149,17 +7149,14 @@ NITFPRIV(int) nitf_ImageIO_writeToBlock(_nitf_ImageIOBlock * blockIO,
                                         size_t count,
                                         nitf_Error * error)
 {
-    _nitf_ImageIO *nitf;                    /* Associated image I/O object */
+    _nitf_ImageIO *nitf = ((_nitf_ImageIOControl *)(blockIO->cntl))->nitf; /* Associated image I/O object */
     _nitf_ImageIOBlockCacheControl *blockCntl; /* Associated block control */
-    nitf_Uint64 fileOffset;                 /* Offset in filw for write */
+    nitf_Uint64 fileOffset;                 /* Offset in file for write */
     _NITF_IMAGE_IO_PAD_SCAN_FUNC scanner;   /* Pad scanning function */
-    nitf_Int64 nBlocks;
-    NITF_BOOL lastBlock = 0;
-    nitf = ((_nitf_ImageIOControl *)(blockIO->cntl))->nitf;
+    const nitf_Int64 nBlocks = nitf->nBlocksTotal;
+    const NITF_BOOL lastBlock = (blockIO->number == (nBlocks - 1));
     blockCntl = &(blockIO->blockControl);
     scanner = nitf->padScanner;
-    nBlocks = nitf->nBlocksTotal;
-    lastBlock = (blockIO->number == (nBlocks - 1));
 
     if (blockCntl->block == NULL)
     {


### PR DESCRIPTION
There was a bug when outputting compression type "NM".  If an image segment had all blank tiles the offset was not being adjusted for the next image segment to the start of where the pixels would have been written.  I added a working variable to blockIO to specify the total blocks written and use this during the write to see when we are on the last tile.  If the last tile is blank and no other tiles have been written then we adjust the file offset to go past the Mask header and to the start of the pixel data.  This will now be pointing to the proper offset for the next image segment to be written.