### PR TITLE
Remove exception specifications.

### DIFF
--- a/modules/c++/nitf/include/nitf/BandInfo.hpp
+++ b/modules/c++/nitf/include/nitf/BandInfo.hpp
@@ -98,7 +98,7 @@ public:
               const std::string& imageFilterCode,
               nitf::Uint32 numLUTs,
               nitf::Uint32 bandEntriesPerLUT,
-              nitf::LookupTable& lut) throw(nitf::NITFException);
+              nitf::LookupTable& lut);
 
     /*!
      * Initialize the BandInfo with the given data. This assumes there is no
@@ -112,7 +112,7 @@ public:
     void init(const std::string& representation,
               const std::string& subcategory,
               const std::string& imageFilterCondition,
-              const std::string& imageFilterCode) throw(nitf::NITFException);
+              const std::string& imageFilterCode);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/BandSource.hpp
+++ b/modules/c++/nitf/include/nitf/BandSource.hpp
@@ -68,7 +68,7 @@ public:
      *  \param pixelSkip  The amount of pixels to skip
      */
     MemorySource(const void* data, size_t size, nitf::Off start,
-            int numBytesPerPixel, int pixelSkip) throw (nitf::NITFException);
+            int numBytesPerPixel, int pixelSkip);
 };
 
 /*!
@@ -87,7 +87,7 @@ public:
     FileSource(const std::string& fname,
                nitf::Off start,
                int numBytesPerPixel,
-               int pixelSkip) throw (nitf::NITFException);
+               int pixelSkip);
 
     /*!
      *  Constructor
@@ -99,7 +99,7 @@ public:
     FileSource(nitf::IOHandle& io,
                nitf::Off start,
                int numBytesPerPixel,
-               int pixelSkip) throw (nitf::NITFException);
+               int pixelSkip);
 };
 
 struct RowSourceCallback
@@ -108,15 +108,14 @@ struct RowSourceCallback
     {
     }
 
-    virtual void nextRow(nitf::Uint32 band, void* buf) throw (nitf::NITFException) = 0;
+    virtual void nextRow(nitf::Uint32 band, void* buf) = 0;
 };
 
 class RowSource : public BandSource
 {
 public:
     RowSource(nitf::Uint32 band, nitf::Uint32 numRows, nitf::Uint32 numCols,
-            nitf::Uint32 pixelSize, RowSourceCallback *callback)
-            throw (nitf::NITFException);
+            nitf::Uint32 pixelSize, RowSourceCallback *callback);
 
 private:
     static
@@ -133,14 +132,13 @@ class DirectBlockSource : public BandSource
 {
 public:
     DirectBlockSource(nitf::ImageReader& imageReader,
-                      nitf::Uint32 numBands)
-        throw (nitf::NITFException);
+                      nitf::Uint32 numBands);
 
 protected:
     virtual void nextBlock(void* buf,
                            const void* block,
                            nitf::Uint32 blockNumber,
-                           nitf::Uint64 blockSize) throw (nitf::NITFException) = 0;
+                           nitf::Uint64 blockSize) = 0;
 private:
     static
     NITF_BOOL nextBlock(void *algorithm,
@@ -154,8 +152,7 @@ private:
 class CopyBlockSource: public ::nitf::DirectBlockSource
 {
 public:
-    CopyBlockSource(nitf::ImageReader& imageReader, nitf::Uint32 numBands)
-        throw (::nitf::NITFException) :
+    CopyBlockSource(nitf::ImageReader& imageReader, nitf::Uint32 numBands) :
         nitf::DirectBlockSource(imageReader, numBands)
     {}
 
@@ -165,7 +162,7 @@ protected:
     virtual void nextBlock(void* buf,
                            const void* block,
                            nitf::Uint32 /*blockNumber*/,
-                           nitf::Uint64 blockSize) throw (::nitf::NITFException)
+                           nitf::Uint64 blockSize)
     {
         memcpy(buf, block, blockSize);
     }

--- a/modules/c++/nitf/include/nitf/ComponentInfo.hpp
+++ b/modules/c++/nitf/include/nitf/ComponentInfo.hpp
@@ -62,7 +62,7 @@ public:
     ComponentInfo(nitf_ComponentInfo * x);
 
     //! Clone
-    nitf::ComponentInfo clone() throw(nitf::NITFException);
+    nitf::ComponentInfo clone();
 
     ~ComponentInfo();
 
@@ -78,8 +78,7 @@ protected:
      *  \param subHeaderSize  The size of the subheader
      *  \param dataSize  The size of the data
      */
-    ComponentInfo(nitf::Uint32 subHeaderSize = 0, nitf::Uint64 dataSize = 0)
-        throw(nitf::NITFException);
+    ComponentInfo(nitf::Uint32 subHeaderSize = 0, nitf::Uint64 dataSize = 0);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/DESegment.hpp
+++ b/modules/c++/nitf/include/nitf/DESegment.hpp
@@ -57,14 +57,14 @@ public:
     DESegment(nitf_DESegment * x);
 
     //! Constructor
-    DESegment() throw(nitf::NITFException);
+    DESegment();
 
     DESegment(NITF_DATA * x);
 
     DESegment & operator=(NITF_DATA * x);
 
     //! Clone
-    nitf::DESegment clone() throw(nitf::NITFException);
+    nitf::DESegment clone();
 
     ~DESegment();
 

--- a/modules/c++/nitf/include/nitf/DESubheader.hpp
+++ b/modules/c++/nitf/include/nitf/DESubheader.hpp
@@ -57,10 +57,10 @@ public:
     DESubheader(nitf_DESubheader * x);
 
     //! Constructor
-    DESubheader() throw(nitf::NITFException);
+    DESubheader();
 
     //! Clone
-    nitf::DESubheader clone() throw(nitf::NITFException);
+    nitf::DESubheader clone();
 
     ~DESubheader();
 

--- a/modules/c++/nitf/include/nitf/DataSource.hpp
+++ b/modules/c++/nitf/include/nitf/DataSource.hpp
@@ -83,7 +83,7 @@ public:
      *  \param buf  The buffer
      *  \param size  The size of the buffer
      */
-    void read(void* buf, nitf::Off size) throw (nitf::NITFException);
+    void read(void* buf, nitf::Off size);
 
     /*
      * Returns the size of the DataSource, in bytes

--- a/modules/c++/nitf/include/nitf/DateTime.hpp
+++ b/modules/c++/nitf/include/nitf/DateTime.hpp
@@ -43,17 +43,17 @@ class DateTime
 {
 public:
     //! Sets to current date/time
-    DateTime() throw(nitf::NITFException);
+    DateTime();
 
     //! Set native object - takes ownership
-    DateTime(nitf_DateTime* dateTime) throw(nitf::NITFException);
+    DateTime(nitf_DateTime* dateTime);
 
     /*
      * Construct from a specified date/time
      *
      * \param timeInMillis Number of milliseconds since the epoch (1/1/1970)
      */
-    DateTime(double timeInMillis) throw(nitf::NITFException);
+    DateTime(double timeInMillis);
 
     /*!
      * Construct from a string representation of a date
@@ -70,7 +70,7 @@ public:
      * For example, the NITF 2.1 format is represented as "%Y%m%d%H%M%S"
      */
     DateTime(const std::string& dateString,
-             const std::string& dateFormat) throw(nitf::NITFException);
+             const std::string& dateFormat);
 
     /*!
      * Construct from a specified year, month, and day
@@ -147,7 +147,7 @@ public:
      */
     void format(const std::string& format,
                 char* outBuf,
-                size_t maxSize) const throw(nitf::NITFException);
+                size_t maxSize) const;
 
     /*
      * Produce a string representation of the date/time, formatted as
@@ -157,7 +157,7 @@ public:
      * \param str Output string to store the formatted date/time in
      */
     void format(const std::string& format,
-                std::string &str) const throw(nitf::NITFException);
+                std::string &str) const;
 
     /*
      * Produce a string representation of the date/time, formatted as
@@ -167,8 +167,7 @@ public:
      *
      * \return Formatted date/time
      */
-    std::string format(const std::string& format) const
-        throw(nitf::NITFException);
+    std::string format(const std::string& format) const;
 
     //! Get the year
     int getYear() const;

--- a/modules/c++/nitf/include/nitf/DownSampler.hpp
+++ b/modules/c++/nitf/include/nitf/DownSampler.hpp
@@ -105,7 +105,7 @@ public:
                        nitf::Uint32 pixelType,
                        nitf::Uint32 pixelSize,
                        nitf::Uint32 rowsInLastWindow,
-                       nitf::Uint32 colsInLastWindow) throw (nitf::NITFException);
+                       nitf::Uint32 colsInLastWindow);
 
     nitf::Uint32 getRowSkip();
 
@@ -142,7 +142,7 @@ public:
      *  \param colSkip  The number of columns to skip
      */
     PixelSkip(nitf::Uint32 rowSkip,
-              nitf::Uint32 colSkip) throw (nitf::NITFException);
+              nitf::Uint32 colSkip);
 
     //! Destructor
     ~PixelSkip();
@@ -172,7 +172,7 @@ public:
      *  \param colSkip  The number of columns to skip
      */
     MaxDownSample(nitf::Uint32 rowSkip,
-                  nitf::Uint32 colSkip) throw (nitf::NITFException);
+                  nitf::Uint32 colSkip);
     //! Destructor
     ~MaxDownSample();
 };
@@ -198,7 +198,7 @@ public:
      *  \param colSkip  The number of cols to skip
      */
     SumSq2DownSample(nitf::Uint32 rowSkip,
-                     nitf::Uint32 colSkip) throw (nitf::NITFException);
+                     nitf::Uint32 colSkip);
     //! Destructor
     ~SumSq2DownSample();
 };
@@ -223,7 +223,7 @@ public:
      *  \param colSkip  The number of cols to skip
      */
     Select2DownSample(nitf::Uint32 rowSkip,
-                      nitf::Uint32 colSkip) throw (nitf::NITFException);
+                      nitf::Uint32 colSkip);
     //! Destructor
     ~Select2DownSample();
 };

--- a/modules/c++/nitf/include/nitf/Extensions.hpp
+++ b/modules/c++/nitf/include/nitf/Extensions.hpp
@@ -199,7 +199,7 @@ typedef nitf::ExtensionsIterator Iterator;
     }
 
     //! Constructor
-    Extensions() throw(nitf::NITFException)
+    Extensions()
     {
         setNative(nitf_Extensions_construct(&error));
         getNativeOrThrow();
@@ -207,7 +207,7 @@ typedef nitf::ExtensionsIterator Iterator;
     }
 
     //! Clone
