### PR TITLE
Allow setField to work with binary TRE fields

### DIFF
--- a/modules/c++/nitf/include/nitf/TRE.hpp
+++ b/modules/c++/nitf/include/nitf/TRE.hpp
@@ -226,21 +226,80 @@ DECLARE_CLASS(TRE)
     nitf::List find(const std::string& pattern);
 
     /*!
+     * Recalculate the field counts and positions for the TRE.
+     * This might be necessary if, for example, you need to
+     * change the number of iterations in a loop.
+     *
+     * setField does not do this by default, because some
+     * applications want to set each field all at once.
+     * If the TRE is large, recalculating the metadata each time
+     * you change something becomes expensive.
+     *
+     * If you find yourself writing code that looks like this:
+     *
+     *  tre.setField("key", value);
+     *  tre.updateFields();
+     *  tre.setField("key2", value);
+     *  tre.updateFields();
+     *  tre.setField("key3", value);
+     *  tre.updateFields();
+     *
+     * You probably want to run an iterator over the TRE instead.
+     * The incrementing will automatically figure out any changed
+     * positioning due to loops or conditionals as it goes, and it
+     * will be faster.
+     *
+     * In short, this is here if you need it, but if you're needing
+     * it frequently you should open an issue/look for a better solution
+     */
+    void updateFields();
+
+    /*!
      * Sets the field with the given value. The input value
      * is converted to a std::string, and the string-ized value
      * is then used as the value input for the TRE field.
+     * \param key The name of the field to set
+     * \param value New value for specified field
+     * \param forceUpdate If true, recalculate the number and positions
+     *                    of the TRE fields. See `updateFields()`
      */
     template <typename T>
-    void setField(std::string key, T value)
+    void setField(std::string key, T value, bool forceUpdate = false)
     {
-        std::string s = str::toString<T>(value);
-        if (!nitf_TRE_setField(getNative(),
-                               key.c_str(),
-                               (NITF_DATA*)s.c_str(),
-                               s.size(),
-                               &error))
+        nitf_Field* field = nitf_TRE_getField(getNative(), key.c_str());
+        if (!field)
         {
-            throw NITFException(&error);
+            std::ostringstream msg;
+            msg << key << " is not a recognized field for this TRE";
+            throw except::Exception(Ctxt(msg.str()));
+        }
+        if (field->type == NITF_BINARY)
+        {
+            if (!nitf_TRE_setField(getNative(),
+                                   key.c_str(),
+                                   &value,
+                                   sizeof(value),
+                                   &error))
+            {
+                throw NITFException(&error);
+            }
+        }
+        else
+        {
+            std::string s = str::toString<T>(value);
+            if (!nitf_TRE_setField(getNative(),
+                                   key.c_str(),
+                                   (NITF_DATA*)s.c_str(),
+                                   s.size(),
+                                   &error))
+            {
+                throw NITFException(&error);
+            }
+        }
+
+        if (forceUpdate)
+        {
+            updateFields();
         }
     }
 

--- a/modules/c++/nitf/source/TRE.cpp
+++ b/modules/c++/nitf/source/TRE.cpp
@@ -20,36 +20,37 @@
  *
  */
 
-#include <string.h>
 #include "nitf/TRE.hpp"
+#include <string.h>
+#include "nitf/TREUtils.h"
 
 using namespace nitf;
 
-TRE::TRE(const TRE & x)
+TRE::TRE(const TRE& x)
 {
     setNative(x.getNative());
 }
 
-TRE & TRE::operator=(const TRE & x)
+TRE& TRE::operator=(const TRE& x)
 {
     if (&x != this)
         setNative(x.getNative());
     return *this;
 }
 
-TRE::TRE(nitf_TRE * x)
+TRE::TRE(nitf_TRE* x)
 {
     setNative(x);
     getNativeOrThrow();
 }
 
-TRE::TRE(NITF_DATA * x)
+TRE::TRE(NITF_DATA* x)
 {
     setNative((nitf_TRE*)x);
     getNativeOrThrow();
 }
 
-TRE & TRE::operator=(NITF_DATA * x)
+TRE& TRE::operator=(NITF_DATA* x)
 {
     setNative((nitf_TRE*)x);
     getNativeOrThrow();
@@ -58,30 +59,30 @@ TRE & TRE::operator=(NITF_DATA * x)
 
 TRE::TRE(const char* tag)
 {
-	setNative(nitf_TRE_construct(tag, NULL, &error));
-	getNativeOrThrow();
-	setManaged(false);
+    setNative(nitf_TRE_construct(tag, NULL, &error));
+    getNativeOrThrow();
+    setManaged(false);
 }
 
 TRE::TRE(const char* tag, const char* id)
 {
-	setNative(nitf_TRE_construct(tag, (::strlen(id) > 0) ? id : NULL, &error));
-	getNativeOrThrow();
-	setManaged(false);
+    setNative(nitf_TRE_construct(tag, (::strlen(id) > 0) ? id : NULL, &error));
+    getNativeOrThrow();
+    setManaged(false);
 }
 
 TRE::TRE(const std::string& tag)
 {
-	setNative(nitf_TRE_construct(tag.c_str(), NULL, &error));
-	getNativeOrThrow();
-	setManaged(false);
+    setNative(nitf_TRE_construct(tag.c_str(), NULL, &error));
+    getNativeOrThrow();
+    setManaged(false);
 }
 
 TRE::TRE(const std::string& tag, const std::string& id)
 {
     setNative(nitf_TRE_construct(tag.c_str(),
-    		                     id.empty() ? NULL : id.c_str(),
-    		                     &error));
+                                 id.empty() ? NULL : id.c_str(),
+                                 &error));
     getNativeOrThrow();
     setManaged(false);
 }
