### PR TITLE
Bug in ImageIO myResidual calculation can cause seg fault 

### DIFF
--- a/modules/c/nitf/source/ImageIO.c
+++ b/modules/c/nitf/source/ImageIO.c
@@ -4957,11 +4957,13 @@ nitf_Uint32 nitf_ImageIO_updateMyResidual(
         }
         else
         {
-            myResidual = cntl->column + numColsFR - nitf->numColumns;
-
-            if (myResidual < 0)
+            if (cntl->column + numColsFR < nitf->numColumns)
             {
                 myResidual = 0;
+            }
+            else
+            {
+                myResidual = cntl->column + numColsFR - nitf->numColumns;
             }
         }
     }


### PR DESCRIPTION
The bug is in lines 4960-4965 of modules/c/nitf/source/ImageIO.c. myResidual is an unsigned integer, so it cannot be negative. The "if (myResidual < 0)" case can never happen. Instead of myResidual being set to 0 in such a case, it is a very large positive number, which can result it a seg fault.