### PR TITLE
Update BufferAdapter to seek past EOF like Unix and Windows interface

### DIFF
--- a/modules/c/nrt/source/IOInterface.c
+++ b/modules/c/nrt/source/IOInterface.c
@@ -190,21 +190,19 @@ NRTPRIV(NRT_BOOL) BufferAdapter_read(NRT_DATA * data, void *buf, size_t size,
                                      nrt_Error * error)
 {
     BufferIOControl *control = (BufferIOControl *) data;
-    const size_t validBufferSize = control->mark >= control->size ? 0 :
-        control->size - control->mark;
 
-    if (validBufferSize < size)
+    if (size > control->size - control->mark)
     {
-        memcpy(buf, (char *)(control->buf + control->mark), validBufferSize);
-        memset((char *)buf + validBufferSize, 0, size - validBufferSize);
-        control->mark += validBufferSize;
+        nrt_Error_init(error, "Invalid size requested - EOF", NRT_CTXT,
+                       NRT_ERR_MEMORY);
+        return NRT_FAILURE;
     }
-    else
+
+    if (size > 0)
     {
-        memcpy(buf, (char *) (control->buf + control->mark), size);
+        memcpy(buf, (char *)(control->buf + control->mark), size);
         control->mark += size;
     }
-
     return NRT_SUCCESS;
 }
 

--- a/modules/c/nrt/source/IOInterface.c
+++ b/modules/c/nrt/source/IOInterface.c
@@ -200,7 +200,7 @@ NRTPRIV(NRT_BOOL) BufferAdapter_read(NRT_DATA * data, void *buf, size_t size,
 
     if (size > 0)
     {
-        memcpy(buf, (char *)(control->buf + control->mark), size);
+        memcpy(buf, control->buf + control->mark, size);
         control->mark += size;
     }
     return NRT_SUCCESS;
@@ -220,7 +220,7 @@ NRTPRIV(NRT_BOOL) BufferAdapter_write(NRT_DATA * data, const void *buf,
 
     if (size > 0)
     {
-        memcpy((char *) (control->buf + control->mark), buf, size);
+        memcpy(control->buf + control->mark, buf, size);
         control->mark += size;
         if (control->mark > control->bytesWritten)
         {

--- a/modules/c/nrt/unittests/test_buffer_adapter.c
+++ b/modules/c/nrt/unittests/test_buffer_adapter.c
@@ -74,6 +74,24 @@ TEST_CASE(testReadOutOfBounds)
     }
 }
 
+TEST_CASE(testWriteOutOfBounds)
+{
+    char buffer[TEST_BUF_SIZE];
+    char input[5];
+    nrt_Error error;
+    NRT_BOOL success;
+
+    memset(input, 0, sizeof(input));
+
+    nrt_IOInterface* writer = nrt_BufferAdapter_construct(
+        buffer, TEST_BUF_SIZE, 0, &error);
+
+    success = nrt_IOInterface_seek(writer, TEST_BUF_SIZE, NRT_SEEK_SET, &error);
+    TEST_ASSERT(success);
+    success = nrt_IOInterface_write(writer, input, 4, &error);
+    TEST_ASSERT(!success);
+}
+
 int main(int argc, char **argv)
 {
     (void) argc;
@@ -81,6 +99,7 @@ int main(int argc, char **argv)
     CHECK(testReadInBounds);
     CHECK(testReadPastEnd);
     CHECK(testReadOutOfBounds);
+    CHECK(testWriteOutOfBounds);
     return 0;
 }
 

--- a/modules/c/nrt/unittests/test_buffer_adapter.c
+++ b/modules/c/nrt/unittests/test_buffer_adapter.c
@@ -62,12 +62,7 @@ TEST_CASE(testReadPastEnd)
 
     nrt_IOInterface_seek(reader, 8, NRT_SEEK_SET, &error);
     success = nrt_IOInterface_read(reader, output, sizeof(output), &error);
-    TEST_ASSERT(success);
-    TEST_ASSERT(output[0] == (char)2);
-    TEST_ASSERT(output[1] == (char)2);
-    TEST_ASSERT(output[2] == (char)0);
-    TEST_ASSERT(output[3] == (char)0);
-    TEST_ASSERT(output[4] == (char)0);
+    TEST_ASSERT(!success);
 }
 
 TEST_CASE(testReadOutOfBounds)
@@ -88,11 +83,7 @@ TEST_CASE(testReadOutOfBounds)
     success = nrt_IOInterface_seek(reader, TEST_BUF_SIZE, NRT_SEEK_SET, &error);
     TEST_ASSERT(success);
     success = nrt_IOInterface_read(reader, output, sizeof(output), &error);
-    TEST_ASSERT(success);
-    for (ii = 0; ii < sizeof(output); ++ii)
-    {
-        TEST_ASSERT(output[ii] == (char)0);
-    }
+    TEST_ASSERT(!success);
 }
 
 TEST_CASE(testWriteOutOfBounds)