-    nitf::Extensions clone() throw(nitf::NITFException)
+    nitf::Extensions clone()
     {
         nitf::Extensions dolly(nitf_Extensions_clone(getNativeOrThrow(), &error));
         dolly.setManaged(false);
@@ -221,7 +221,7 @@ typedef nitf::ExtensionsIterator Iterator;
      *  \param name  The name of the TRE
      *  \param tre  The TRE itself
      */
-    void appendTRE(nitf::TRE & tre) throw(nitf::NITFException)
+    void appendTRE(nitf::TRE & tre)
     {
         //if the TRE is already managed, we throw an Exception
         if (tre.isManaged())
@@ -239,7 +239,7 @@ typedef nitf::ExtensionsIterator Iterator;
      *  \param  The name of the TRE to get
      *  \return  A List of TREs matching the specified name
      */
-    nitf::List getTREsByName(const std::string& name) throw(except::NoSuchKeyException)
+    nitf::List getTREsByName(const std::string& name)
     {
         nitf_List* x = nitf_Extensions_getTREsByName(getNative(), name.c_str());
         if (!x)

--- a/modules/c++/nitf/include/nitf/Field.hpp
+++ b/modules/c++/nitf/include/nitf/Field.hpp
@@ -90,7 +90,7 @@ enum FieldType
         BINARY = NITF_BINARY
     };
 
-    Field & operator=(const char * value) throw(nitf::NITFException)
+    Field & operator=(const char * value)
     {
         set(value);
         return *this;
@@ -213,14 +213,14 @@ enum FieldType
             throw nitf::NITFException(&error);
     }
 
-    void set(nitf::Uint32 data) throw(nitf::NITFException)
+    void set(nitf::Uint32 data)
     {
         NITF_BOOL x = nitf_Field_setUint32(getNativeOrThrow(), data, &error);
         if (!x)
             throw nitf::NITFException(&error);
     }
 
-    void set(nitf::Uint64 data) throw(nitf::NITFException)
+    void set(nitf::Uint64 data)
     {
         NITF_BOOL x = nitf_Field_setUint64(getNativeOrThrow(), data, &error);
         if (!x)
@@ -269,14 +269,14 @@ enum FieldType
             throw nitf::NITFException(&error);
     }
 
-    void set(const char * data) throw(nitf::NITFException)
+    void set(const char * data)
     {
         NITF_BOOL x = nitf_Field_setString(getNativeOrThrow(), (char*)data, &error);
         if (!x)
             throw nitf::NITFException(&error);
     }
 
-    void set(const std::string& data) throw(nitf::NITFException)
+    void set(const std::string& data)
     {
         const NITF_BOOL x =
                 nitf_Field_setString(getNativeOrThrow(), data.c_str(), &error);
@@ -285,7 +285,7 @@ enum FieldType
     }
 
     void set(const nitf::DateTime& dateTime,
-             const std::string& format = NITF_DATE_FORMAT_21) throw(nitf::NITFException)
+             const std::string& format = NITF_DATE_FORMAT_21)
     {
         const NITF_BOOL x = nitf_Field_setDateTime(getNativeOrThrow(),
                 dateTime.getNative(), format.c_str(), &error);
@@ -293,7 +293,7 @@ enum FieldType
             throw nitf::NITFException(&error);
     }
 
-    nitf::DateTime asDateTime(const std::string& format = NITF_DATE_FORMAT_21) throw(nitf::NITFException)
+    nitf::DateTime asDateTime(const std::string& format = NITF_DATE_FORMAT_21)
     {
         nitf_DateTime* const dateTime =
                 nitf_Field_asDateTime(getNativeOrThrow(), format.c_str(),
@@ -323,7 +323,7 @@ enum FieldType
         return getNativeOrThrow()->raw;
     }
     //! Set the data
-    void setRawData(char * raw, size_t length) throw(nitf::NITFException)
+    void setRawData(char * raw, size_t length)
     {
         set(raw, length);
     }
@@ -387,7 +387,7 @@ private:
     }
 
     //! set the value
-    void set(NITF_DATA* inval, size_t length) throw(nitf::NITFException)
+    void set(NITF_DATA* inval, size_t length)
     {
         NITF_BOOL x = nitf_Field_setRawData(getNativeOrThrow(), inval, length, &error);
         if (!x)

--- a/modules/c++/nitf/include/nitf/FieldWarning.hpp
+++ b/modules/c++/nitf/include/nitf/FieldWarning.hpp
@@ -77,7 +77,6 @@ public:
      */
     FieldWarning(nitf::Off fileOffset, const std::string& fieldName,
         nitf::Field & field, const std::string& expectation)
-            throw(nitf::NITFException)
     {
         setNative(nitf_FieldWarning_construct(fileOffset, fieldName.c_str(),
             field.getNative(), expectation.c_str(), &error));

--- a/modules/c++/nitf/include/nitf/FileHeader.hpp
+++ b/modules/c++/nitf/include/nitf/FileHeader.hpp
@@ -61,10 +61,10 @@ public:
     FileHeader(nitf_FileHeader * x);
 
     //! Constructor
-    FileHeader() throw(nitf::NITFException);
+    FileHeader();
 
     //! Clone
-    nitf::FileHeader clone() throw(nitf::NITFException);
+    nitf::FileHeader clone();
 
     ~FileHeader();
 
@@ -141,28 +141,22 @@ public:
     nitf::Field getNumReservedExtensions();
 
     //! Get the imageInfo
-    nitf::ComponentInfo getImageInfo(int i)
-        throw(except::IndexOutOfRangeException);
+    nitf::ComponentInfo getImageInfo(int i);
 
     //! Get the graphicInfo
-    nitf::ComponentInfo getGraphicInfo(int i)
-        throw(except::IndexOutOfRangeException);
+    nitf::ComponentInfo getGraphicInfo(int i);
 
     //! Get the labelInfo
-    nitf::ComponentInfo getLabelInfo(int i)
-        throw(except::IndexOutOfRangeException);
+    nitf::ComponentInfo getLabelInfo(int i);
 
     //! Get the textInfo
-    nitf::ComponentInfo getTextInfo(int i)
-        throw(except::IndexOutOfRangeException);
+    nitf::ComponentInfo getTextInfo(int i);
 
     //! Get the dataExtensionInfo
-    nitf::ComponentInfo getDataExtensionInfo(int i)
-        throw(except::IndexOutOfRangeException);
+    nitf::ComponentInfo getDataExtensionInfo(int i);
 
     //! Get the reservedExtensionInfo
-    nitf::ComponentInfo getReservedExtensionInfo(int i)
-        throw(except::IndexOutOfRangeException);
+    nitf::ComponentInfo getReservedExtensionInfo(int i);
 
     //! Get the userDefinedHeaderLength
     nitf::Field getUserDefinedHeaderLength();

--- a/modules/c++/nitf/include/nitf/FileSecurity.hpp
+++ b/modules/c++/nitf/include/nitf/FileSecurity.hpp
@@ -57,10 +57,10 @@ public:
     FileSecurity(nitf_FileSecurity * x);
 
     //! Constructor
-    FileSecurity() throw(nitf::NITFException);
+    FileSecurity();
 
     //! Clone
-    nitf::FileSecurity clone() throw(nitf::NITFException);
+    nitf::FileSecurity clone();
 
     ~FileSecurity();
 

--- a/modules/c++/nitf/include/nitf/GraphicSegment.hpp
+++ b/modules/c++/nitf/include/nitf/GraphicSegment.hpp
@@ -55,14 +55,14 @@ public:
     GraphicSegment(nitf_GraphicSegment * x);
 
     //! Constructor
-    GraphicSegment() throw(nitf::NITFException);
+    GraphicSegment();
 
     GraphicSegment(NITF_DATA * x);
 
     GraphicSegment & operator=(NITF_DATA * x);
 
     //! Clone
-    nitf::GraphicSegment clone() throw(nitf::NITFException);
+    nitf::GraphicSegment clone();
 
     ~GraphicSegment();
 

--- a/modules/c++/nitf/include/nitf/GraphicSubheader.hpp
+++ b/modules/c++/nitf/include/nitf/GraphicSubheader.hpp
@@ -55,10 +55,10 @@ public:
     GraphicSubheader(nitf_GraphicSubheader * x);
 
     //! Default Constructor
-    GraphicSubheader() throw(nitf::NITFException);
+    GraphicSubheader();
 
     //! Clone
-    nitf::GraphicSubheader clone() throw(nitf::NITFException);
+    nitf::GraphicSubheader clone();
 
     ~GraphicSubheader();
 

--- a/modules/c++/nitf/include/nitf/HashTable.hpp
+++ b/modules/c++/nitf/include/nitf/HashTable.hpp
@@ -141,11 +141,10 @@ public:
      *  Constructor
      *  \param nbuckets  The size of the hash
      */
-    HashTable(int nbuckets = 5) throw(nitf::NITFException);
+    HashTable(int nbuckets = 5);
 
     //! Clone
-    nitf::HashTable clone(NITF_DATA_ITEM_CLONE cloner)
-        throw(nitf::NITFException);
+    nitf::HashTable clone(NITF_DATA_ITEM_CLONE cloner);
 
     /*!
      *  This function controls ownership.  You may elect either
@@ -192,23 +191,20 @@ public:
      *  For each item in the hash table, do something (slow);
      *  \param fn  The function to perform
      */
-    void forEach(HashIterator& fun, NITF_DATA* userData = NULL)
-        throw(nitf::NITFException);
+    void forEach(HashIterator& fun, NITF_DATA* userData = NULL);
 
     /*!
      *  Insert this key/data pair into the hash table
      *  \param key  The key to insert under
      *  \param data  The data to insert into the second value of the pair
      */
-    void insert(const std::string& key, NITF_DATA* data)
-        throw(nitf::NITFException);
+    void insert(const std::string& key, NITF_DATA* data);
 
     /*!
      * Templated insert, allowing us to insert nitf::Objects
      */
     template <typename T>
     void insert(const std::string& key, nitf::Object<T> object)
-        throw(nitf::NITFException)
     {
         insert(key, (NITF_DATA*)object.getNative());
     }
@@ -218,12 +214,12 @@ public:
      *  \param key  The key to retrieve by
      *  \return  The key/value pair
      */
-    nitf::Pair find(const std::string& key) throw(except::NoSuchKeyException);
+    nitf::Pair find(const std::string& key);
 
-    nitf::Pair operator[] (const std::string& key) throw(except::NoSuchKeyException);
+    nitf::Pair operator[] (const std::string& key);
 
     //! Get the buckets
-    nitf::List getBucket(int i) throw(nitf::NITFException);
+    nitf::List getBucket(int i);
 
     //! Get the nbuckets
     int getNumBuckets() const;

--- a/modules/c++/nitf/include/nitf/IOHandle.hpp
+++ b/modules/c++/nitf/include/nitf/IOHandle.hpp
@@ -48,20 +48,18 @@ public:
 
     IOHandle(const std::string& fname,
              nitf::AccessFlags access = NITF_ACCESS_READONLY,
-             nitf::CreationFlags creation = NITF_OPEN_EXISTING)
-                 throw (nitf::NITFException);
+             nitf::CreationFlags creation = NITF_OPEN_EXISTING);
 
     IOHandle(const char* fname,
              nitf::AccessFlags access = NITF_ACCESS_READONLY,
-             nitf::CreationFlags creation = NITF_OPEN_EXISTING)
-                 throw (nitf::NITFException);
+             nitf::CreationFlags creation = NITF_OPEN_EXISTING);
 
 private:
     static
     nitf_IOInterface*
     open(const char* fname,
          nitf::AccessFlags access,
-         nitf::CreationFlags creation) throw (nitf::NITFException);
+         nitf::CreationFlags creation);
 
 };
 

--- a/modules/c++/nitf/include/nitf/ImageReader.hpp
+++ b/modules/c++/nitf/include/nitf/ImageReader.hpp
@@ -55,7 +55,7 @@ public:
     ~ImageReader();
 
     //! Get the blocking info
-    nitf::BlockingInfo getBlockingInfo() throw (nitf::NITFException);
+    nitf::BlockingInfo getBlockingInfo();
 
     /*!
      *  Read a sub-window.  See ImageIO::read for more details.
@@ -63,8 +63,7 @@ public:
      *  \param  user  User-defined data buffers for read
      *  \param  padded  Returns TRUE if pad pixels may have been read
      */
-    void read(nitf::SubWindow & subWindow, nitf::Uint8 ** user, int * padded)
-        throw (nitf::NITFException);
+    void read(nitf::SubWindow & subWindow, nitf::Uint8 ** user, int * padded);
 
     /*!
      *  Read a block directly from file
@@ -74,15 +73,14 @@ public:
      *          (something must be done with buffer before next call)
      */
     const nitf::Uint8* readBlock(nitf::Uint32 blockNumber, 
-                                 nitf::Uint64* blockSize) 
-                                 throw (nitf::NITFException);
+                                 nitf::Uint64* blockSize);
 
     //!  Set read caching
     void setReadCaching();
 
 private:
     nitf_Error error;
-    ImageReader() throw(nitf::NITFException){}
+    ImageReader(){}
 };
 
 }

--- a/modules/c++/nitf/include/nitf/ImageSegment.hpp
+++ b/modules/c++/nitf/include/nitf/ImageSegment.hpp
@@ -55,14 +55,14 @@ public:
     ImageSegment(nitf_ImageSegment * x);
 
     //! Constructor
-    ImageSegment() throw(nitf::NITFException);
+    ImageSegment();
 
     ImageSegment(NITF_DATA * x);
 
     ImageSegment & operator=(NITF_DATA * x);
 
      //! Clone
-    nitf::ImageSegment clone() throw(nitf::NITFException);
+    nitf::ImageSegment clone();
 
     ~ImageSegment();
 

--- a/modules/c++/nitf/include/nitf/ImageSource.hpp
+++ b/modules/c++/nitf/include/nitf/ImageSource.hpp
@@ -57,15 +57,15 @@ public:
     /*!
      *  Constructor
      */
-    ImageSource() throw(nitf::NITFException);
+    ImageSource();
 
     ~ImageSource();
 
     //! Add a band
-    void addBand(nitf::BandSource bandSource) throw(nitf::NITFException);
+    void addBand(nitf::BandSource bandSource);
 
     //! Get a band
-    nitf::BandSource getBand(int n) throw (nitf::NITFException);
+    nitf::BandSource getBand(int n);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/ImageSubheader.hpp
+++ b/modules/c++/nitf/include/nitf/ImageSubheader.hpp
@@ -59,11 +59,11 @@ public:
     ImageSubheader(nitf_ImageSubheader * x);
 
     //! Constructor
-    ImageSubheader() throw(nitf::NITFException);
+    ImageSubheader();
 
 
     //! Clone
-    nitf::ImageSubheader clone() throw(nitf::NITFException);
+    nitf::ImageSubheader clone();
 
     /*!
      *  Destructor
@@ -86,8 +86,7 @@ public:
                              nitf::Uint32 abpp,
                              std::string justification,
                              std::string irep, std::string icat,
-                             std::vector<nitf::BandInfo>& bands)
-        throw(nitf::NITFException);
+                             std::vector<nitf::BandInfo>& bands);
 
     /*!
      *  This function allows the user to set the corner coordinates from a
@@ -109,8 +108,7 @@ public:
      *  following in line with 2500C.
      */
     void setCornersFromLatLons(nitf::CornersType type,
-                               double corners[4][2])
-        throw(nitf::NITFException);
+                               double corners[4][2]);
 
 
     /*!
@@ -128,14 +126,14 @@ public:
      *
      *  following in line with 2500C.
      */
-    void getCornersAsLatLons(double corners[4][2]) throw(nitf::NITFException);
+    void getCornersAsLatLons(double corners[4][2]);
 
     /*!
      *  Get the type of corners.  This will return NITF_CORNERS_UNKNOWN
      *  in the event that it is not 'U', 'N', 'S', 'D', or 'G'.
      *
      */
-    nitf::CornersType getCornersType() throw(nitf::NITFException);
+    nitf::CornersType getCornersType();
 
     /*!
      * Set the image dimensions and blocking info.
@@ -155,7 +153,7 @@ public:
                      nitf::Uint32 numCols,
                      nitf::Uint32 numRowsPerBlock,
                      nitf::Uint32 numColsPerBlock,
-                     const std::string& imode) throw(nitf::NITFException);
+                     const std::string& imode);
 
     /*!
      * Compute blocking parameters
@@ -198,15 +196,13 @@ public:
      * \param numRows           The number of rows
      * \param numCols           The number of columns
      */
-    void setDimensions(nitf::Uint32 numRows, nitf::Uint32 numCols)
-        throw(nitf::NITFException);
-
+    void setDimensions(nitf::Uint32 numRows, nitf::Uint32 numCols);
 
     //! Get the number of bands
-    nitf::Uint32 getBandCount() throw(nitf::NITFException);
+    nitf::Uint32 getBandCount();
 
     //! Create new bands
-    void createBands(nitf::Uint32 numBands) throw(nitf::NITFException);
+    void createBands(nitf::Uint32 numBands);
 
     //! Insert the given comment at the given index (zero-indexed);
     int insertImageComment(std::string comment, int index);
@@ -290,7 +286,7 @@ public:
     nitf::Field getNumMultispectralImageBands();
 
     //! Get the bandInfo
