### PR TITLE
Fix BufferAdapter_getSize

### DIFF
--- a/modules/c/nrt/source/IOInterface.c
+++ b/modules/c/nrt/source/IOInterface.c
@@ -278,7 +278,7 @@ NRTPRIV(nrt_Off) BufferAdapter_getSize(NRT_DATA * data, nrt_Error * error)
     /* Silence compiler warnings about unused variables */
     (void)error;
 
-    return (nrt_Off) control->bytesWritten;
+    return (nrt_Off) control->size;
 }
 
 NRTPRIV(int) BufferAdapter_getMode(NRT_DATA * data, nrt_Error * error)


### PR DESCRIPTION
I agree that this is the right thing to do. Otherwise the size will always report as 0 when you just want to read. 

This does make things slightly more clunky if you want to use it for writing, but this is already not very good for writing. If someone wants to know how many bytes have been written, they should probably be using `BufferAdapter_tell()` anyway. 