### PR TITLE
Bug fix for the totalBlocksWritten

### DIFF
--- a/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
+++ b/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
@@ -134,17 +134,13 @@ void createSingleBandBuffer(std::vector<nitf::Uint8>& buffer,
 
    buffer.resize(bytes);
    memset(&buffer.front(), '\0', bytes);
-   for (nitf::Int32 segIdx = 0; segIdx < segments.size(); ++segIdx)
+   for (nitf::Uint32 segIdx = 0; segIdx < segments.size(); ++segIdx)
    {
       nitf::Uint8 *segStart = &buffer.front() + (segmentSizeInBytes * segIdx);
       /* Set only the center that way we are surrounded by empty blocks */
       if (segIdx != segmentIdxToMakeEmpty)
       {
          segStart[segmentSizeInBytes/2] = 0xff;
-      }
-      else
-      {
-         memset(segStart, '\0', segmentSizeInBytes);
       }
    }
 }

--- a/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
+++ b/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
@@ -24,8 +24,8 @@ extern "C"{
                                       nitf_Uint8** padValue, nitf_Uint64** blockMask, nitf_Uint64** padMask);
                      
 }
-const nitf::Int64 BLOCK_LENGTH = 1024;
-const nitf::Int64 ILOC_MAX     = 99999;
+const nitf::Int64 BLOCK_LENGTH = 256;
+const nitf::Int64 ILOC_MAX = 99999;
 std::string generateILOC(const types::RowCol<nitf::Int64>& offset)
 {
    std::ostringstream oss;
@@ -133,9 +133,20 @@ void createSingleBandBuffer(std::vector<nitf::Uint8>& buffer,
    const nitf::Int64 segmentSizeInBytes = segments[segmentIdxToMakeEmpty].numRows * fullDims.col;
 
    buffer.resize(bytes);
-   memset(&buffer.front(), '0xff', bytes);
-   memset(&buffer.front() + (segmentSizeInBytes * segmentIdxToMakeEmpty),
-          '\0', segmentSizeInBytes);
+   memset(&buffer.front(), '\0', bytes);
+   for (nitf::Int32 segIdx = 0; segIdx < segments.size(); ++segIdx)
+   {
+      nitf::Uint8 *segStart = &buffer.front() + (segmentSizeInBytes * segIdx);
+      /* Set only the center that way we are surrounded by empty blocks */
+      if (segIdx != segmentIdxToMakeEmpty)
+      {
+         segStart[segmentSizeInBytes/2] = 0xff;
+      }
+      else
+      {
+         memset(segStart, '\0', segmentSizeInBytes);
+      }
+   }
 }
 
 void createBuffers(std::vector<std::vector<nitf::Uint8> >& buffers,
@@ -168,9 +179,10 @@ TEST_CASE(testBlankSegmentsValid)
     *
     * Create 3 segments for testing
     */
-   const nitf::Int64 numberLines     = BLOCK_LENGTH * 3;
-   const nitf::Int64 numberElements  = BLOCK_LENGTH * 2;
-   const nitf::Int64 bytesPerSegment = BLOCK_LENGTH * BLOCK_LENGTH * 2;
+   const nitf::Int64 BLOCK_LENGTH_SCALED = BLOCK_LENGTH*4;
+   const nitf::Int64 numberLines = BLOCK_LENGTH_SCALED * 3;
+   const nitf::Int64 numberElements = BLOCK_LENGTH_SCALED * 2;
+   const nitf::Int64 bytesPerSegment = BLOCK_LENGTH_SCALED * BLOCK_LENGTH_SCALED * 2;
    const nitf::Int64 elementSize     = 1;
    nitf::Int64 numberOfTests         = 0;
    const types::RowCol<nitf::Int64> fullDims(numberLines, numberElements);
@@ -276,7 +288,7 @@ TEST_CASE(testBlankSegmentsValid)
             }
             else
             {
-               TEST_ASSERT_EQ(nBlocksPresent, totalBlocks);
+               TEST_ASSERT_GREATER(nBlocksPresent, 0);
             }
             ++imgCtr;
          }


### PR DESCRIPTION
When we updated the inside location with the latest code it introduced a number of new errors.  After tracing the code I noticed that the totalBlocksWritten was in the block IO object and this is not unique.  We had to move this variable to the nitf block for that is unique for the segment. I also had to update the test so it would fail properly for these conditions.   I made it have more than just one row of Blocks per segment and instead of filling all white and then the blank with black I filled everything black and then any segment that is not suppose to be blank I wrote a single white value in the center of the segment.  This produced the proper error I was looking for and now this should handle the worst possible case. and fix the problem