@@ -93,12 +94,14 @@ nitf::TRE TRE::clone()
     return dolly;
 }
 
-TRE::~TRE(){}
+TRE::~TRE()
+{
+}
 
 TRE::Iterator TRE::begin()
 {
     nitf_TREEnumerator* iter = nitf_TRE_begin(getNativeOrThrow(), &error);
-    if(!iter)
+    if (!iter)
         throw nitf::NITFException(Ctxt("Invalid TRE: " + getTag()));
     return TRE::Iterator(iter);
 }
@@ -112,12 +115,24 @@ nitf::Field TRE::getField(const std::string& key)
 {
     nitf_Field* field = nitf_TRE_getField(getNativeOrThrow(), key.c_str());
     if (!field)
-        throw except::NoSuchKeyException(Ctxt(FmtX(
-                "Field does not exist in TRE: %s", key.c_str())));
+        throw except::NoSuchKeyException(
+                Ctxt(FmtX("Field does not exist in TRE: %s", key.c_str())));
     return nitf::Field(field);
 }
 
-nitf::Field TRE::operator[] (const std::string& key)
+void TRE::updateFields()
+{
+    nitf_Error error;
+    if (!nitf_TREUtils_fillData(
+                getNative(),
+                ((nitf_TREPrivateData*)getNative()->priv)->description,
+                &error))
+    {
+        throw NITFException(&error);
+    }
+}
+
+nitf::Field TRE::operator[](const std::string& key)
 {
     return getField(key);
 }
@@ -140,7 +155,7 @@ std::string TRE::getTag() const
     return std::string(getNativeOrThrow()->tag);
 }
 
-void TRE::setTag(const std::string & value)
+void TRE::setTag(const std::string& value)
 {
     memset(getNativeOrThrow()->tag, 0, 7);
     memcpy(getNativeOrThrow()->tag, value.c_str(), 7);

--- a/modules/c++/nitf/source/TRE.cpp
+++ b/modules/c++/nitf/source/TRE.cpp
@@ -122,7 +122,6 @@ nitf::Field TRE::getField(const std::string& key)
 
 void TRE::updateFields()
 {
-    nitf_Error error;
     if (!nitf_TREUtils_fillData(
                 getNative(),
                 ((nitf_TREPrivateData*)getNative()->priv)->description,

--- a/modules/c++/nitf/unittests/test_tre_mods++.cpp
+++ b/modules/c++/nitf/unittests/test_tre_mods++.cpp
@@ -124,7 +124,7 @@ int main(int /*argc*/, char** /*argv*/)
     TEST_CHECK(setFields);
     TEST_CHECK(setBinaryFields);
     TEST_CHECK(cloneTRE);
-    // TEST_CHECK(basicIteration);
+    TEST_CHECK(basicIteration);
     TEST_CHECK(populateWhileIterating);
     return 0;
 }

--- a/modules/c++/nitf/unittests/test_tre_mods++.cpp
+++ b/modules/c++/nitf/unittests/test_tre_mods++.cpp
@@ -45,6 +45,17 @@ TEST_CASE(setFields)
     TEST_EXCEPTION(tre.setField("invalid-tag", "some data"));
 }
 
+TEST_CASE(setBinaryFields)
+{
+    nitf::TRE tre("RPFHDR");
+    const int value = 123;
+    tre.setField("LOCSEC", value);
+
+    nitf::Field field = tre.getField("LOCSEC");
+    const int readValue = *reinterpret_cast<int*>(field.getRawData());
+    TEST_ASSERT_EQ(readValue, value);
+}
+
 TEST_CASE(cloneTRE)
 {
     nitf::TRE tre("JITCID");
@@ -73,7 +84,7 @@ TEST_CASE(basicIteration)
     TEST_ASSERT_EQ(numFields, 1);
 
     numFields = 0;
-    tre.setField("NUMACPO", 2);
+    tre.setField("NUMACPO", 2, true);
     tre.setField("NUMPTS[0]", 3);
     tre.setField("NUMPTS[1]", 2);
     for (nitf::TRE::Iterator it = tre.begin(); it != tre.end(); ++it)
@@ -111,8 +122,9 @@ TEST_CASE(populateWhileIterating)
 int main(int /*argc*/, char** /*argv*/)
 {
     TEST_CHECK(setFields);
+    TEST_CHECK(setBinaryFields);
     TEST_CHECK(cloneTRE);
-    TEST_CHECK(basicIteration);
+    // TEST_CHECK(basicIteration);
     TEST_CHECK(populateWhileIterating);
     return 0;
 }


### PR DESCRIPTION
Fixes https://github.com/mdaus/nitro/issues/184

I forgot to run the formatter separately for TRE.cpp. The only "real" change in that file is the implementation of `updateData`