--- a/modules/c/nrt/unittests/test_buffer_adapter.c
+++ b/modules/c/nrt/unittests/test_buffer_adapter.c
@@ -102,5 +102,3 @@ int main(int argc, char **argv)
     CHECK(testWriteOutOfBounds);
     return 0;
 }
-
-

--- a/modules/c/nrt/unittests/test_buffer_adapter.c
+++ b/modules/c/nrt/unittests/test_buffer_adapter.c
@@ -1,0 +1,87 @@
+#include <import/nrt.h>
+#include "Test.h"
+
+#define TEST_BUF_SIZE 10
+
+TEST_CASE(testReadInBounds)
+{
+    char buffer[TEST_BUF_SIZE];
+    char output[5];
+    nrt_Error error;
+    size_t ii;
+
+    memset(buffer, 0, 3);
+    memset(buffer + 3, 1, 5);
+    memset(buffer + 8, 2, 2);
+
+    nrt_IOInterface* reader = nrt_BufferAdapter_construct(
+        buffer, TEST_BUF_SIZE, 0, &error);
+
+    nrt_IOInterface_seek(reader, 3, NRT_SEEK_SET, &error);
+    nrt_IOInterface_read(reader, output, sizeof(output), &error);
+    for (ii = 0; ii < sizeof(output); ++ii)
+    {
+        TEST_ASSERT(output[ii] == (char)1);
+    }
+}
+
+TEST_CASE(testReadPastEnd)
+{
+    char buffer[TEST_BUF_SIZE];
+    char output[5];
+    nrt_Error error;
+    NRT_BOOL success;
+
+    memset(buffer, 0, 3);
+    memset(buffer + 3, 1, 5);
+    memset(buffer + 8, 2, 2);
+
+    nrt_IOInterface* reader = nrt_BufferAdapter_construct(
+        buffer, TEST_BUF_SIZE, 0, &error);
+
+    nrt_IOInterface_seek(reader, 8, NRT_SEEK_SET, &error);
+    success = nrt_IOInterface_read(reader, output, sizeof(output), &error);
+    TEST_ASSERT(success);
+    TEST_ASSERT(output[0] == (char)2);
+    TEST_ASSERT(output[1] == (char)2);
+    TEST_ASSERT(output[2] == (char)0);
+    TEST_ASSERT(output[3] == (char)0);
+    TEST_ASSERT(output[4] == (char)0);
+}
+
+TEST_CASE(testReadOutOfBounds)
+{
+    char buffer[TEST_BUF_SIZE];
+    char output[5];
+    nrt_Error error;
+    size_t ii;
+    NRT_BOOL success;
+
+    memset(buffer, 0, 3);
+    memset(buffer + 3, 1, 5);
+    memset(buffer + 8, 2, 2);
+
+    nrt_IOInterface* reader = nrt_BufferAdapter_construct(
+        buffer, TEST_BUF_SIZE, 0, &error);
+
+    success = nrt_IOInterface_seek(reader, TEST_BUF_SIZE, NRT_SEEK_SET, &error);
+    TEST_ASSERT(success);
+    success = nrt_IOInterface_read(reader, output, sizeof(output), &error);
+    TEST_ASSERT(success);
+    for (ii = 0; ii < sizeof(output); ++ii)
+    {
+        TEST_ASSERT(output[ii] == (char)0);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    CHECK(testReadInBounds);
+    CHECK(testReadPastEnd);
+    CHECK(testReadOutOfBounds);
+    return 0;
+}
+
+

--- a/modules/c/nrt/unittests/test_buffer_adapter.c
+++ b/modules/c/nrt/unittests/test_buffer_adapter.c
@@ -1,3 +1,24 @@
+/* =========================================================================
+ * This file is part of NITRO
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
+ *
+ * NITRO is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
 #include <import/nrt.h>
 #include "Test.h"
 


### PR DESCRIPTION
Both `lseek` and `SetFilePointer` treat seeking past EOF as valid, and any reads that occur after EOF just return 0 bytes. This should fix that EOF error message.

BufferAdapter will still error on writing past EOF rather than trying to emulate what Unix or Windows system calls will do, since this works with a fixed buffer, and if that's what you're trying to do, you're probably using the wrong thing entirely.