-    nitf::BandInfo getBandInfo(nitf::Uint32 band) throw(nitf::NITFException);
+    nitf::BandInfo getBandInfo(nitf::Uint32 band);
 
     //! Get the imageSyncCode
     nitf::Field getImageSyncCode();

--- a/modules/c++/nitf/include/nitf/ImageWriter.hpp
+++ b/modules/c++/nitf/include/nitf/ImageWriter.hpp
@@ -49,7 +49,7 @@ public:
      *  Constructor
      *  \param subheader    The subheader of the Image to write
      */
-    ImageWriter(nitf::ImageSubheader& subheader) throw(nitf::NITFException);
+    ImageWriter(nitf::ImageSubheader& subheader);
 
     // Set native object
     ImageWriter(nitf_ImageWriter *x) : WriteHandler(x)
@@ -62,8 +62,7 @@ public:
      *  Attach an image source from which to write.
      *  \param imageSource  The image source from which to write
      */
-    void attachSource(nitf::ImageSource imageSource)
-            throw (nitf::NITFException);
+    void attachSource(nitf::ImageSource imageSource);
 
     //! Enable/disable cached writes
     void setWriteCaching(int enable);

--- a/modules/c++/nitf/include/nitf/LabelSegment.hpp
+++ b/modules/c++/nitf/include/nitf/LabelSegment.hpp
@@ -53,14 +53,14 @@ public:
     LabelSegment(nitf_LabelSegment * x);
 
     //! Constructor
-    LabelSegment() throw(nitf::NITFException);
+    LabelSegment();
 
     LabelSegment(NITF_DATA * x);
 
     LabelSegment & operator=(NITF_DATA * x);
 
     //! Clone
-    nitf::LabelSegment clone() throw(nitf::NITFException);
+    nitf::LabelSegment clone();
 
     ~LabelSegment();
 

--- a/modules/c++/nitf/include/nitf/LabelSubheader.hpp
+++ b/modules/c++/nitf/include/nitf/LabelSubheader.hpp
@@ -56,10 +56,10 @@ public:
     LabelSubheader(nitf_LabelSubheader * x);
 
     //! Default Constructor
-    LabelSubheader() throw(nitf::NITFException);
+    LabelSubheader();
 
     //! Clone
-    nitf::LabelSubheader clone() throw(nitf::NITFException);
+    nitf::LabelSubheader clone();
 
     ~LabelSubheader();
 

--- a/modules/c++/nitf/include/nitf/List.hpp
+++ b/modules/c++/nitf/include/nitf/List.hpp
@@ -64,8 +64,7 @@ public:
      *  \param next  The next node
      *  \param data  The data to insert into the list
      */
-    ListNode(nitf::ListNode & prev, nitf::ListNode & next, NITF_DATA* data)
-        throw(nitf::NITFException);
+    ListNode(nitf::ListNode & prev, nitf::ListNode & next, NITF_DATA* data);
 
     //! Destructor
     ~ListNode() {}
@@ -194,10 +193,10 @@ public:
      *  need a copy, make one up front.
      *  \param data  The data to push to the front
      */
-    void pushFront(NITF_DATA* data) throw(nitf::NITFException);
+    void pushFront(NITF_DATA* data);
 
     template <typename  T>
-    void pushFront(nitf::Object<T> object) throw(nitf::NITFException)
+    void pushFront(nitf::Object<T> object)
     {
         pushFront((NITF_DATA*)object.getNativeOrThrow());
     }
@@ -206,10 +205,10 @@ public:
      *  Push something onto the back of our chain
      *  \param data  The data to push onto the back
      */
-    void pushBack(NITF_DATA* data) throw(nitf::NITFException);
+    void pushBack(NITF_DATA* data);
 
     template <typename  T>
-    void pushBack(T object) throw(nitf::NITFException)
+    void pushBack(T object)
     {
         pushBack((NITF_DATA*)object.getNativeOrThrow());
     }
@@ -231,10 +230,10 @@ public:
     NITF_DATA* popBack();
 
     //! Constructor
-    List() throw(nitf::NITFException);
+    List();
 
     //! Clone
-    nitf::List clone(NITF_DATA_ITEM_CLONE cloner) throw(nitf::NITFException);
+    nitf::List clone(NITF_DATA_ITEM_CLONE cloner);
 
     //! Destructor
     ~List();
@@ -265,10 +264,10 @@ public:
      *  \param iter  The iterator to insert before
      *  \param data  This is a pointer assignment, not a data copy
      */
-    void insert(nitf::ListIterator & iter, NITF_DATA* data) throw(nitf::NITFException);
+    void insert(nitf::ListIterator & iter, NITF_DATA* data);
 
     template <typename T>
-    void insert(nitf::ListIterator & iter, nitf::Object<T> object) throw(nitf::NITFException)
+    void insert(nitf::ListIterator & iter, nitf::Object<T> object)
     {
         insert(iter, (NITF_DATA*)object.getNativeOrThrow());
     }
@@ -294,7 +293,7 @@ public:
     size_t getSize();
 
     //! Returns the data at the given index
-    NITF_DATA* operator[] (size_t index) throw(nitf::NITFException);
+    NITF_DATA* operator[] (size_t index);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/MemoryIO.hpp
+++ b/modules/c++/nitf/include/nitf/MemoryIO.hpp
@@ -42,19 +42,18 @@ namespace nitf
 class MemoryIO : public IOInterface
 {
 public:
-    MemoryIO(size_t capacity) throw(nitf::NITFException);
+    MemoryIO(size_t capacity);
 
     // If adopt is true, the memory will be deallocated via NRT_FREE(), so it
     // must be allocated via NRT_MALLOC() (not new[]).  If adopt is false, the
     // allocation method does not matter.
-    MemoryIO(void* buffer, size_t size, bool adopt = false)
-            throw(nitf::NITFException);
+    MemoryIO(void* buffer, size_t size, bool adopt = false);
 
 private:
     static
     nitf_IOInterface* create(void* buffer,
                              size_t size,
-                             bool adopt) throw(nitf::NITFException);
+                             bool adopt);
 };
 
 }

--- a/modules/c++/nitf/include/nitf/Object.hpp
+++ b/modules/c++/nitf/include/nitf/Object.hpp
@@ -101,7 +101,7 @@ public:
     }
 
     //! Get native object
-    virtual T * getNativeOrThrow() const throw(nitf::NITFException)
+    virtual T * getNativeOrThrow() const
     {
         T* val = getNative();
         if (val)

--- a/modules/c++/nitf/include/nitf/PluginRegistry.hpp
+++ b/modules/c++/nitf/include/nitf/PluginRegistry.hpp
@@ -47,36 +47,33 @@ public:
      * Load plugins from the given directory
      * \param dirName  The name of the directory to load
      */
-    static void loadDir(const std::string& dirName) throw(nitf::NITFException);
+    static void loadDir(const std::string& dirName);
 
-    static void loadPlugin(const std::string& path) throw(nitf::NITFException);
+    static void loadPlugin(const std::string& path);
 
     /*!
      *  This function allows you to register your own TRE handlers.  It
      *  will override any handlers that are currently handling the identifier.
      */
     static void registerTREHandler(NITF_PLUGIN_INIT_FUNCTION init,
-            NITF_PLUGIN_TRE_HANDLER_FUNCTION handler)
-            throw(nitf::NITFException);
+            NITF_PLUGIN_TRE_HANDLER_FUNCTION handler);
 
     /*!
      *  This function allows you to register your own compression handlers.  It
      *  will override any handlers that are currently handling the identifier.
      */
     static void registerCompressionHandler(NITF_PLUGIN_INIT_FUNCTION init,
-            NITF_PLUGIN_COMPRESSION_CONSTRUCT_FUNCTION handler)
-            throw(nitf::NITFException);
+            NITF_PLUGIN_COMPRESSION_CONSTRUCT_FUNCTION handler);
 
     /*!
      *  This function allows you to register your own decompression handlers.  It
      *  will override any handlers that are currently handling the identifier.
      */
     static void registerDecompressionHandler(NITF_PLUGIN_INIT_FUNCTION init,
-            NITF_PLUGIN_DECOMPRESSION_CONSTRUCT_FUNCTION handler)
-            throw(nitf::NITFException);
+            NITF_PLUGIN_DECOMPRESSION_CONSTRUCT_FUNCTION handler);
 
     static nitf_CompressionInterface* retrieveCompressionInterface(
-            const std::string& comp) throw(nitf::NITFException);
+            const std::string& comp);
 
     /*!
      * Checks if a TRE handler exists for 'ident'

--- a/modules/c++/nitf/include/nitf/RESegment.hpp
+++ b/modules/c++/nitf/include/nitf/RESegment.hpp
@@ -53,14 +53,14 @@ public:
     RESegment(nitf_RESegment * x);
 
     //! Default Constructor
-    RESegment() throw(nitf::NITFException);
+    RESegment();
 
     RESegment(NITF_DATA * x);
 
     RESegment & operator=(NITF_DATA * x);
 
     //! Clone
-    nitf::RESegment clone() throw(nitf::NITFException);
+    nitf::RESegment clone();
 
     ~RESegment();
 

--- a/modules/c++/nitf/include/nitf/RESubheader.hpp
+++ b/modules/c++/nitf/include/nitf/RESubheader.hpp
@@ -56,10 +56,10 @@ public:
     RESubheader(nitf_RESubheader * x);
 
      //! Constructor
-    RESubheader() throw(nitf::NITFException);
+    RESubheader();
 
     //! Clone
-    nitf::RESubheader clone() throw(nitf::NITFException);
+    nitf::RESubheader clone();
 
     ~RESubheader();
 

--- a/modules/c++/nitf/include/nitf/Reader.hpp
+++ b/modules/c++/nitf/include/nitf/Reader.hpp
@@ -65,7 +65,7 @@ public:
     Reader(nitf_Reader * x);
 
     //! Default Constructor
-    Reader() throw(nitf::NITFException);
+    Reader();
 
     ~Reader();
 
@@ -81,22 +81,21 @@ public:
      *  \param io  The IO handle
      *  \return  A Record containing the read information
      */
-    nitf::Record read(nitf::IOHandle & io) throw (nitf::NITFException);
+    nitf::Record read(nitf::IOHandle & io);
 
     /*!
      *  This is the preferred method for reading a NITF 2.1 file.
      *  \param io  The IO handle
      *  \return  A Record containing the read information
      */
-    nitf::Record readIO(nitf::IOInterface & io) throw (nitf::NITFException);
+    nitf::Record readIO(nitf::IOInterface & io);
 
     /*!
      *  Get a new image reader for the segment
      *  \param imageSegmentNumber  The image segment number
      *  \return  An ImageReader matching the imageSegmentNumber
      */
-    nitf::ImageReader newImageReader(int imageSegmentNumber)
-        throw (nitf::NITFException);
+    nitf::ImageReader newImageReader(int imageSegmentNumber);
     
     /*!
      *  Get a new image reader for the segment
@@ -105,32 +104,28 @@ public:
      *  \return  An ImageReader matching the imageSegmentNumber
      */
     nitf::ImageReader newImageReader(int imageSegmentNumber,
-                                     const std::map<std::string, void*>& options)
-        throw (nitf::NITFException);
+                                     const std::map<std::string, void*>& options);
 
     /*!
      *  Get a new DE reader for the segment
      *  \param deSegmentNumber  The DE segment number
      *  \return  A SegmentReader matching the deSegmentNumber
      */
-    nitf::SegmentReader newDEReader(int deSegmentNumber)
-        throw (nitf::NITFException);
+    nitf::SegmentReader newDEReader(int deSegmentNumber);
 
     /*!
      *  Get a new SegmentReader for the Graphic segment
      *  \param segmentNumber the segment Number
      *  \return  A SegmentReader matching the segmentNumber
      */
-    nitf::SegmentReader newGraphicReader(int segmentNumber)
-        throw (nitf::NITFException);
+    nitf::SegmentReader newGraphicReader(int segmentNumber);
 
     /*!
      *  Get a new SegmentReader for the Text segment
      *  \param segmentNumber the segment Number
      *  \return  A SegmentReader matching the segmentNumber
      */
-    nitf::SegmentReader newTextReader(int segmentNumber)
-        throw (nitf::NITFException);
+    nitf::SegmentReader newTextReader(int segmentNumber);
 
     //! Get the warningList
     nitf::List getWarningList() const;

--- a/modules/c++/nitf/include/nitf/Record.hpp
+++ b/modules/c++/nitf/include/nitf/Record.hpp
@@ -66,10 +66,10 @@ public:
     Record(nitf_Record * x);
 
     //! Default Constructor
-    Record(nitf::Version version = NITF_VER_21) throw(nitf::NITFException);
+    Record(nitf::Version version = NITF_VER_21);
 
     //! Clone
-    nitf::Record clone() const throw(nitf::NITFException);
+    nitf::Record clone() const;
 
     ~Record();
 

--- a/modules/c++/nitf/include/nitf/SegmentReader.hpp
+++ b/modules/c++/nitf/include/nitf/SegmentReader.hpp
@@ -67,7 +67,7 @@ public:
      * \param buffer    buffer to hold data
      * \param count     amount of data to return
      */
-    void read(NITF_DATA *buffer, size_t count) throw (nitf::NITFException);
+    void read(NITF_DATA *buffer, size_t count);
 
     /*!
      * \brief seek - Seek in segment data
@@ -82,7 +82,7 @@ public:
      * \param whence    starting at (SEEK_SET, SEEK_CUR, SEEK_END)
      * \return The offset from the beginning to the current position is set.
      */
-    nitf::Off seek(nitf::Off offset, int whence) throw (nitf::NITFException);
+    nitf::Off seek(nitf::Off offset, int whence);
 
     /*!
      * \brief tell - Tell location in segment data

--- a/modules/c++/nitf/include/nitf/SegmentSource.hpp
+++ b/modules/c++/nitf/include/nitf/SegmentSource.hpp
@@ -68,7 +68,7 @@ public:
      *  false, the data must outlive the memory source.
      */
     SegmentMemorySource(const char* data, size_t size, nitf::Off start,
-                        int byteSkip, bool copyData) throw (nitf::NITFException);
+                        int byteSkip, bool copyData);
 };
 
 /*!
@@ -88,8 +88,7 @@ public:
      *  \param start    The location to seek to (as the beginning)
      *  \param byteSkip The number of bytes to skip
      */
-    SegmentFileSource(nitf::IOHandle & io, nitf::Off start, int byteSkip)
-            throw (nitf::NITFException);
+    SegmentFileSource(nitf::IOHandle & io, nitf::Off start, int byteSkip);
 
     ~SegmentFileSource()
     {
@@ -105,7 +104,7 @@ public:
      *  \param start    The location to seek to (as the beginning)
      *  \param byteSkip The number of bytes to skip
      */
-    SegmentReaderSource(nitf::SegmentReader reader) throw (nitf::NITFException);
+    SegmentReaderSource(nitf::SegmentReader reader);
 
     ~SegmentReaderSource()
     {

--- a/modules/c++/nitf/include/nitf/SegmentWriter.hpp
+++ b/modules/c++/nitf/include/nitf/SegmentWriter.hpp
@@ -43,10 +43,9 @@ namespace nitf
 class SegmentWriter : public WriteHandler
 {
 public:
-    SegmentWriter() throw (nitf::NITFException);
+    SegmentWriter();
 
-    SegmentWriter(nitf::SegmentSource segmentSource)
-            throw (nitf::NITFException);
+    SegmentWriter(nitf::SegmentSource segmentSource);
 
     // Set native object
     SegmentWriter(nitf_SegmentWriter *x) : WriteHandler(x)
@@ -59,8 +58,7 @@ public:
      *  Attach a segment source from which to write.
      *  \param segmentSource  The segment source from which to write
      */
-    void attachSource(nitf::SegmentSource segmentSource)
-            throw (nitf::NITFException);
+    void attachSource(nitf::SegmentSource segmentSource);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/SubWindow.hpp
+++ b/modules/c++/nitf/include/nitf/SubWindow.hpp
@@ -68,7 +68,7 @@ public:
     SubWindow(nitf_SubWindow * x);
 
     //! Constructor
-    SubWindow() throw(nitf::NITFException);
+    SubWindow();
 
     //! Destructor
     ~SubWindow();
@@ -92,14 +92,13 @@ public:
      * The SubWindow does NOT own the DownSampler
      * \param downSampler  The down sampler to reference
      */
-    void setDownSampler(nitf::DownSampler* downSampler)
-        throw (nitf::NITFException);
+    void setDownSampler(nitf::DownSampler* downSampler);
 
     /*!
      * Return the DownSampler that is referenced by this SubWindow.
      * If no DownSampler is referenced, a NITFException is thrown.
      */
-    nitf::DownSampler* getDownSampler() throw (nitf::NITFException);
+    nitf::DownSampler* getDownSampler();
 
 private:
     nitf::DownSampler* mDownSampler;

--- a/modules/c++/nitf/include/nitf/TRE.hpp
+++ b/modules/c++/nitf/include/nitf/TRE.hpp
@@ -189,17 +189,16 @@ typedef nitf::TREFieldIterator Iterator;
     //! Without the const char* constructors, in VS if you do something like
     //  TRE("my_tre_tag")
     //  You get the NITF_DATA* constructor rather than the std::string one
-    TRE(const char* tag) throw(nitf::NITFException);
+    TRE(const char* tag);
 
-    TRE(const char* tag, const char* id) throw(nitf::NITFException);
+    TRE(const char* tag, const char* id);
 
-    TRE(const std::string& tag) throw(nitf::NITFException);
+    TRE(const std::string& tag);
 
-    TRE(const std::string& tag, const std::string& id)
-        throw(nitf::NITFException);
+    TRE(const std::string& tag, const std::string& id);
 
     //! Clone
-    nitf::TRE clone() throw(nitf::NITFException);
+    nitf::TRE clone();
 
     ~TRE();
 
@@ -213,17 +212,15 @@ typedef nitf::TREFieldIterator Iterator;
      *  Get an end TRE field iterator
      *  \return  A field iterator pointing PAST the last field in the TRE
      */
-    Iterator end() throw (nitf::NITFException);
+    Iterator end();
 
     /*!
      * Get the field specified by the key. Throws an exception if the field
      * does not exist.
      */
-    nitf::Field getField(const std::string& key)
-        throw(except::NoSuchKeyException);
+    nitf::Field getField(const std::string& key);
 
-    nitf::Field operator[] (const std::string& key)
-        throw(except::NoSuchKeyException);
+    nitf::Field operator[] (const std::string& key);
 
     /*!
      * Returns a List of Fields that match the given pattern.
@@ -242,8 +239,7 @@ typedef nitf::TREFieldIterator Iterator;
 	                            key.c_str(),
 	                            (NITF_DATA*)s.c_str(),
 	                            s.size(),
-	                            &error) )
-	        throw nitf::NITFException(&error);
+	                            &error) );
     }
 
     /*!

--- a/modules/c++/nitf/include/nitf/TextSegment.hpp
+++ b/modules/c++/nitf/include/nitf/TextSegment.hpp
@@ -55,14 +55,14 @@ public:
     TextSegment(nitf_TextSegment * x);
 
     //! Constructor
-    TextSegment() throw(nitf::NITFException);
+    TextSegment();
 
     TextSegment(NITF_DATA * x);
 
     TextSegment & operator=(NITF_DATA * x);
 
     //! Clone
-    nitf::TextSegment clone() throw(nitf::NITFException);
+    nitf::TextSegment clone();
 
     ~TextSegment();
 

--- a/modules/c++/nitf/include/nitf/TextSubheader.hpp
+++ b/modules/c++/nitf/include/nitf/TextSubheader.hpp
@@ -56,10 +56,10 @@ public:
     TextSubheader(nitf_TextSubheader * x);
 
     //! Default Constructor
-    TextSubheader() throw(nitf::NITFException);
+    TextSubheader();
 
     //! Clone
-    nitf::TextSubheader clone() throw(nitf::NITFException);
+    nitf::TextSubheader clone();
 
     ~TextSubheader();
 

--- a/modules/c++/nitf/include/nitf/WriteHandler.hpp
+++ b/modules/c++/nitf/include/nitf/WriteHandler.hpp
@@ -76,7 +76,7 @@ public:
      *  Write to the given output IOInterface
      *  \param handle   the output IOInterface
      */
-    virtual void write(IOInterface& handle) throw (nitf::NITFException);
+    virtual void write(IOInterface& handle);
 
 protected:
     //! Constructor

--- a/modules/c++/nitf/include/nitf/Writer.hpp
+++ b/modules/c++/nitf/include/nitf/Writer.hpp
@@ -68,7 +68,7 @@ public:
     Writer(nitf_Writer * x);
 
     //! Constructor
-    Writer() throw (nitf::NITFException);
+    Writer();
 
     ~Writer();
 
@@ -80,16 +80,14 @@ public:
      *  \param io  The IO handle to use
      *  \param record  The record to write out
      */
-    void prepare(nitf::IOHandle & io, nitf::Record & record)
-            throw (nitf::NITFException);
+    void prepare(nitf::IOHandle & io, nitf::Record & record);
 
     /*!
      *  Prepare the writer
      *  \param io  The IO handle to use
      *  \param record  The record to write out
      */
-    void prepareIO(nitf::IOInterface & io, nitf::Record & record)
-            throw (nitf::NITFException);
+    void prepareIO(nitf::IOInterface & io, nitf::Record & record);
 
     /*!
      * Set write handlers for images, graphics, texts, and DES
@@ -130,37 +128,32 @@ public:
      * Sets the WriteHandler for the Image at the given index.
      */
     void setImageWriteHandler(int index,
-                              mem::SharedPtr<WriteHandler> writeHandler)
-            throw (nitf::NITFException);
+                              mem::SharedPtr<WriteHandler> writeHandler);
 
     /*!
      * Sets the WriteHandler for the Graphic at the given index.
      */
     void setGraphicWriteHandler(int index,
-                                mem::SharedPtr<WriteHandler> writeHandler)
-            throw (nitf::NITFException);
+                                mem::SharedPtr<WriteHandler> writeHandler);
 
     /*!
      * Sets the WriteHandler for the Text at the given index.
      */
     void setTextWriteHandler(int index,
-                             mem::SharedPtr<WriteHandler> writeHandler)
-            throw (nitf::NITFException);
+                             mem::SharedPtr<WriteHandler> writeHandler);
 
     /*!
      * Sets the WriteHandler for the DE Segment at the given index.
      */
     void setDEWriteHandler(int index,
-                           mem::SharedPtr<WriteHandler> writeHandler)
-            throw (nitf::NITFException);
+                           mem::SharedPtr<WriteHandler> writeHandler);
 
     /**
      * Returns a NEW ImageWriter for the given index
      *
      * The pointer is deleted by the library, so don't delete it yourself.
      */
-    nitf::ImageWriter newImageWriter(int imageNumber)
-            throw (nitf::NITFException);
+    nitf::ImageWriter newImageWriter(int imageNumber);
 
     /**
      * Returns a NEW ImageWriter for the given index
@@ -168,31 +161,28 @@ public:
      * The pointer is deleted by the library, so don't delete it yourself.
      */
     nitf::ImageWriter newImageWriter(int imageNumber,
-                                     const std::map<std::string, void*>& options)
-        throw (nitf::NITFException);
+                                     const std::map<std::string, void*>& options);
 
     /**
      * Returns a NEW SegmentWriter for the given index
      *
      * The pointer is deleted by the library, so don't delete it yourself.
      */
-    nitf::SegmentWriter newGraphicWriter(int graphicNumber)
-            throw (nitf::NITFException);
+    nitf::SegmentWriter newGraphicWriter(int graphicNumber);
 
     /**
      * Returns a NEW SegmentWriter for the given index
      *
      * The pointer is deleted by the library, so don't delete it yourself.
      */
-    nitf::SegmentWriter newTextWriter(int textNumber)
-            throw (nitf::NITFException);
+    nitf::SegmentWriter newTextWriter(int textNumber);
 
     /**
      * Returns a NEW SegmentWriter for the given index
      *
      * The pointer is deleted by the library, so don't delete it yourself.
      */
-    nitf::SegmentWriter newDEWriter(int deNumber) throw (nitf::NITFException);
+    nitf::SegmentWriter newDEWriter(int deNumber);
 
     //! Get the warningList
     nitf::List getWarningList();

--- a/modules/c++/nitf/source/BandInfo.cpp
+++ b/modules/c++/nitf/source/BandInfo.cpp
@@ -99,7 +99,7 @@ void BandInfo::init(const std::string& representation,
                     const std::string& imageFilterCode,
                     nitf::Uint32 numLUTs,
                     nitf::Uint32 bandEntriesPerLUT,
-                    nitf::LookupTable& lut) throw(nitf::NITFException)
+                    nitf::LookupTable& lut)
 {
     if (getNativeOrThrow()->lut)
     {
@@ -127,7 +127,7 @@ void BandInfo::init(const std::string& representation,
 void BandInfo::init(const std::string& representation,
                     const std::string& subcategory,
                     const std::string& imageFilterCondition,
-                    const std::string& imageFilterCode) throw(nitf::NITFException)
+                    const std::string& imageFilterCode)
 {
     if (getNativeOrThrow()->lut)
     {

--- a/modules/c++/nitf/source/BandSource.cpp
+++ b/modules/c++/nitf/source/BandSource.cpp
@@ -26,7 +26,7 @@ nitf::MemorySource::MemorySource(const void* data,
                                  size_t size,
                                  nitf::Off start,
                                  int numBytesPerPixel,
-                                 int pixelSkip) throw(nitf::NITFException)
+                                 int pixelSkip)
 {
     setNative(nitf_MemorySource_construct(data, size, start, numBytesPerPixel, pixelSkip, &error));
     setManaged(false);
@@ -35,7 +35,7 @@ nitf::MemorySource::MemorySource(const void* data,
 nitf::FileSource::FileSource(nitf::IOHandle & io,
                              nitf::Off start,
                              int numBytesPerPixel,
-                             int pixelSkip) throw(nitf::NITFException)
+                             int pixelSkip)
 {
     setNative(nitf_IOSource_construct(io.getNative(), start, numBytesPerPixel, pixelSkip, &error));
     setManaged(false);
@@ -45,7 +45,7 @@ nitf::FileSource::FileSource(nitf::IOHandle & io,
 nitf::FileSource::FileSource(const std::string& fname,
                              nitf::Off start,
                              int numBytesPerPixel,
-                             int pixelSkip) throw (nitf::NITFException)
+                             int pixelSkip)
 {
     setNative(nitf_FileSource_constructFile(fname.c_str(),
                                             start,
@@ -59,7 +59,7 @@ nitf::RowSource::RowSource(
     nitf::Uint32 numRows,
     nitf::Uint32 numCols,
     nitf::Uint32 pixelSize,
-    nitf::RowSourceCallback *callback) throw(nitf::NITFException)
+    nitf::RowSourceCallback *callback)
     : mBand(band),
       mNumRows(numRows),
       mNumCols(numCols),
@@ -121,7 +121,6 @@ NITF_BOOL nitf::RowSource::nextRow(void* algorithm,
 }
 
 nitf::DirectBlockSource::DirectBlockSource(nitf::ImageReader& imageReader, nitf::Uint32 numBands)
-    throw(nitf::NITFException)
 {
     setNative(nitf_DirectBlockSource_construct(this,
                                                &DirectBlockSource::nextBlock, 

--- a/modules/c++/nitf/source/ComponentInfo.cpp
+++ b/modules/c++/nitf/source/ComponentInfo.cpp
@@ -43,14 +43,13 @@ ComponentInfo::ComponentInfo(nitf_ComponentInfo * x)
 }
 
 ComponentInfo::ComponentInfo(nitf::Uint32 subHeaderSize, nitf::Uint64 dataSize)
-    throw(nitf::NITFException)
 {
     setNative(nitf_ComponentInfo_construct(subHeaderSize, dataSize, &error));
     getNativeOrThrow();
     setManaged(false);
 }
 
-ComponentInfo ComponentInfo::clone() throw(nitf::NITFException)
+ComponentInfo ComponentInfo::clone()
 {
     nitf::ComponentInfo dolly(nitf_ComponentInfo_clone(getNativeOrThrow(), &error));
     dolly.setManaged(false);

--- a/modules/c++/nitf/source/DESegment.cpp
+++ b/modules/c++/nitf/source/DESegment.cpp
@@ -42,7 +42,7 @@ DESegment::DESegment(nitf_DESegment * x)
     getNativeOrThrow();
 }
 
-DESegment::DESegment() throw(nitf::NITFException)
+DESegment::DESegment()
 {
     setNative(nitf_DESegment_construct(&error));
     getNativeOrThrow();
@@ -62,7 +62,7 @@ DESegment & DESegment::operator=(NITF_DATA * x)
     return *this;
 }
 
-nitf::DESegment DESegment::clone() throw(nitf::NITFException)
+nitf::DESegment DESegment::clone()
 {
     nitf::DESegment dolly(nitf_DESegment_clone(getNativeOrThrow(), &error));
     dolly.setManaged(false);

--- a/modules/c++/nitf/source/DESubheader.cpp
+++ b/modules/c++/nitf/source/DESubheader.cpp
@@ -42,14 +42,14 @@ DESubheader::DESubheader(nitf_DESubheader * x)
     getNativeOrThrow();
 }
 
-DESubheader::DESubheader() throw(nitf::NITFException)
+DESubheader::DESubheader()
 {
     setNative(nitf_DESubheader_construct(&error));
     getNativeOrThrow();
     setManaged(false);
 }
 
-nitf::DESubheader DESubheader::clone() throw(nitf::NITFException)
+nitf::DESubheader DESubheader::clone()
 {
     nitf::DESubheader dolly(nitf_DESubheader_clone(getNativeOrThrow(), &error));
     dolly.setManaged(false);

--- a/modules/c++/nitf/source/DataSource.cpp
+++ b/modules/c++/nitf/source/DataSource.cpp
@@ -23,7 +23,6 @@
 #include "nitf/DataSource.hpp"
 
 void nitf::DataSource::read(void* buf, nitf::Off size)
-        throw (nitf::NITFException)
 {
     nitf_DataSource *ds = getNativeOrThrow();
     if (ds && ds->iface)

--- a/modules/c++/nitf/source/DateTime.cpp
+++ b/modules/c++/nitf/source/DateTime.cpp
@@ -23,7 +23,7 @@
 #include "sys/Conf.h"
 #include "nitf/DateTime.hpp"
 
-nitf::DateTime::DateTime() throw (nitf::NITFException)
+nitf::DateTime::DateTime()
 {
     nitf_Error error;
     mDateTime = nitf_DateTime_now(&error);
@@ -33,7 +33,7 @@ nitf::DateTime::DateTime() throw (nitf::NITFException)
     }
 }
 
-nitf::DateTime::DateTime(nitf_DateTime* dateTime) throw(nitf::NITFException) :
+nitf::DateTime::DateTime(nitf_DateTime* dateTime) :
     mDateTime(dateTime)
 {
     if (!dateTime)
@@ -42,7 +42,7 @@ nitf::DateTime::DateTime(nitf_DateTime* dateTime) throw(nitf::NITFException) :
     }
 }
 
-nitf::DateTime::DateTime(double timeInMillis) throw (nitf::NITFException)
+nitf::DateTime::DateTime(double timeInMillis)
 {
     nitf_Error error;
     mDateTime = nitf_DateTime_fromMillis(timeInMillis, &error);
@@ -53,7 +53,7 @@ nitf::DateTime::DateTime(double timeInMillis) throw (nitf::NITFException)
 }
 
 nitf::DateTime::DateTime(const std::string& dateString,
-        const std::string& dateFormat) throw (nitf::NITFException)
+        const std::string& dateFormat)
 {
     nitf_Error error;
     mDateTime =
@@ -122,7 +122,7 @@ nitf::DateTime & nitf::DateTime::operator=(const nitf::DateTime& rhs)
 }
 
 void nitf::DateTime::format(const std::string& format, char* outBuf,
-        size_t maxSize) const throw (nitf::NITFException)
+        size_t maxSize) const
 {
     nitf_Error error;
     if (!nitf_DateTime_format(mDateTime,
@@ -136,7 +136,7 @@ void nitf::DateTime::format(const std::string& format, char* outBuf,
 }
 
 void nitf::DateTime::format(const std::string& format,
-                            std::string &str) const throw(nitf::NITFException)
+                            std::string &str) const
 {
     str.clear();
 
@@ -147,7 +147,6 @@ void nitf::DateTime::format(const std::string& format,
 }
 
 std::string nitf::DateTime::format(const std::string& format) const
-    throw(nitf::NITFException)
 {
     std::string str;
     this->format(format, str);

--- a/modules/c++/nitf/source/DownSampler.cpp
+++ b/modules/c++/nitf/source/DownSampler.cpp
@@ -38,7 +38,6 @@ void nitf::DownSampler::apply(NITF_DATA ** inputWindow,
         nitf::Uint32 numInputCols, nitf::Uint32 numSubWindowCols,
         nitf::Uint32 pixelType, nitf::Uint32 pixelSize,
         nitf::Uint32 rowsInLastWindow, nitf::Uint32 colsInLastWindow)
-        throw (nitf::NITFException)
 {
     nitf_DownSampler *ds = getNativeOrThrow();
     if (ds && ds->iface)
@@ -56,7 +55,6 @@ void nitf::DownSampler::apply(NITF_DATA ** inputWindow,
 }
 
 nitf::PixelSkip::PixelSkip(nitf::Uint32 rowSkip, nitf::Uint32 colSkip)
-        throw (nitf::NITFException)
 {
     setNative(nitf_PixelSkip_construct(rowSkip, colSkip, &error));
     setManaged(false);
@@ -67,7 +65,6 @@ nitf::PixelSkip::~PixelSkip()
 }
 
 nitf::MaxDownSample::MaxDownSample(nitf::Uint32 rowSkip, nitf::Uint32 colSkip)
-        throw (nitf::NITFException)
 {
     setNative(nitf_MaxDownSample_construct(rowSkip, colSkip, &error));
     setManaged(false);
@@ -78,7 +75,7 @@ nitf::MaxDownSample::~MaxDownSample()
 }
 
 nitf::SumSq2DownSample::SumSq2DownSample(nitf::Uint32 rowSkip,
-        nitf::Uint32 colSkip) throw (nitf::NITFException)
+        nitf::Uint32 colSkip)
 {
     setNative(nitf_SumSq2DownSample_construct(rowSkip, colSkip, &error));
     setManaged(false);
@@ -89,7 +86,7 @@ nitf::SumSq2DownSample::~SumSq2DownSample()
 }
 
 nitf::Select2DownSample::Select2DownSample(nitf::Uint32 rowSkip,
-        nitf::Uint32 colSkip) throw (nitf::NITFException)
+        nitf::Uint32 colSkip)
 {
     setNative(nitf_Select2DownSample_construct(rowSkip, colSkip, &error));
     setManaged(false);

--- a/modules/c++/nitf/source/FileHeader.cpp
+++ b/modules/c++/nitf/source/FileHeader.cpp
@@ -42,7 +42,7 @@ FileHeader::FileHeader(nitf_FileHeader * x)
     getNativeOrThrow();
 }
 
-FileHeader::FileHeader() throw(nitf::NITFException)
+FileHeader::FileHeader()
 {
     setNative(nitf_FileHeader_construct(&error));
     getNativeOrThrow();
@@ -50,7 +50,7 @@ FileHeader::FileHeader() throw(nitf::NITFException)
 }
 
 
-nitf::FileHeader FileHeader::clone() throw(nitf::NITFException)
+nitf::FileHeader FileHeader::clone()
 {
     nitf::FileHeader dolly(nitf_FileHeader_clone(getNativeOrThrow(), &error));
     dolly.setManaged(false);
@@ -186,7 +186,6 @@ nitf::Field FileHeader::getNumReservedExtensions()
 }
 
 nitf::ComponentInfo FileHeader::getImageInfo(int i)
-    throw(except::IndexOutOfRangeException)
 {
     int num = getNumImages();
     if (i < 0 || i >= num)
@@ -196,7 +195,6 @@ nitf::ComponentInfo FileHeader::getImageInfo(int i)
 }
 
 nitf::ComponentInfo FileHeader::getGraphicInfo(int i)
-    throw(except::IndexOutOfRangeException)
 {
     int num = getNumGraphics();
     if (i < 0 || i >= num)
@@ -206,7 +204,6 @@ nitf::ComponentInfo FileHeader::getGraphicInfo(int i)
 }
 
 nitf::ComponentInfo FileHeader::getLabelInfo(int i)
-    throw(except::IndexOutOfRangeException)
 {
     int num = getNumLabels();
     if (i < 0 || i >= num)
@@ -216,7 +213,6 @@ nitf::ComponentInfo FileHeader::getLabelInfo(int i)
 }
 
 nitf::ComponentInfo FileHeader::getTextInfo(int i)
-    throw(except::IndexOutOfRangeException)
 {
     int num = getNumTexts();
     if (i < 0 || i >= num)
@@ -226,7 +222,6 @@ nitf::ComponentInfo FileHeader::getTextInfo(int i)
 }
 
 nitf::ComponentInfo FileHeader::getDataExtensionInfo(int i)
-    throw(except::IndexOutOfRangeException)
 {
     int num = getNumDataExtensions();
     if (i < 0 || i >= num)
@@ -236,7 +231,6 @@ nitf::ComponentInfo FileHeader::getDataExtensionInfo(int i)
 }
 
 nitf::ComponentInfo FileHeader::getReservedExtensionInfo(int i)
-    throw(except::IndexOutOfRangeException)
 {
     int num = getNumReservedExtensions();
     if (i < 0 || i >= num)

--- a/modules/c++/nitf/source/FileSecurity.cpp
+++ b/modules/c++/nitf/source/FileSecurity.cpp
@@ -42,14 +42,14 @@ FileSecurity::FileSecurity(nitf_FileSecurity * x)
     getNativeOrThrow();
 }
 
-FileSecurity::FileSecurity() throw(nitf::NITFException)
+FileSecurity::FileSecurity()
 {
     setNative(nitf_FileSecurity_construct(&error));
     getNativeOrThrow();
     setManaged(false);
 }
 
-nitf::FileSecurity FileSecurity::clone() throw(nitf::NITFException)
+nitf::FileSecurity FileSecurity::clone()
 {
     nitf::FileSecurity dolly(nitf_FileSecurity_clone(getNativeOrThrow(), &error));
     dolly.setManaged(false);

--- a/modules/c++/nitf/source/GraphicSegment.cpp
+++ b/modules/c++/nitf/source/GraphicSegment.cpp
@@ -44,7 +44,7 @@ GraphicSegment::GraphicSegment(nitf_GraphicSegment * x)
 }
 
 
-GraphicSegment::GraphicSegment() throw(nitf::NITFException)
+GraphicSegment::GraphicSegment()
 {
     setNative(nitf_GraphicSegment_construct(&error));
     getNativeOrThrow();
@@ -65,7 +65,7 @@ GraphicSegment & GraphicSegment::operator=(NITF_DATA * x)
 }
 
 
-nitf::GraphicSegment GraphicSegment::clone() throw(nitf::NITFException)
+nitf::GraphicSegment GraphicSegment::clone()
 {
     nitf::GraphicSegment dolly(nitf_GraphicSegment_clone(getNativeOrThrow(), &error));
     dolly.setManaged(false);

--- a/modules/c++/nitf/source/GraphicSubheader.cpp
+++ b/modules/c++/nitf/source/GraphicSubheader.cpp
@@ -43,7 +43,7 @@ GraphicSubheader::GraphicSubheader(nitf_GraphicSubheader * x)
     getNativeOrThrow();
 }
 
-GraphicSubheader::GraphicSubheader() throw(nitf::NITFException)
+GraphicSubheader::GraphicSubheader()
 {
     setNative(nitf_GraphicSubheader_construct(&error));
     getNativeOrThrow();
@@ -51,7 +51,7 @@ GraphicSubheader::GraphicSubheader() throw(nitf::NITFException)
 }
 
 
-nitf::GraphicSubheader GraphicSubheader::clone() throw(nitf::NITFException)
+nitf::GraphicSubheader GraphicSubheader::clone()
 {
     nitf::GraphicSubheader dolly(
         nitf_GraphicSubheader_clone(getNativeOrThrow(), &error));

--- a/modules/c++/nitf/source/HashTable.cpp
+++ b/modules/c++/nitf/source/HashTable.cpp
@@ -95,7 +95,7 @@ nitf::HashTable::HashTable(nitf_HashTable * x)
     getNativeOrThrow();
 }
 
-nitf::HashTable::HashTable(int nbuckets) throw(nitf::NITFException)
+nitf::HashTable::HashTable(int nbuckets)
 {
     setNative(nitf_HashTable_construct(nbuckets, &error));
     getNativeOrThrow();
@@ -103,7 +103,7 @@ nitf::HashTable::HashTable(int nbuckets) throw(nitf::NITFException)
 }
 
 
-nitf::HashTable nitf::HashTable::clone(NITF_DATA_ITEM_CLONE cloner) throw(nitf::NITFException)
+nitf::HashTable nitf::HashTable::clone(NITF_DATA_ITEM_CLONE cloner)
 {
     nitf::HashTable dolly(nitf_HashTable_clone(getNativeOrThrow(),
         cloner, &error));
@@ -139,7 +139,6 @@ void nitf::HashTable::print()
 }
 
 void nitf::HashTable::forEach(HashIterator& fun, NITF_DATA* userData)
-    throw(nitf::NITFException)
 {
     int numBuckets = getNumBuckets();
     for (int i = 0; i < numBuckets; i++)
@@ -154,7 +153,7 @@ void nitf::HashTable::forEach(HashIterator& fun, NITF_DATA* userData)
     }
 }
 
-void nitf::HashTable::insert(const std::string& key, NITF_DATA* data) throw(nitf::NITFException)
+void nitf::HashTable::insert(const std::string& key, NITF_DATA* data)
 {
     if (key.length() == 0)
         throw except::NoSuchKeyException(Ctxt("Empty key value"));
@@ -163,7 +162,7 @@ void nitf::HashTable::insert(const std::string& key, NITF_DATA* data) throw(nitf
         throw nitf::NITFException(&error);
 }
 
-nitf::Pair nitf::HashTable::find(const std::string& key) throw(except::NoSuchKeyException)
+nitf::Pair nitf::HashTable::find(const std::string& key)
 {
     if (key.length() == 0)
         throw except::NoSuchKeyException(Ctxt("Empty key value"));
@@ -173,12 +172,12 @@ nitf::Pair nitf::HashTable::find(const std::string& key) throw(except::NoSuchKey
     return nitf::Pair(x);
 }
 
-nitf::Pair nitf::HashTable::operator[] (const std::string& key) throw(except::NoSuchKeyException)
+nitf::Pair nitf::HashTable::operator[] (const std::string& key)
 {
     return find(key);
 }
 
-nitf::List nitf::HashTable::getBucket(int i) throw(nitf::NITFException)
+nitf::List nitf::HashTable::getBucket(int i)
 {
     //return *mBuckets.at(i);
     if (!getNativeOrThrow()->buckets || !getNativeOrThrow()->buckets[i])

--- a/modules/c++/nitf/source/IOHandle.cpp
+++ b/modules/c++/nitf/source/IOHandle.cpp
@@ -26,7 +26,7 @@ namespace nitf
 {
 IOHandle::IOHandle(const std::string& fname,
                    nitf::AccessFlags access,
-                   nitf::CreationFlags creation) throw (nitf::NITFException) :
+                   nitf::CreationFlags creation) :
     IOInterface(open(fname.c_str(), access, creation))
 {
     setManaged(false);
@@ -34,7 +34,7 @@ IOHandle::IOHandle(const std::string& fname,
 
 IOHandle::IOHandle(const char* fname,
                    nitf::AccessFlags access,
-                   nitf::CreationFlags creation) throw (nitf::NITFException) :
+                   nitf::CreationFlags creation) :
     IOInterface(open(fname, access, creation))
 {
     setManaged(false);
@@ -43,7 +43,7 @@ IOHandle::IOHandle(const char* fname,
 nitf_IOInterface*
 IOHandle::open(const char* fname,
                nitf::AccessFlags access,
-               nitf::CreationFlags creation) throw (nitf::NITFException)
+               nitf::CreationFlags creation)
 {
     nitf_Error error;
     nitf_IOInterface* const ioInterface =

--- a/modules/c++/nitf/source/ImageReader.cpp
+++ b/modules/c++/nitf/source/ImageReader.cpp
@@ -44,7 +44,7 @@ ImageReader::ImageReader(nitf_ImageReader * x)
 
 ImageReader::~ImageReader(){}
 
-nitf::BlockingInfo ImageReader::getBlockingInfo() throw (nitf::NITFException)
+nitf::BlockingInfo ImageReader::getBlockingInfo()
 {
     nitf_BlockingInfo* blockingInfo =
             nitf_ImageReader_getBlockingInfo(getNativeOrThrow(), &error);
@@ -55,7 +55,7 @@ nitf::BlockingInfo ImageReader::getBlockingInfo() throw (nitf::NITFException)
     return cppBlockingInfo;
 }
 
-void ImageReader::read(nitf::SubWindow & subWindow, nitf::Uint8 ** user, int * padded) throw (nitf::NITFException)
+void ImageReader::read(nitf::SubWindow & subWindow, nitf::Uint8 ** user, int * padded)
 {
     NITF_BOOL x = nitf_ImageReader_read(getNativeOrThrow(), subWindow.getNative(), user, padded, &error);
     if (!x)
@@ -63,7 +63,6 @@ void ImageReader::read(nitf::SubWindow & subWindow, nitf::Uint8 ** user, int * p
 }
 
 const nitf::Uint8* ImageReader::readBlock(nitf::Uint32 blockNumber, nitf::Uint64* blockSize)
-    throw (nitf::NITFException)
 {
     const nitf::Uint8* x = nitf_ImageReader_readBlock(
         getNativeOrThrow(), blockNumber, blockSize, &error);

--- a/modules/c++/nitf/source/ImageSegment.cpp
+++ b/modules/c++/nitf/source/ImageSegment.cpp
@@ -42,7 +42,7 @@ ImageSegment::ImageSegment(nitf_ImageSegment * x)
     getNativeOrThrow();
 }
 
-ImageSegment::ImageSegment() throw(nitf::NITFException)
+ImageSegment::ImageSegment()
 {
     setNative(nitf_ImageSegment_construct(&error));
     getNativeOrThrow();
@@ -63,7 +63,7 @@ ImageSegment & ImageSegment::operator=(NITF_DATA * x)
 }
 
 
-nitf::ImageSegment ImageSegment::clone() throw(nitf::NITFException)
+nitf::ImageSegment ImageSegment::clone()
 {
     nitf::ImageSegment dolly(nitf_ImageSegment_clone(getNativeOrThrow(), &error));
     dolly.setManaged(false);

--- a/modules/c++/nitf/source/ImageSource.cpp
+++ b/modules/c++/nitf/source/ImageSource.cpp
@@ -42,7 +42,7 @@ ImageSource::ImageSource(nitf_ImageSource * x)
     getNativeOrThrow();
 }
 
-ImageSource::ImageSource() throw (nitf::NITFException)
+ImageSource::ImageSource()
 {
     setNative(nitf_ImageSource_construct(&error));
     getNativeOrThrow();
@@ -61,7 +61,6 @@ ImageSource::~ImageSource()
 }
 
 void ImageSource::addBand(nitf::BandSource bandSource)
-        throw (nitf::NITFException)
 {
     NITF_BOOL x = nitf_ImageSource_addBand(getNativeOrThrow(),
                                            bandSource.getNativeOrThrow(),
@@ -73,7 +72,7 @@ void ImageSource::addBand(nitf::BandSource bandSource)
     //    bandSource->incRef();
 }
 
-nitf::BandSource ImageSource::getBand(int n) throw (nitf::NITFException)
+nitf::BandSource ImageSource::getBand(int n)
 {
     nitf_DataSource * x = nitf_ImageSource_getBand(getNativeOrThrow(), n,
                                                    &error);

--- a/modules/c++/nitf/source/ImageSubheader.cpp
+++ b/modules/c++/nitf/source/ImageSubheader.cpp
@@ -43,7 +43,7 @@ ImageSubheader::ImageSubheader(nitf_ImageSubheader * x)
     getNativeOrThrow();
 }
 
-ImageSubheader::ImageSubheader() throw(nitf::NITFException)
+ImageSubheader::ImageSubheader()
 {
     setNative(nitf_ImageSubheader_construct(&error));
     getNativeOrThrow();
@@ -51,7 +51,7 @@ ImageSubheader::ImageSubheader() throw(nitf::NITFException)
 }
 
 
-nitf::ImageSubheader ImageSubheader::clone() throw(nitf::NITFException)
+nitf::ImageSubheader ImageSubheader::clone()
 {
     nitf::ImageSubheader dolly(nitf_ImageSubheader_clone(getNativeOrThrow(), &error));
     dolly.setManaged(false);
@@ -69,7 +69,7 @@ void ImageSubheader::setPixelInformation(std::string pvtype,
                          nitf::Uint32 abpp,
                          std::string justification,
                          std::string irep, std::string icat,
-                         std::vector<nitf::BandInfo>& bands) throw(nitf::NITFException)
+                         std::vector<nitf::BandInfo>& bands)
 {
     const size_t bandCount = bands.size();
     nitf_BandInfo ** bandInfo = (nitf_BandInfo **)NITF_MALLOC(
@@ -97,7 +97,7 @@ void ImageSubheader::setBlocking(nitf::Uint32 numRows,
                      nitf::Uint32 numCols,
                      nitf::Uint32 numRowsPerBlock,
                      nitf::Uint32 numColsPerBlock,
-                     const std::string& imode) throw(nitf::NITFException)
+                     const std::string& imode)
 {
     NITF_BOOL x = nitf_ImageSubheader_setBlocking(getNativeOrThrow(),
         numRows, numCols, numRowsPerBlock, numColsPerBlock, imode.c_str(),
@@ -122,7 +122,6 @@ void ImageSubheader::computeBlocking(nitf::Uint32 numRows,
 }
 
 void ImageSubheader::setDimensions(nitf::Uint32 numRows, nitf::Uint32 numCols)
-    throw(nitf::NITFException)
 {
     NITF_BOOL x = nitf_ImageSubheader_setDimensions(getNativeOrThrow(),
         numRows, numCols, &error);
@@ -130,7 +129,7 @@ void ImageSubheader::setDimensions(nitf::Uint32 numRows, nitf::Uint32 numCols)
         throw nitf::NITFException(&error);
 }
 
-nitf::Uint32 ImageSubheader::getBandCount() throw(nitf::NITFException)
+nitf::Uint32 ImageSubheader::getBandCount()
 {
     nitf::Uint32 x = nitf_ImageSubheader_getBandCount(getNativeOrThrow(), &error);
     if (x == NITF_INVALID_BAND_COUNT)
@@ -138,7 +137,7 @@ nitf::Uint32 ImageSubheader::getBandCount() throw(nitf::NITFException)
     return x;
 }
 
-void ImageSubheader::createBands(nitf::Uint32 numBands) throw(nitf::NITFException)
+void ImageSubheader::createBands(nitf::Uint32 numBands)
 {
     if (!nitf_ImageSubheader_createBands(getNativeOrThrow(), numBands, &error))
         throw nitf::NITFException(&error);
@@ -147,7 +146,6 @@ void ImageSubheader::createBands(nitf::Uint32 numBands) throw(nitf::NITFExceptio
 
 void ImageSubheader::setCornersFromLatLons(nitf::CornersType type,
                                            double corners[4][2])
-    throw(nitf::NITFException)
 {
     NITF_BOOL x = nitf_ImageSubheader_setCornersFromLatLons(getNativeOrThrow(),
                                                             type,
@@ -159,7 +157,6 @@ void ImageSubheader::setCornersFromLatLons(nitf::CornersType type,
 }
 
 void ImageSubheader::getCornersAsLatLons(double corners[4][2])
-    throw(nitf::NITFException)
 {
     NITF_BOOL x = nitf_ImageSubheader_getCornersAsLatLons(getNativeOrThrow(),
                                                           corners,
@@ -170,7 +167,6 @@ void ImageSubheader::getCornersAsLatLons(double corners[4][2])
 }
 
 nitf::CornersType ImageSubheader::getCornersType()
-    throw(nitf::NITFException)
 {
     return nitf_ImageSubheader_getCornersType(getNativeOrThrow());
 }
@@ -325,7 +321,7 @@ nitf::Field ImageSubheader::getNumMultispectralImageBands()
     return nitf::Field(getNativeOrThrow()->numMultispectralImageBands);
 }
 
-nitf::BandInfo ImageSubheader::getBandInfo(nitf::Uint32 band) throw(nitf::NITFException)
+nitf::BandInfo ImageSubheader::getBandInfo(nitf::Uint32 band)
 {
     return nitf::BandInfo(nitf_ImageSubheader_getBandInfo(
         getNativeOrThrow(), band, &error));

--- a/modules/c++/nitf/source/ImageWriter.cpp
+++ b/modules/c++/nitf/source/ImageWriter.cpp
@@ -25,7 +25,6 @@
 using namespace nitf;
 
 ImageWriter::ImageWriter(nitf::ImageSubheader& subheader)
-        throw (nitf::NITFException)
 {
     setNative(nitf_ImageWriter_construct(subheader.getNative(), NULL, &error));
 }
@@ -40,7 +39,6 @@ ImageWriter::~ImageWriter()
 }
 
 void ImageWriter::attachSource(nitf::ImageSource imageSource)
-        throw (nitf::NITFException)
 {
     if (!nitf_ImageWriter_attachSource(getNativeOrThrow(),
                                        imageSource.getNative(), &error))

--- a/modules/c++/nitf/source/LabelSegment.cpp
+++ b/modules/c++/nitf/source/LabelSegment.cpp
@@ -42,7 +42,7 @@ LabelSegment::LabelSegment(nitf_LabelSegment * x)
     getNativeOrThrow();
 }
 
-LabelSegment::LabelSegment() throw(nitf::NITFException)
+LabelSegment::LabelSegment()
 {
     setNative(nitf_LabelSegment_construct(&error));
     getNativeOrThrow();
@@ -63,7 +63,7 @@ LabelSegment & LabelSegment::operator=(NITF_DATA * x)
 }
 
 
-nitf::LabelSegment LabelSegment::clone() throw(nitf::NITFException)
+nitf::LabelSegment LabelSegment::clone()
 {
     nitf::LabelSegment dolly(
         nitf_LabelSegment_clone(getNativeOrThrow(), &error));

--- a/modules/c++/nitf/source/LabelSubheader.cpp
+++ b/modules/c++/nitf/source/LabelSubheader.cpp
@@ -42,7 +42,7 @@ LabelSubheader::LabelSubheader(nitf_LabelSubheader * x)
     getNativeOrThrow();
 }
 
-LabelSubheader::LabelSubheader() throw(nitf::NITFException)
+LabelSubheader::LabelSubheader()
 {
     setNative(nitf_LabelSubheader_construct(&error));
     getNativeOrThrow();
@@ -50,7 +50,7 @@ LabelSubheader::LabelSubheader() throw(nitf::NITFException)
 }
 
 
-LabelSubheader LabelSubheader::clone() throw(nitf::NITFException)
+LabelSubheader LabelSubheader::clone()
 {
     nitf::LabelSubheader dolly(
         nitf_LabelSubheader_clone(getNativeOrThrow(), &error));

--- a/modules/c++/nitf/source/List.cpp
+++ b/modules/c++/nitf/source/List.cpp
@@ -39,7 +39,6 @@ nitf::ListNode::ListNode(nitf_ListNode * x)
 }
 
 nitf::ListNode::ListNode(nitf::ListNode & prev, nitf::ListNode & next, NITF_DATA* data)
-    throw(nitf::NITFException)
 {
     setNative(nitf_ListNode_construct(prev.getNative(),
         next.getNative(), data, &error));
@@ -147,14 +146,14 @@ bool nitf::List::isEmpty()
     return x ? true : false;
 }
 
-void nitf::List::pushFront(NITF_DATA* data) throw(nitf::NITFException)
+void nitf::List::pushFront(NITF_DATA* data)
 {
     NITF_BOOL x = nitf_List_pushFront(getNativeOrThrow(), data, &error);
     if (!x)
         throw nitf::NITFException(&error);
 }
 
-void nitf::List::pushBack(NITF_DATA* data) throw(nitf::NITFException)
+void nitf::List::pushBack(NITF_DATA* data)
 {
     NITF_BOOL x = nitf_List_pushBack(getNativeOrThrow(), data, &error);
     if (!x)
@@ -173,14 +172,14 @@ NITF_DATA* nitf::List::popBack()
     return data;
 }
 
-nitf::List::List() throw(nitf::NITFException)
+nitf::List::List()
 {
     setNative(nitf_List_construct(&error));
     getNativeOrThrow();
     setManaged(false);
 }
 
-nitf::List nitf::List::clone(NITF_DATA_ITEM_CLONE cloner) throw(nitf::NITFException)
+nitf::List nitf::List::clone(NITF_DATA_ITEM_CLONE cloner)
 {
     nitf::List dolly(nitf_List_clone(getNativeOrThrow(), cloner, &error));
     dolly.setManaged(false);
@@ -201,7 +200,7 @@ nitf::ListIterator nitf::List::end()
     return nitf::ListIterator(x);
 }
 
-void nitf::List::insert(nitf::ListIterator & iter, NITF_DATA* data) throw(nitf::NITFException)
+void nitf::List::insert(nitf::ListIterator & iter, NITF_DATA* data)
 {
     NITF_BOOL x = nitf_List_insert(getNativeOrThrow(), iter.getHandle(), data, &error);
     if (!x)
@@ -229,7 +228,7 @@ size_t nitf::List::getSize()
     return (size_t)nitf_List_size(getNativeOrThrow());
 }
 
-NITF_DATA* nitf::List::operator[] (size_t index) throw(nitf::NITFException)
+NITF_DATA* nitf::List::operator[] (size_t index)
 {
     NITF_DATA* x = nitf_List_get(getNativeOrThrow(), index, &error);
     if (!x)

--- a/modules/c++/nitf/source/MemoryIO.cpp
+++ b/modules/c++/nitf/source/MemoryIO.cpp
@@ -26,7 +26,7 @@ namespace nitf
 {
 nitf_IOInterface* MemoryIO::create(void* buffer,
                                    size_t size,
-                                   bool adopt) throw(nitf::NITFException)
+                                   bool adopt)
 {
     nitf_Error error;
     nitf_IOInterface* const ioInterface = nitf_BufferAdapter_construct(
@@ -45,7 +45,7 @@ nitf_IOInterface* MemoryIO::create(void* buffer,
     return ioInterface;
 }
 
-MemoryIO::MemoryIO(size_t capacity) throw(nitf::NITFException) :
+MemoryIO::MemoryIO(size_t capacity) :
     IOInterface(create(NRT_MALLOC(capacity), capacity, true))
 {
     // NOTE: We are telling the C layer to adopt this memory which means it
@@ -55,8 +55,7 @@ MemoryIO::MemoryIO(size_t capacity) throw(nitf::NITFException) :
 }
 
 MemoryIO::MemoryIO(void* buffer, size_t size, bool adopt)
-        throw(nitf::NITFException) :
-    IOInterface(create(buffer, size, adopt))
+  : IOInterface(create(buffer, size, adopt))
 {
     setManaged(false);
 }

--- a/modules/c++/nitf/source/PluginRegistry.cpp
+++ b/modules/c++/nitf/source/PluginRegistry.cpp
@@ -24,14 +24,14 @@
 
 namespace nitf
 {
-void PluginRegistry::loadDir(const std::string& dirName) throw(NITFException)
+void PluginRegistry::loadDir(const std::string& dirName)
 {
     nitf_Error error;
     if (!nitf_PluginRegistry_loadDir(dirName.c_str(), &error))
         throw NITFException(&error);
 }
 
-void PluginRegistry::loadPlugin(const std::string& path) throw(NITFException)
+void PluginRegistry::loadPlugin(const std::string& path)
 {
     nitf_Error error;
     if (!nitf_PluginRegistry_loadPlugin(path.c_str(), &error))
@@ -40,7 +40,6 @@ void PluginRegistry::loadPlugin(const std::string& path) throw(NITFException)
 
 void PluginRegistry::registerTREHandler(NITF_PLUGIN_INIT_FUNCTION init,
         NITF_PLUGIN_TRE_HANDLER_FUNCTION handler)
-        throw(NITFException)
 {
     nitf_Error error;
     if (!nitf_PluginRegistry_registerTREHandler(init, handler, &error))
@@ -49,7 +48,6 @@ void PluginRegistry::registerTREHandler(NITF_PLUGIN_INIT_FUNCTION init,
 
 void PluginRegistry::registerCompressionHandler(NITF_PLUGIN_INIT_FUNCTION init,
         NITF_PLUGIN_COMPRESSION_CONSTRUCT_FUNCTION handler)
-        throw(NITFException)
 {
     nitf_Error error;
     if (!nitf_PluginRegistry_registerCompressionHandler(init, handler, &error))
@@ -60,7 +58,6 @@ void PluginRegistry::registerCompressionHandler(NITF_PLUGIN_INIT_FUNCTION init,
 
 void PluginRegistry::registerDecompressionHandler(NITF_PLUGIN_INIT_FUNCTION init,
         NITF_PLUGIN_DECOMPRESSION_CONSTRUCT_FUNCTION handler)
-        throw(NITFException)
 {
     nitf_Error error;
     if (!nitf_PluginRegistry_registerDecompressionHandler(init, handler, &error))
@@ -70,7 +67,7 @@ void PluginRegistry::registerDecompressionHandler(NITF_PLUGIN_INIT_FUNCTION init
 }
 
 nitf_CompressionInterface* PluginRegistry::retrieveCompressionInterface(
-        const std::string& comp) throw(NITFException)
+        const std::string& comp)
 {
     nitf_Error error;
     nitf_CompressionInterface* const compIface =

--- a/modules/c++/nitf/source/RESegment.cpp
+++ b/modules/c++/nitf/source/RESegment.cpp
@@ -42,7 +42,7 @@ RESegment::RESegment(nitf_RESegment * x)
     getNativeOrThrow();
 }
 
-RESegment::RESegment() throw(nitf::NITFException)
+RESegment::RESegment()
 {
     setNative(nitf_RESegment_construct(&error));
     getNativeOrThrow();
@@ -62,7 +62,7 @@ RESegment & RESegment::operator=(NITF_DATA * x)
     return *this;
 }
 
-nitf::RESegment RESegment::clone() throw(nitf::NITFException)
+nitf::RESegment RESegment::clone()
 {
     nitf::RESegment dolly(
         nitf_RESegment_clone(getNativeOrThrow(), &error));

--- a/modules/c++/nitf/source/RESubheader.cpp
+++ b/modules/c++/nitf/source/RESubheader.cpp
@@ -42,7 +42,7 @@ RESubheader::RESubheader(nitf_RESubheader * x)
     getNativeOrThrow();
 }
 
-RESubheader::RESubheader() throw(nitf::NITFException)
+RESubheader::RESubheader()
 {
     setNative(nitf_RESubheader_construct(&error));
     getNativeOrThrow();
@@ -50,7 +50,7 @@ RESubheader::RESubheader() throw(nitf::NITFException)
 }
 
 
-nitf::RESubheader RESubheader::clone() throw(nitf::NITFException)
+nitf::RESubheader RESubheader::clone()
 {
     nitf::RESubheader dolly(
         nitf_RESubheader_clone(getNativeOrThrow(), &error));

--- a/modules/c++/nitf/source/Reader.cpp
+++ b/modules/c++/nitf/source/Reader.cpp
@@ -62,7 +62,7 @@ Reader::Reader(nitf_Reader * x)
     getNativeOrThrow();
 }
 
-Reader::Reader() throw (nitf::NITFException)
+Reader::Reader()
 {
     setNative(nitf_Reader_construct(&error));
     getNativeOrThrow();
@@ -78,12 +78,12 @@ nitf::Version Reader::getNITFVersion(const std::string& fileName)
     return nitf_Reader_getNITFVersion(fileName.c_str());
 }
 
-nitf::Record Reader::read(nitf::IOHandle & io) throw (nitf::NITFException)
+nitf::Record Reader::read(nitf::IOHandle & io)
 {
     return readIO(io);
 }
 
-nitf::Record Reader::readIO(nitf::IOInterface & io) throw (nitf::NITFException)
+nitf::Record Reader::readIO(nitf::IOInterface & io)
 {
     //free up the existing record, if we have one
     nitf_Reader *reader = getNativeOrThrow();
@@ -117,7 +117,6 @@ nitf::Record Reader::readIO(nitf::IOInterface & io) throw (nitf::NITFException)
 }
 
 nitf::ImageReader Reader::newImageReader(int imageSegmentNumber)
-        throw (nitf::NITFException)
 {
     nitf_ImageReader * x = nitf_Reader_newImageReader(getNativeOrThrow(),
                                                       imageSegmentNumber,
@@ -134,7 +133,6 @@ nitf::ImageReader Reader::newImageReader(int imageSegmentNumber)
 
 nitf::ImageReader Reader::newImageReader(int imageSegmentNumber,
                                          const std::map<std::string, void*>& options)
-        throw (nitf::NITFException)
 {
     nitf::HashTable userOptions;
     nrt_HashTable* userOptionsNative = NULL;
@@ -169,7 +167,6 @@ nitf::ImageReader Reader::newImageReader(int imageSegmentNumber,
 }
 
 nitf::SegmentReader Reader::newDEReader(int deSegmentNumber)
-        throw (nitf::NITFException)
 {
     nitf_SegmentReader * x = nitf_Reader_newDEReader(getNativeOrThrow(),
                                                      deSegmentNumber, &error);
@@ -183,7 +180,6 @@ nitf::SegmentReader Reader::newDEReader(int deSegmentNumber)
 }
 
 nitf::SegmentReader Reader::newGraphicReader(int segmentNumber)
-        throw (nitf::NITFException)
 {
     nitf_SegmentReader * x =
             nitf_Reader_newGraphicReader(getNativeOrThrow(), segmentNumber,
@@ -198,7 +194,6 @@ nitf::SegmentReader Reader::newGraphicReader(int segmentNumber)
 }
 
 nitf::SegmentReader Reader::newTextReader(int segmentNumber)
-        throw (nitf::NITFException)
 {
     nitf_SegmentReader * x = nitf_Reader_newTextReader(getNativeOrThrow(),
                                                        segmentNumber, &error);

--- a/modules/c++/nitf/source/Record.cpp
+++ b/modules/c++/nitf/source/Record.cpp
@@ -45,14 +45,14 @@ Record::Record(nitf_Record * x)
     getNativeOrThrow();
 }
 
-Record::Record(nitf::Version version) throw(nitf::NITFException)
+Record::Record(nitf::Version version)
 {
     setNative(nitf_Record_construct(version, &error));
     getNativeOrThrow();
     setManaged(false);
 }
 
-nitf::Record Record::clone() const throw(nitf::NITFException)
+nitf::Record Record::clone() const
 {
     nitf::Record dolly(nitf_Record_clone(getNativeOrThrow(), &error));
     dolly.setManaged(false);

--- a/modules/c++/nitf/source/SegmentReader.cpp
+++ b/modules/c++/nitf/source/SegmentReader.cpp
@@ -49,7 +49,7 @@ void SegmentReader::read
 (
     NITF_DATA *buffer,           /*!< Buffer to hold data */
     size_t count                /*!< Amount of data to return */
-) throw (nitf::NITFException)
+)
 {
     if (!nitf_SegmentReader_read(getNativeOrThrow(), buffer, count, &error))
         throw nitf::NITFException(&error);
@@ -60,7 +60,7 @@ nitf::Off SegmentReader::seek
 (
     nitf::Off offset,                 /*!< The seek offset */
     int whence                   /*!< Starting at (SEEK_SET, SEEK_CUR, SEEK_END)*/
-) throw (nitf::NITFException)
+)
 {
     offset = nitf_SegmentReader_seek(getNativeOrThrow(), offset, whence, &error);
     if (offset < 0)

--- a/modules/c++/nitf/source/SegmentSource.cpp
+++ b/modules/c++/nitf/source/SegmentSource.cpp
@@ -23,7 +23,7 @@
 #include "nitf/SegmentSource.hpp"
 
 nitf::SegmentMemorySource::SegmentMemorySource(const char * data, size_t size,
-        nitf::Off start, int byteSkip, bool copyData) throw (nitf::NITFException)
+        nitf::Off start, int byteSkip, bool copyData)
 {
     setNative(nitf_SegmentMemorySource_construct(data, size, start, byteSkip,
     		                                     copyData, &error));
@@ -31,7 +31,7 @@ nitf::SegmentMemorySource::SegmentMemorySource(const char * data, size_t size,
 }
 
 nitf::SegmentFileSource::SegmentFileSource(nitf::IOHandle & io,
-        nitf::Off start, int byteSkip) throw (nitf::NITFException)
+        nitf::Off start, int byteSkip)
 {
     setNative(nitf_SegmentFileSource_constructIO(io.getNative(),
                                                  start, byteSkip,
@@ -41,7 +41,6 @@ nitf::SegmentFileSource::SegmentFileSource(nitf::IOHandle & io,
 }
 
 nitf::SegmentReaderSource::SegmentReaderSource(nitf::SegmentReader reader)
-        throw (nitf::NITFException)
 {
     setNative(nitf_SegmentReaderSource_construct(reader.getNativeOrThrow(),
                                                  &error));

--- a/modules/c++/nitf/source/SegmentWriter.cpp
+++ b/modules/c++/nitf/source/SegmentWriter.cpp
@@ -24,14 +24,13 @@
 
 using namespace nitf;
 
-SegmentWriter::SegmentWriter() throw (nitf::NITFException)
+SegmentWriter::SegmentWriter()
 {
     setNative(nitf_SegmentWriter_construct(&error));
     setManaged(false);
 }
 
 SegmentWriter::SegmentWriter(nitf::SegmentSource segmentSource)
-        throw (nitf::NITFException)
 {
     setNative(nitf_SegmentWriter_construct(&error));
     setManaged(false);
@@ -48,7 +47,6 @@ SegmentWriter::~SegmentWriter()
 }
 
 void SegmentWriter::attachSource(nitf::SegmentSource segmentSource)
-        throw (nitf::NITFException)
 {
     if (!nitf_SegmentWriter_attachSource(getNativeOrThrow(),
                                          segmentSource.getNative(), &error))

--- a/modules/c++/nitf/source/SubWindow.cpp
+++ b/modules/c++/nitf/source/SubWindow.cpp
@@ -42,7 +42,7 @@ SubWindow::SubWindow(nitf_SubWindow * x)
     getNativeOrThrow();
 }
 
-SubWindow::SubWindow() throw(nitf::NITFException) : mDownSampler(NULL)
+SubWindow::SubWindow() : mDownSampler(NULL)
 {
     setNative(nitf_SubWindow_construct(&error));
     getNativeOrThrow();
@@ -120,7 +120,6 @@ void SubWindow::setNumBands(nitf::Uint32 value)
 }
 
 void SubWindow::setDownSampler(nitf::DownSampler* downSampler)
-    throw (nitf::NITFException)
 {
     if (getNativeOrThrow()->downsampler)
     {
@@ -136,7 +135,7 @@ void SubWindow::setDownSampler(nitf::DownSampler* downSampler)
 }
 
 
-nitf::DownSampler* SubWindow::getDownSampler() throw (nitf::NITFException)
+nitf::DownSampler* SubWindow::getDownSampler()
 {
     return mDownSampler;
 }

--- a/modules/c++/nitf/source/TRE.cpp
+++ b/modules/c++/nitf/source/TRE.cpp
@@ -56,21 +56,21 @@ TRE & TRE::operator=(NITF_DATA * x)
     return *this;
 }
 
-TRE::TRE(const char* tag) throw(nitf::NITFException)
+TRE::TRE(const char* tag)
 {
 	setNative(nitf_TRE_construct(tag, NULL, &error));
 	getNativeOrThrow();
 	setManaged(false);
 }
 
-TRE::TRE(const char* tag, const char* id) throw(nitf::NITFException)
+TRE::TRE(const char* tag, const char* id)
 {
 	setNative(nitf_TRE_construct(tag, (::strlen(id) > 0) ? id : NULL, &error));
 	getNativeOrThrow();
 	setManaged(false);
 }
 
-TRE::TRE(const std::string& tag) throw(nitf::NITFException)
+TRE::TRE(const std::string& tag)
 {
 	setNative(nitf_TRE_construct(tag.c_str(), NULL, &error));
 	getNativeOrThrow();
@@ -78,7 +78,6 @@ TRE::TRE(const std::string& tag) throw(nitf::NITFException)
 }
 
 TRE::TRE(const std::string& tag, const std::string& id)
-    throw(nitf::NITFException)
 {
     setNative(nitf_TRE_construct(tag.c_str(),
     		                     id.empty() ? NULL : id.c_str(),
@@ -87,7 +86,7 @@ TRE::TRE(const std::string& tag, const std::string& id)
     setManaged(false);
 }
 
-nitf::TRE TRE::clone() throw(nitf::NITFException)
+nitf::TRE TRE::clone()
 {
     nitf::TRE dolly(nitf_TRE_clone(getNativeOrThrow(), &error));
     dolly.setManaged(false);
@@ -104,13 +103,12 @@ TRE::Iterator TRE::begin()
     return TRE::Iterator(iter);
 }
 
-TRE::Iterator TRE::end() throw (nitf::NITFException)
+TRE::Iterator TRE::end()
 {
     return TRE::Iterator();
 }
 
 nitf::Field TRE::getField(const std::string& key)
-    throw(except::NoSuchKeyException)
 {
     nitf_Field* field = nitf_TRE_getField(getNativeOrThrow(), key.c_str());
     if (!field)
@@ -120,7 +118,6 @@ nitf::Field TRE::getField(const std::string& key)
 }
 
 nitf::Field TRE::operator[] (const std::string& key)
-    throw(except::NoSuchKeyException)
 {
     return getField(key);
 }

--- a/modules/c++/nitf/source/TextSegment.cpp
+++ b/modules/c++/nitf/source/TextSegment.cpp
@@ -42,7 +42,7 @@ TextSegment::TextSegment(nitf_TextSegment * x)
     getNativeOrThrow();
 }
 
-TextSegment::TextSegment() throw(nitf::NITFException)
+TextSegment::TextSegment()
 {
     setNative(nitf_TextSegment_construct(&error));
     getNativeOrThrow();
@@ -62,7 +62,7 @@ TextSegment & TextSegment::operator=(NITF_DATA * x)
     return *this;
 }
 
-nitf::TextSegment TextSegment::clone() throw(nitf::NITFException)
+nitf::TextSegment TextSegment::clone()
 {
     nitf::TextSegment dolly(
         nitf_TextSegment_clone(getNativeOrThrow(), &error));

--- a/modules/c++/nitf/source/TextSubheader.cpp
+++ b/modules/c++/nitf/source/TextSubheader.cpp
@@ -42,14 +42,14 @@ TextSubheader::TextSubheader(nitf_TextSubheader * x)
     getNativeOrThrow();
 }
 
-TextSubheader::TextSubheader() throw(nitf::NITFException)
+TextSubheader::TextSubheader()
 {
     setNative(nitf_TextSubheader_construct(&error));
     getNativeOrThrow();
     setManaged(false);
 }
 
-nitf::TextSubheader TextSubheader::clone() throw(nitf::NITFException)
+nitf::TextSubheader TextSubheader::clone()
 {
     nitf::TextSubheader dolly(nitf_TextSubheader_clone(getNativeOrThrow(), &error));
     dolly.setManaged(false);

--- a/modules/c++/nitf/source/WriteHandler.cpp
+++ b/modules/c++/nitf/source/WriteHandler.cpp
@@ -23,7 +23,6 @@
 #include "nitf/WriteHandler.hpp"
 
 void nitf::WriteHandler::write(nitf::IOInterface& handle)
-        throw (nitf::NITFException)
 {
     nitf_WriteHandler *handler = getNativeOrThrow();
     if (handler && handler->iface)

--- a/modules/c++/nitf/source/Writer.cpp
+++ b/modules/c++/nitf/source/Writer.cpp
@@ -59,7 +59,7 @@ Writer::Writer(nitf_Writer * x)
     getNativeOrThrow();
 }
 
-Writer::Writer() throw (nitf::NITFException)
+Writer::Writer()
 {
     setNative(nitf_Writer_construct(&error));
     getNativeOrThrow();
@@ -83,13 +83,11 @@ void Writer::write()
 }
 
 void Writer::prepare(nitf::IOHandle & io, nitf::Record & record)
-        throw (nitf::NITFException)
 {
     prepareIO(io, record);
 }
 
 void Writer::prepareIO(nitf::IOInterface & io, nitf::Record & record)
-        throw (nitf::NITFException)
 {
     NITF_BOOL x = nitf_Writer_prepareIO(getNativeOrThrow(), record.getNative(),
                                         io.getNative(), &error);
@@ -183,7 +181,6 @@ void Writer::setDEWriteHandlers(nitf::IOHandle& io, nitf::Record& record)
 
 void Writer::setImageWriteHandler(int index,
                                   mem::SharedPtr<WriteHandler> writeHandler)
-        throw (nitf::NITFException)
 {
     if (!nitf_Writer_setImageWriteHandler(getNativeOrThrow(), index,
                                           writeHandler->getNative(), &error))
@@ -194,7 +191,6 @@ void Writer::setImageWriteHandler(int index,
 
 void Writer::setGraphicWriteHandler(int index,
                                     mem::SharedPtr<WriteHandler> writeHandler)
-        throw (nitf::NITFException)
 {
     if (!nitf_Writer_setGraphicWriteHandler(getNativeOrThrow(), index,
                                             writeHandler->getNative(), &error))
@@ -205,7 +201,6 @@ void Writer::setGraphicWriteHandler(int index,
 
 void Writer::setTextWriteHandler(int index,
                                  mem::SharedPtr<WriteHandler> writeHandler)
-        throw (nitf::NITFException)
 {
     if (!nitf_Writer_setTextWriteHandler(getNativeOrThrow(), index,
                                          writeHandler->getNative(), &error))
@@ -216,7 +211,6 @@ void Writer::setTextWriteHandler(int index,
 
 void Writer::setDEWriteHandler(int index,
                                mem::SharedPtr<WriteHandler> writeHandler)
-        throw (nitf::NITFException)
 {
     if (!nitf_Writer_setDEWriteHandler(getNativeOrThrow(), index,
                                        writeHandler->getNative(), &error))
@@ -226,7 +220,6 @@ void Writer::setDEWriteHandler(int index,
 }
 
 nitf::ImageWriter Writer::newImageWriter(int imageNumber)
-        throw (nitf::NITFException)
 {
     nitf_SegmentWriter * x = nitf_Writer_newImageWriter(getNativeOrThrow(),
                                                         imageNumber, NULL, &error);
@@ -241,7 +234,6 @@ nitf::ImageWriter Writer::newImageWriter(int imageNumber)
 
 nitf::ImageWriter Writer::newImageWriter(int imageNumber,
                                          const std::map<std::string, void*>& options)
-    throw (nitf::NITFException)
 {
     nitf::HashTable userOptions;
     nrt_HashTable* userOptionsNative = NULL;
@@ -276,7 +268,6 @@ nitf::ImageWriter Writer::newImageWriter(int imageNumber,
 }
 
 nitf::SegmentWriter Writer::newGraphicWriter(int graphicNumber)
-        throw (nitf::NITFException)
 {
     nitf_SegmentWriter * x =
             nitf_Writer_newGraphicWriter(getNativeOrThrow(), graphicNumber,
@@ -291,7 +282,6 @@ nitf::SegmentWriter Writer::newGraphicWriter(int graphicNumber)
 }
 
 nitf::SegmentWriter Writer::newTextWriter(int textNumber)
-        throw (nitf::NITFException)
 {
     nitf_SegmentWriter * x = nitf_Writer_newTextWriter(getNativeOrThrow(),
                                                        textNumber, &error);
@@ -305,7 +295,6 @@ nitf::SegmentWriter Writer::newTextWriter(int textNumber)
 }
 
 nitf::SegmentWriter Writer::newDEWriter(int deNumber)
-        throw (nitf::NITFException)
 {
     nitf_SegmentWriter * x = nitf_Writer_newDEWriter(getNativeOrThrow(),
                                                      deNumber, &error);

--- a/modules/c++/nitf/tests/test_direct_block_round_trip.cpp
+++ b/modules/c++/nitf/tests/test_direct_block_round_trip.cpp
@@ -33,13 +33,13 @@ class TestDirectBlockSource: public nitf::DirectBlockSource
 public:
     TestDirectBlockSource(nitf::ImageReader& imageReader,
                       nitf::Uint32 numBands)
-        throw (nitf::NITFException) : nitf::DirectBlockSource(imageReader, numBands){}
+        : nitf::DirectBlockSource(imageReader, numBands){}
 
 protected:
     virtual void nextBlock(void* buf,
                            const void* block,
                            nitf::Uint32 blockNumber,
-                           nitf::Uint64 blockSize) throw (nitf::NITFException)
+                           nitf::Uint64 blockSize)
     {
         std::cout << "BLOCK NUMBER: " << blockNumber << " " << blockSize << std::endl;
         if (buf)

--- a/modules/c++/nitf/tests/test_round_trip.cpp
+++ b/modules/c++/nitf/tests/test_round_trip.cpp
@@ -41,7 +41,7 @@ class RowStreamer : public nitf::RowSourceCallback
 public:
     RowStreamer(nitf::Uint32 band,
                 nitf::Uint32 numCols,
-                nitf::ImageReader reader) throw (nitf::NITFException) :
+                nitf::ImageReader reader) :
         mReader(reader),
         mBand(band)
     {
@@ -53,7 +53,7 @@ public:
         mWindow.setNumBands(1);
     }
 
-    virtual void nextRow(nitf::Uint32 band, void* buffer) throw (nitf::NITFException)
+    virtual void nextRow(nitf::Uint32 band, void* buffer)
     {
         int padded;
         mReader.read(mWindow, (nitf::Uint8**) &buffer, &padded);


### PR DESCRIPTION
Exception specifications were discouraged in C++11, deprecated in C++14,
and removed in C++17.

Get rid of them so that newer compilers stop warning about them.