### PR TITLE
Feature/use standard c types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(nitro)
 
-set(CMAKE_C_STANDARD 90)
+set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
 
 if (${CMAKE_PROJECT_NAME} STREQUAL nitro)

--- a/modules/c++/nitf/apps/show_nitf++.cpp
+++ b/modules/c++/nitf/apps/show_nitf++.cpp
@@ -42,7 +42,7 @@ void printTRE(nitf::TRE tre)
 
 
     // This is so you know how long the TRE is
-    nitf_Uint32 treLength = tre.getCurrentSize();
+    uint32_t treLength = tre.getCurrentSize();
 
     /*
      *  This is the name for the description that was selected to field

--- a/modules/c++/nitf/apps/show_nitf++.cpp
+++ b/modules/c++/nitf/apps/show_nitf++.cpp
@@ -235,7 +235,7 @@ void showImageSubheader(nitf::ImageSubheader imsub)
     SHOW( imsub.getImageCoordinateSystem().toString() );
     SHOW( imsub.getCornerCoordinates().toString() );
 
-    SHOW( (nitf::Uint32)imsub.getNumImageComments() );
+    SHOW( (uint32_t)imsub.getNumImageComments() );
     nitf::List comments = imsub.getImageComments();
     for (nitf::ListIterator it = comments.begin(); it != comments.end(); ++it)
         SHOW(((nitf::Field)*it).toString());
@@ -244,7 +244,7 @@ void showImageSubheader(nitf::ImageSubheader imsub)
     SHOW( imsub.getCompressionRate().toString() );
 
     SHOW( imsub.getNumImageBands().toString() );
-    SHOW( (nitf::Uint32)imsub.getNumMultispectralImageBands() );
+    SHOW( (uint32_t)imsub.getNumMultispectralImageBands() );
 
     for (i = 0; i < (unsigned int)imsub.getNumImageBands(); i++)
     {
@@ -252,17 +252,17 @@ void showImageSubheader(nitf::ImageSubheader imsub)
         SHOW( imsub.getBandInfo(i).getSubcategory().toString() );
         SHOW( imsub.getBandInfo(i).getImageFilterCondition().toString() );
         SHOW( imsub.getBandInfo(i).getImageFilterCode().toString() );
-        SHOW( (nitf::Uint32)imsub.getBandInfo(i).getNumLUTs() );
-        SHOW( (nitf::Uint32)imsub.getBandInfo(i).getBandEntriesPerLUT() );
+        SHOW( (uint32_t)imsub.getBandInfo(i).getNumLUTs() );
+        SHOW( (uint32_t)imsub.getBandInfo(i).getBandEntriesPerLUT() );
     }
 
     SHOW( imsub.getImageSyncCode().toString() );
     SHOW( imsub.getImageMode().toString() );
-    SHOW( (nitf::Uint32)imsub.getNumBlocksPerRow() );
-    SHOW( (nitf::Uint32)imsub.getNumBlocksPerCol() );
-    SHOW( (nitf::Uint32)imsub.getNumPixelsPerHorizBlock() );
-    SHOW( (nitf::Uint32)imsub.getNumPixelsPerVertBlock() );
-    SHOW( (nitf::Uint32)imsub.getNumBitsPerPixel() );
+    SHOW( (uint32_t)imsub.getNumBlocksPerRow() );
+    SHOW( (uint32_t)imsub.getNumBlocksPerCol() );
+    SHOW( (uint32_t)imsub.getNumPixelsPerHorizBlock() );
+    SHOW( (uint32_t)imsub.getNumPixelsPerVertBlock() );
+    SHOW( (uint32_t)imsub.getNumBitsPerPixel() );
     SHOW( imsub.getImageDisplayLevel().toString() );
     SHOW( imsub.getImageAttachmentLevel().toString() );
     SHOW( imsub.getImageLocation().toString() );
@@ -277,7 +277,7 @@ void showImageSubheader(nitf::ImageSubheader imsub)
     // nitf::HashTable htUd = udExts.getHash();
     //    htUd.forEach(showTRE);
 
-    SHOW( (nitf::Uint32)imsub.getExtendedHeaderLength() );
+    SHOW( (uint32_t)imsub.getExtendedHeaderLength() );
     SHOW( imsub.getExtendedHeaderOverflow().toString() );
 
     nitf::Extensions exExts = imsub.getExtendedSection();
@@ -475,7 +475,7 @@ void showDESubheader(nitf::DESubheader sub)
      *  It is only valid if the subheader fields length > 0; otherwise, it will
      *  throw an Exception since there is no TRE defining the subheader fields.
      */
-    if (((nitf::Uint32)sub.getSubheaderFieldsLength()) > 0)
+    if (((uint32_t)sub.getSubheaderFieldsLength()) > 0)
     {
         nitf::TRE tre = sub.getSubheaderFields();
         printTRE( tre );

--- a/modules/c++/nitf/include/nitf/BandInfo.hpp
+++ b/modules/c++/nitf/include/nitf/BandInfo.hpp
@@ -96,8 +96,8 @@ public:
               const std::string& subcategory,
               const std::string& imageFilterCondition,
               const std::string& imageFilterCode,
-              nitf::Uint32 numLUTs,
-              nitf::Uint32 bandEntriesPerLUT,
+              uint32_t numLUTs,
+              uint32_t bandEntriesPerLUT,
               nitf::LookupTable& lut);
 
     /*!

--- a/modules/c++/nitf/include/nitf/BandSource.hpp
+++ b/modules/c++/nitf/include/nitf/BandSource.hpp
@@ -120,7 +120,7 @@ public:
 private:
     static
     NITF_BOOL nextRow(void* algorithm,
-                      nitf_Uint32 band,
+                      uint32_t band,
                       NITF_DATA* buffer,
                       nitf_Error* error);
 
@@ -144,8 +144,8 @@ private:
     NITF_BOOL nextBlock(void *algorithm,
                         void* buf,
                         const void* block,
-                        nitf_Uint32 blockNumber,
-                        nitf_Uint64 blockSize,
+                        uint32_t blockNumber,
+                        uint64_t blockSize,
                         nitf_Error * error);
 };
 

--- a/modules/c++/nitf/include/nitf/BandSource.hpp
+++ b/modules/c++/nitf/include/nitf/BandSource.hpp
@@ -108,14 +108,14 @@ struct RowSourceCallback
     {
     }
 
-    virtual void nextRow(nitf::Uint32 band, void* buf) = 0;
+    virtual void nextRow(uint32_t band, void* buf) = 0;
 };
 
 class RowSource : public BandSource
 {
 public:
-    RowSource(nitf::Uint32 band, nitf::Uint32 numRows, nitf::Uint32 numCols,
-            nitf::Uint32 pixelSize, RowSourceCallback *callback);
+    RowSource(uint32_t band, uint32_t numRows, uint32_t numCols,
+            uint32_t pixelSize, RowSourceCallback *callback);
 
 private:
     static
@@ -125,20 +125,20 @@ private:
                       nitf_Error* error);
 
 private:
-    nitf::Uint32 mBand, mNumRows, mNumCols, mPixelSize;
+    uint32_t mBand, mNumRows, mNumCols, mPixelSize;
 };
 
 class DirectBlockSource : public BandSource
 {
 public:
     DirectBlockSource(nitf::ImageReader& imageReader,
-                      nitf::Uint32 numBands);
+                      uint32_t numBands);
 
 protected:
     virtual void nextBlock(void* buf,
                            const void* block,
-                           nitf::Uint32 blockNumber,
-                           nitf::Uint64 blockSize) = 0;
+                           uint32_t blockNumber,
+                           uint64_t blockSize) = 0;
 private:
     static
     NITF_BOOL nextBlock(void *algorithm,
@@ -152,7 +152,7 @@ private:
 class CopyBlockSource: public ::nitf::DirectBlockSource
 {
 public:
-    CopyBlockSource(nitf::ImageReader& imageReader, nitf::Uint32 numBands) :
+    CopyBlockSource(nitf::ImageReader& imageReader, uint32_t numBands) :
         nitf::DirectBlockSource(imageReader, numBands)
     {}
 
@@ -161,8 +161,8 @@ public:
 protected:
     virtual void nextBlock(void* buf,
                            const void* block,
-                           nitf::Uint32 /*blockNumber*/,
-                           nitf::Uint64 blockSize)
+                           uint32_t /*blockNumber*/,
+                           uint64_t blockSize)
     {
         memcpy(buf, block, blockSize);
     }

--- a/modules/c++/nitf/include/nitf/BlockingInfo.hpp
+++ b/modules/c++/nitf/include/nitf/BlockingInfo.hpp
@@ -69,28 +69,28 @@ public:
     ~BlockingInfo();
 
     //! Get the number of blocks per row
-    nitf::Uint32 getNumBlocksPerRow() const;
+    uint32_t getNumBlocksPerRow() const;
 
     //! Set the number of blocks per row
-    void setNumBlocksPerRow(nitf::Uint32 value);
+    void setNumBlocksPerRow(uint32_t value);
 
     //! Get the number of blocks per column
-    nitf::Uint32 getNumBlocksPerCol() const;
+    uint32_t getNumBlocksPerCol() const;
 
     //! Set the number of blocks per column
-    void setNumBlocksPerCol(nitf::Uint32 value);
+    void setNumBlocksPerCol(uint32_t value);
 
     //! Get the number of rows per block
-    nitf::Uint32 getNumRowsPerBlock() const;
+    uint32_t getNumRowsPerBlock() const;
 
     //! Set the number of rows per block
-    void setNumRowsPerBlock(nitf::Uint32 value);
+    void setNumRowsPerBlock(uint32_t value);
 
     //! Get the number of columns per block
-    nitf::Uint32 getNumColsPerBlock() const;
+    uint32_t getNumColsPerBlock() const;
 
     //! Set the number of columns per block
-    void setNumColsPerBlock(nitf::Uint32 value);
+    void setNumColsPerBlock(uint32_t value);
 
     //! Get the length
     size_t getLength() const;

--- a/modules/c++/nitf/include/nitf/BufferedWriter.hpp
+++ b/modules/c++/nitf/include/nitf/BufferedWriter.hpp
@@ -43,17 +43,17 @@ public:
 
     void flushBuffer();
 
-    nitf::Uint64 getTotalWritten() const
+    uint64_t getTotalWritten() const
     {
         return mTotalWritten;
     }
 
-    nitf::Uint64 getNumBlocksWritten() const
+    uint64_t getNumBlocksWritten() const
     {
         return mBlocksWritten;
     }
 
-    nitf::Uint64 getNumPartialBlocksWritten() const
+    uint64_t getNumPartialBlocksWritten() const
     {
         return mPartialBlocks;
     }
@@ -87,10 +87,10 @@ private:
     const mem::ScopedArray<char> mScopedBuffer;
     char* const mBuffer;
 
-    nitf::Uint64 mPosition;
-    nitf::Uint64 mTotalWritten;
-    nitf::Uint64 mBlocksWritten;
-    nitf::Uint64 mPartialBlocks;
+    uint64_t mPosition;
+    uint64_t mTotalWritten;
+    uint64_t mBlocksWritten;
+    uint64_t mPartialBlocks;
     double mElapsedTime;
 
     // NOTE: This is at the end to give us a chance to adopt the buffer

--- a/modules/c++/nitf/include/nitf/ComponentInfo.hpp
+++ b/modules/c++/nitf/include/nitf/ComponentInfo.hpp
@@ -78,7 +78,7 @@ protected:
      *  \param subHeaderSize  The size of the subheader
      *  \param dataSize  The size of the data
      */
-    ComponentInfo(nitf::Uint32 subHeaderSize = 0, nitf::Uint64 dataSize = 0);
+    ComponentInfo(uint32_t subHeaderSize = 0, uint64_t dataSize = 0);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/CompressionInterface.hpp
+++ b/modules/c++/nitf/include/nitf/CompressionInterface.hpp
@@ -91,10 +91,10 @@ public:
     //! These are canned methods which turn around
     //  and call the nitf_CompressionControl of your choice
     static NITF_BOOL adapterStart(nitf_CompressionControl* object,
-                                  nitf::Uint64 offset,
-                                  nitf::Uint64 dataLength,
-                                  nitf::Uint64* blockMask,
-                                  nitf::Uint64* padMask,
+                                  uint64_t offset,
+                                  uint64_t dataLength,
+                                  uint64_t* blockMask,
+                                  uint64_t* padMask,
                                   nitf_Error* error);
 
     static NITF_BOOL adapterWriteBlock(nitf_CompressionControl* object,
@@ -122,13 +122,13 @@ public:
     Compressor() {}
     virtual ~Compressor() {}
 
-    virtual void start(nitf::Uint64 offset,
-                       nitf::Uint64 dataLength,
-                       nitf::Uint64* blockMask,
-                       nitf::Uint64* padMask) = 0;
+    virtual void start(uint64_t offset,
+                       uint64_t dataLength,
+                       uint64_t* blockMask,
+                       uint64_t* padMask) = 0;
 
     virtual void writeBlock(nitf::IOInterface& io,
-                            const nitf::Uint8* data,
+                            const uint8_t* data,
                             bool pad,
                             bool noData) = 0;
 

--- a/modules/c++/nitf/include/nitf/CompressionInterface.hpp
+++ b/modules/c++/nitf/include/nitf/CompressionInterface.hpp
@@ -99,7 +99,7 @@ public:
 
     static NITF_BOOL adapterWriteBlock(nitf_CompressionControl* object,
                                        nitf_IOInterface* io,
-                                       const nitf_Uint8* data,
+                                       const uint8_t* data,
                                        NITF_BOOL pad,
                                        NITF_BOOL noData,
                                        nitf_Error* error);

--- a/modules/c++/nitf/include/nitf/DESegment.hpp
+++ b/modules/c++/nitf/include/nitf/DESegment.hpp
@@ -75,16 +75,16 @@ public:
     void setSubheader(nitf::DESubheader & value);
 
     //! Get the offset
-    nitf::Uint64 getOffset() const;
+    uint64_t getOffset() const;
 
     //! Set the offset
-    void setOffset(nitf::Uint64 value);
+    void setOffset(uint64_t value);
 
     //! Get the end
-    nitf::Uint64 getEnd() const;
+    uint64_t getEnd() const;
 
     //! Set the end
-    void setEnd(nitf::Uint64 value);
+    void setEnd(uint64_t value);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/DESubheader.hpp
+++ b/modules/c++/nitf/include/nitf/DESubheader.hpp
@@ -98,10 +98,10 @@ public:
     void setSubheaderFields(nitf::TRE fields);
 
     //! Get the dataLength
-    nitf::Uint32 getDataLength() const;
+    uint32_t getDataLength() const;
 
     //! Set the dataLength
-    void setDataLength(nitf::Uint32 value);
+    void setDataLength(uint32_t value);
 
     //! Get the userDefinedSection
     nitf::Extensions getUserDefinedSection();

--- a/modules/c++/nitf/include/nitf/DecompressionInterface.hpp
+++ b/modules/c++/nitf/include/nitf/DecompressionInterface.hpp
@@ -93,19 +93,19 @@ public:
     //  and call the nitf_DecompressionControl of your choice
     static NITF_BOOL adapterStart(nitf_DecompressionControl* object,
                                   nitf_IOInterface* io,
-                                  nitf_Uint64 offset,
-                                  nitf_Uint64 fileLength,
+                                  uint64_t offset,
+                                  uint64_t fileLength,
                                   nitf_BlockingInfo* blockingDefinition,
-                                  nitf_Uint64* blockMask, 
+                                  uint64_t* blockMask, 
                                   nitf_Error* error);
 
-    static nitf_Uint8* adapterReadBlock(nitf_DecompressionControl* object,
-                                        nitf_Uint32 blockNumber, 
-                                        nitf_Uint64* blockSize, 
+    static uint8_t* adapterReadBlock(nitf_DecompressionControl* object,
+                                        uint32_t blockNumber, 
+                                        uint64_t* blockSize, 
                                         nitf_Error* error);
 
     static NITF_BOOL adapterFreeBlock(nitf_DecompressionControl* object,
-                                      nitf_Uint8* block, 
+                                      uint8_t* block, 
                                       nitf_Error* error);
 
     static void adapterDestroy(nitf_DecompressionControl** object);
@@ -128,7 +128,7 @@ public:
                        nitf::BlockingInfo& blockingDefinition,
                        nitf::Uint64* blockMask) = 0;
 
-    virtual nitf_Uint8* readBlock(nitf::Uint32 blockNumber, 
+    virtual uint8_t* readBlock(nitf::Uint32 blockNumber, 
                                   nitf::Uint64* blockSize) = 0;
 
     virtual void freeBlock(nitf::Uint8* block) = 0;

--- a/modules/c++/nitf/include/nitf/DecompressionInterface.hpp
+++ b/modules/c++/nitf/include/nitf/DecompressionInterface.hpp
@@ -123,15 +123,15 @@ public:
     virtual ~Decompressor() {}
 
     virtual void start(nitf::IOInterface& io,
-                       nitf::Uint64 offset,
-                       nitf::Uint64 fileLength,
+                       uint64_t offset,
+                       uint64_t fileLength,
                        nitf::BlockingInfo& blockingDefinition,
-                       nitf::Uint64* blockMask) = 0;
+                       uint64_t* blockMask) = 0;
 
-    virtual uint8_t* readBlock(nitf::Uint32 blockNumber, 
-                                  nitf::Uint64* blockSize) = 0;
+    virtual uint8_t* readBlock(uint32_t blockNumber, 
+                                  uint64_t* blockSize) = 0;
 
-    virtual void freeBlock(nitf::Uint8* block) = 0;
+    virtual void freeBlock(uint8_t* block) = 0;
 };
 
 }

--- a/modules/c++/nitf/include/nitf/DownSampler.hpp
+++ b/modules/c++/nitf/include/nitf/DownSampler.hpp
@@ -97,19 +97,19 @@ public:
      */
     virtual void apply(NITF_DATA ** inputWindow,
                        NITF_DATA ** outputWindow,
-                       nitf::Uint32 numBands,
-                       nitf::Uint32 numWindowRows,
-                       nitf::Uint32 numWindowCols,
-                       nitf::Uint32 numInputCols,
-                       nitf::Uint32 numSubWindowCols,
-                       nitf::Uint32 pixelType,
-                       nitf::Uint32 pixelSize,
-                       nitf::Uint32 rowsInLastWindow,
-                       nitf::Uint32 colsInLastWindow);
+                       uint32_t numBands,
+                       uint32_t numWindowRows,
+                       uint32_t numWindowCols,
+                       uint32_t numInputCols,
+                       uint32_t numSubWindowCols,
+                       uint32_t pixelType,
+                       uint32_t pixelSize,
+                       uint32_t rowsInLastWindow,
+                       uint32_t colsInLastWindow);
 
-    nitf::Uint32 getRowSkip();
+    uint32_t getRowSkip();
 
-    nitf::Uint32 getColSkip();
+    uint32_t getColSkip();
 
 protected:
 
@@ -141,8 +141,8 @@ public:
      *  \param rowSkip  The number of rows to skip
      *  \param colSkip  The number of columns to skip
      */
-    PixelSkip(nitf::Uint32 rowSkip,
-              nitf::Uint32 colSkip);
+    PixelSkip(uint32_t rowSkip,
+              uint32_t colSkip);
 
     //! Destructor
     ~PixelSkip();
@@ -171,8 +171,8 @@ public:
      *  \param rowSkip  The number of rows to skip
      *  \param colSkip  The number of columns to skip
      */
-    MaxDownSample(nitf::Uint32 rowSkip,
-                  nitf::Uint32 colSkip);
+    MaxDownSample(uint32_t rowSkip,
+                  uint32_t colSkip);
     //! Destructor
     ~MaxDownSample();
 };
@@ -197,8 +197,8 @@ public:
      *  \param rowSkip  The number of rows to skip
      *  \param colSkip  The number of cols to skip
      */
-    SumSq2DownSample(nitf::Uint32 rowSkip,
-                     nitf::Uint32 colSkip);
+    SumSq2DownSample(uint32_t rowSkip,
+                     uint32_t colSkip);
     //! Destructor
     ~SumSq2DownSample();
 };
@@ -222,8 +222,8 @@ public:
      *  \param rowSkip  The number of rows to skip
      *  \param colSkip  The number of cols to skip
      */
-    Select2DownSample(nitf::Uint32 rowSkip,
-                      nitf::Uint32 colSkip);
+    Select2DownSample(uint32_t rowSkip,
+                      uint32_t colSkip);
     //! Destructor
     ~Select2DownSample();
 };

--- a/modules/c++/nitf/include/nitf/Extensions.hpp
+++ b/modules/c++/nitf/include/nitf/Extensions.hpp
@@ -318,7 +318,7 @@ typedef nitf::ExtensionsIterator Iterator;
         return nitf::ExtensionsIterator(x);
     }
 
-    nitf::Uint64 computeLength(nitf::Version version)
+    uint64_t computeLength(nitf::Version version)
     {
         return nitf_Extensions_computeLength(getNative(), version, &error);
     }

--- a/modules/c++/nitf/include/nitf/Field.hpp
+++ b/modules/c++/nitf/include/nitf/Field.hpp
@@ -102,49 +102,49 @@ enum FieldType
         return *this;
     }
 
-    Field & operator=(nitf::Int8 value)
+    Field & operator=(int8_t value)
     {
         set(value);
         return *this;
     }
 
-    Field & operator=(nitf::Int16 value)
+    Field & operator=(int16_t value)
     {
         set(value);
         return *this;
     }
 
-    Field & operator=(nitf::Int32 value)
+    Field & operator=(int32_t value)
     {
         set(value);
         return *this;
     }
 
-    Field & operator=(nitf::Int64 value)
+    Field & operator=(int64_t value)
     {
         set(value);
         return *this;
     }
 
-    Field & operator=(nitf::Uint8 value)
+    Field & operator=(uint8_t value)
     {
         set(value);
         return *this;
     }
 
-    Field & operator=(nitf::Uint16 value)
+    Field & operator=(uint16_t value)
     {
         set(value);
         return *this;
     }
 
-    Field & operator=(nitf::Uint32 value)
+    Field & operator=(uint32_t value)
     {
         set(value);
         return *this;
     }
 
-    Field & operator=(nitf::Uint64 value)
+    Field & operator=(uint64_t value)
     {
         set(value);
         return *this;
@@ -199,59 +199,59 @@ enum FieldType
     //! Destructor
     ~Field() {}
 
-    void set(nitf::Uint8 data)
+    void set(uint8_t data)
     {
         if (!nitf_Field_setUint32(getNativeOrThrow(),
-                                  nitf::Uint32(data), &error))
+                                  uint32_t(data), &error))
             throw nitf::NITFException(&error);
     }
 
-    void set(nitf::Uint16 data)
+    void set(uint16_t data)
     {
         if (!nitf_Field_setUint32(getNativeOrThrow(),
-                                  nitf::Uint32(data), &error))
+                                  uint32_t(data), &error))
             throw nitf::NITFException(&error);
     }
 
-    void set(nitf::Uint32 data)
+    void set(uint32_t data)
     {
         NITF_BOOL x = nitf_Field_setUint32(getNativeOrThrow(), data, &error);
         if (!x)
             throw nitf::NITFException(&error);
     }
 
-    void set(nitf::Uint64 data)
+    void set(uint64_t data)
     {
         NITF_BOOL x = nitf_Field_setUint64(getNativeOrThrow(), data, &error);
         if (!x)
             throw nitf::NITFException(&error);
     }
 
-    void set(nitf::Int8 data)
+    void set(int8_t data)
     {
         if (!nitf_Field_setInt32(getNativeOrThrow(),
-                                 nitf::Uint32(data), &error))
+                                 uint32_t(data), &error))
             throw nitf::NITFException(&error);
     }
 
-    void set(nitf::Int16 data)
+    void set(int16_t data)
     {
         if (!nitf_Field_setInt32(getNativeOrThrow(),
-                                 nitf::Uint32(data), &error))
+                                 uint32_t(data), &error))
             throw nitf::NITFException(&error);
     }
 
-    void set(nitf::Int32 data)
+    void set(int32_t data)
     {
         if (!nitf_Field_setInt32(getNativeOrThrow(),
-                                 nitf::Uint32(data), &error))
+                                 uint32_t(data), &error))
             throw nitf::NITFException(&error);
     }
 
-    void set(nitf::Int64 data)
+    void set(int64_t data)
     {
         if (!nitf_Field_setInt64(getNativeOrThrow(),
-                                 nitf::Uint32(data), &error))
+                                 uint32_t(data), &error))
             throw nitf::NITFException(&error);
     }
 

--- a/modules/c++/nitf/include/nitf/GraphicSegment.hpp
+++ b/modules/c++/nitf/include/nitf/GraphicSegment.hpp
@@ -73,16 +73,16 @@ public:
     void setSubheader(nitf::GraphicSubheader & value);
 
     //! Get the offset
-    nitf::Uint64 getOffset() const;
+    uint64_t getOffset() const;
 
     //! Set the offset
-    void setOffset(nitf::Uint64 value);
+    void setOffset(uint64_t value);
 
     //! Get the end
-    nitf::Uint64 getEnd() const;
+    uint64_t getEnd() const;
 
     //! Set the end
-    void setEnd(nitf::Uint64 value);
+    void setEnd(uint64_t value);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/ImageReader.hpp
+++ b/modules/c++/nitf/include/nitf/ImageReader.hpp
@@ -63,7 +63,7 @@ public:
      *  \param  user  User-defined data buffers for read
      *  \param  padded  Returns TRUE if pad pixels may have been read
      */
-    void read(nitf::SubWindow & subWindow, nitf::Uint8 ** user, int * padded);
+    void read(nitf::SubWindow & subWindow, uint8_t ** user, int * padded);
 
     /*!
      *  Read a block directly from file
@@ -72,8 +72,8 @@ public:
      *  \return The read block 
      *          (something must be done with buffer before next call)
      */
-    const nitf::Uint8* readBlock(nitf::Uint32 blockNumber, 
-                                 nitf::Uint64* blockSize);
+    const uint8_t* readBlock(uint32_t blockNumber, 
+                                 uint64_t* blockSize);
 
     //!  Set read caching
     void setReadCaching();

--- a/modules/c++/nitf/include/nitf/ImageSegment.hpp
+++ b/modules/c++/nitf/include/nitf/ImageSegment.hpp
@@ -73,16 +73,16 @@ public:
     void setSubheader(nitf::ImageSubheader & value);
 
     //! Get the imageOffset
-    nitf::Uint64 getImageOffset() const;
+    uint64_t getImageOffset() const;
 
     //! Set the imageOffset
-    void setImageOffset(nitf::Uint64 value);
+    void setImageOffset(uint64_t value);
 
     //! Get the imageEnd
-    nitf::Uint64 getImageEnd() const;
+    uint64_t getImageEnd() const;
 
     //! Set the imageEnd
-    void setImageEnd(nitf::Uint64 value);
+    void setImageEnd(uint64_t value);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/ImageSegmentComputer.h
+++ b/modules/c++/nitf/include/nitf/ImageSegmentComputer.h
@@ -55,7 +55,7 @@ public:
      * Max number of bytes for an image segment's data (per the NITF spec -
      * this is due to the length field only being 10 digits)
      */
-    static const Uint64 NUM_BYTES_MAX;
+    static const uint64_t NUM_BYTES_MAX;
 
     /*!
      * \class Segment
@@ -169,7 +169,7 @@ public:
                          size_t numCols,
                          size_t numBytesPerPixel,
                          size_t maxRows = ILOC_MAX,
-                         Uint64 maxSize = NUM_BYTES_MAX,
+                         uint64_t maxSize = NUM_BYTES_MAX,
                          size_t rowsPerBlock = 0,
                          size_t colsPerBlock = 0);
 
@@ -180,7 +180,7 @@ public:
     }
 
     //! \return Number of total bytes in the image
-    Uint64 getNumBytesTotal() const
+    uint64_t getNumBytesTotal() const
     {
         return mNumBytesTotal;
     }
@@ -192,7 +192,7 @@ public:
     }
 
     //! \return Max number of bytes that each image segment can be
-    Uint64 getMaxNumBytesPerSegment() const
+    uint64_t getMaxNumBytesPerSegment() const
     {
         return mMaxNumBytesPerSegment;
     }
@@ -227,10 +227,10 @@ private:
     const size_t mNumRowsPerBlock;
 
     //! Total size in bytes that each product seg can be
-    const Uint64 mMaxNumBytesPerSegment;
+    const uint64_t mMaxNumBytesPerSegment;
 
     //! Number of bytes in the product
-    const Uint64 mNumBytesTotal;
+    const uint64_t mNumBytesTotal;
 
     //! Segment layout
     std::vector<Segment> mSegments;

--- a/modules/c++/nitf/include/nitf/ImageSubheader.hpp
+++ b/modules/c++/nitf/include/nitf/ImageSubheader.hpp
@@ -82,8 +82,8 @@ public:
      *  \param bands  Band information object list
      */
     void setPixelInformation(std::string pvtype,
-                             nitf::Uint32 nbpp,
-                             nitf::Uint32 abpp,
+                             uint32_t nbpp,
+                             uint32_t abpp,
                              std::string justification,
                              std::string irep, std::string icat,
                              std::vector<nitf::BandInfo>& bands);
@@ -149,10 +149,10 @@ public:
      * \param numColsPerBlock   The number of columns/block
      * \param imode             Image mode
      */
-    void setBlocking(nitf::Uint32 numRows,
-                     nitf::Uint32 numCols,
-                     nitf::Uint32 numRowsPerBlock,
-                     nitf::Uint32 numColsPerBlock,
+    void setBlocking(uint32_t numRows,
+                     uint32_t numCols,
+                     uint32_t numRowsPerBlock,
+                     uint32_t numColsPerBlock,
                      const std::string& imode);
 
     /*!
@@ -176,12 +176,12 @@ public:
      * \param numBlocksPerRow   The number of columns of blocks
      */
     static
-    void computeBlocking(nitf::Uint32 numRows,
-                         nitf::Uint32 numCols,
-                         nitf::Uint32& numRowsPerBlock,
-                         nitf::Uint32& numColsPerBlock,
-                         nitf::Uint32& numBlocksPerCol,
-                         nitf::Uint32& numBlocksPerRow);
+    void computeBlocking(uint32_t numRows,
+                         uint32_t numCols,
+                         uint32_t& numRowsPerBlock,
+                         uint32_t& numColsPerBlock,
+                         uint32_t& numBlocksPerCol,
+                         uint32_t& numBlocksPerRow);
 
     /*!
      * Set the image dimensions and blocking.
@@ -196,13 +196,13 @@ public:
      * \param numRows           The number of rows
      * \param numCols           The number of columns
      */
-    void setDimensions(nitf::Uint32 numRows, nitf::Uint32 numCols);
+    void setDimensions(uint32_t numRows, uint32_t numCols);
 
     //! Get the number of bands
-    nitf::Uint32 getBandCount();
+    uint32_t getBandCount();
 
     //! Create new bands
-    void createBands(nitf::Uint32 numBands);
+    void createBands(uint32_t numBands);
 
     //! Insert the given comment at the given index (zero-indexed);
     int insertImageComment(std::string comment, int index);
@@ -286,7 +286,7 @@ public:
     nitf::Field getNumMultispectralImageBands();
 
     //! Get the bandInfo
-    nitf::BandInfo getBandInfo(nitf::Uint32 band);
+    nitf::BandInfo getBandInfo(uint32_t band);
 
     //! Get the imageSyncCode
     nitf::Field getImageSyncCode();

--- a/modules/c++/nitf/include/nitf/ImageWriter.hpp
+++ b/modules/c++/nitf/include/nitf/ImageWriter.hpp
@@ -75,7 +75,7 @@ public:
      *  For example, if you wanted transparent pixels for fill, you would
      *  set this function using arguments (0, 1)
      */
-    void setPadPixel(nitf::Uint8* value, nitf::Uint32 length);
+    void setPadPixel(uint8_t* value, uint32_t length);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/LabelSegment.hpp
+++ b/modules/c++/nitf/include/nitf/LabelSegment.hpp
@@ -71,16 +71,16 @@ public:
     void setSubheader(nitf::LabelSubheader & value);
 
     //! Get the offset
-    nitf::Uint64 getOffset() const;
+    uint64_t getOffset() const;
 
     //! Set the offset
-    void setOffset(nitf::Uint64 value);
+    void setOffset(uint64_t value);
 
     //! Get the end
-    nitf::Uint64 getEnd() const;
+    uint64_t getEnd() const;
 
     //! Set the end
-    void setEnd(nitf::Uint64 value);
+    void setEnd(uint64_t value);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/RESegment.hpp
+++ b/modules/c++/nitf/include/nitf/RESegment.hpp
@@ -71,16 +71,16 @@ public:
     void setSubheader(nitf::RESubheader & value);
 
     //! Get the offset
-    nitf::Uint64 getOffset() const;
+    uint64_t getOffset() const;
 
     //! Set the offset
-    void setOffset(nitf::Uint64 value);
+    void setOffset(uint64_t value);
 
     //! Get the end
-    nitf::Uint64 getEnd() const;
+    uint64_t getEnd() const;
 
     //! Set the end
-    void setEnd(nitf::Uint64 value);
+    void setEnd(uint64_t value);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/RESubheader.hpp
+++ b/modules/c++/nitf/include/nitf/RESubheader.hpp
@@ -88,10 +88,10 @@ public:
     char * getSubheaderFields() const;
 
     //! Get the dataLength
-    nitf::Uint64 getDataLength() const;
+    uint64_t getDataLength() const;
 
     //! Set the dataLength
-    void setDataLength(nitf::Uint32 value);
+    void setDataLength(uint32_t value);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/Record.hpp
+++ b/modules/c++/nitf/include/nitf/Record.hpp
@@ -81,12 +81,12 @@ public:
     //! Set the header
     void setHeader(nitf::FileHeader & value);
 
-    nitf::Uint32 getNumImages() const;
-    nitf::Uint32 getNumGraphics() const;
-    nitf::Uint32 getNumLabels() const;
-    nitf::Uint32 getNumTexts() const;
-    nitf::Uint32 getNumDataExtensions() const;
-    nitf::Uint32 getNumReservedExtensions() const;
+    uint32_t getNumImages() const;
+    uint32_t getNumGraphics() const;
+    uint32_t getNumLabels() const;
+    uint32_t getNumTexts() const;
+    uint32_t getNumDataExtensions() const;
+    uint32_t getNumReservedExtensions() const;
 
     //! Get the images
     nitf::List getImages();
@@ -120,40 +120,40 @@ public:
     nitf::DESegment newDataExtensionSegment(int index = -1);
 
     //! Remove the image segment at the given index
-    void removeImageSegment(nitf::Uint32 index);
+    void removeImageSegment(uint32_t index);
 
     //! Remove the graphic segment at the given index
-    void removeGraphicSegment(nitf::Uint32 index);
+    void removeGraphicSegment(uint32_t index);
 
     //! Remove the text segment at the given index
-    void removeTextSegment(nitf::Uint32 index);
+    void removeTextSegment(uint32_t index);
 
     //! Remove the label segment at the given index
-    void removeLabelSegment(nitf::Uint32 index);
+    void removeLabelSegment(uint32_t index);
 
     //! Remove the DE segment at the given index
-    void removeDataExtensionSegment(nitf::Uint32 index);
+    void removeDataExtensionSegment(uint32_t index);
 
     //! Remove the RE segment at the given index
-    void removeReservedExtensionSegment(nitf::Uint32 index);
+    void removeReservedExtensionSegment(uint32_t index);
 
     //! Move the image segment from the oldIndex to the newIndex
-    void moveImageSegment(nitf::Uint32 oldIndex, int newIndex = -1);
+    void moveImageSegment(uint32_t oldIndex, int newIndex = -1);
 
     //! Move the text segment from the oldIndex to the newIndex
-    void moveTextSegment(nitf::Uint32 oldIndex, int newIndex = -1);
+    void moveTextSegment(uint32_t oldIndex, int newIndex = -1);
 
     //! Move the graphic segment from the oldIndex to the newIndex
-    void moveGraphicSegment(nitf::Uint32 oldIndex, int newIndex = -1);
+    void moveGraphicSegment(uint32_t oldIndex, int newIndex = -1);
 
     //! Move the label segment from the oldIndex to the newIndex
-    void moveLabelSegment(nitf::Uint32 oldIndex, int newIndex = -1);
+    void moveLabelSegment(uint32_t oldIndex, int newIndex = -1);
 
     //! Move the DE segment from the oldIndex to the newIndex
-    void moveDataExtensionSegment(nitf::Uint32 oldIndex, int newIndex = -1);
+    void moveDataExtensionSegment(uint32_t oldIndex, int newIndex = -1);
 
     //! Move the RE segment from the oldIndex to the newIndex
-    void moveReservedExtensionSegment(nitf::Uint32 oldIndex, int newIndex = -1);
+    void moveReservedExtensionSegment(uint32_t oldIndex, int newIndex = -1);
 
     /*!
      * If the CLEVEL field in this object is not set, computes the complexity

--- a/modules/c++/nitf/include/nitf/SubWindow.hpp
+++ b/modules/c++/nitf/include/nitf/SubWindow.hpp
@@ -73,19 +73,19 @@ public:
     //! Destructor
     ~SubWindow();
 
-    nitf::Uint32 getStartRow() const;
-    nitf::Uint32 getNumRows() const;
-    nitf::Uint32 getStartCol() const;
-    nitf::Uint32 getNumCols() const;
-    nitf::Uint32 getBandList(int i);
-    nitf::Uint32 getNumBands() const;
+    uint32_t getStartRow() const;
+    uint32_t getNumRows() const;
+    uint32_t getStartCol() const;
+    uint32_t getNumCols() const;
+    uint32_t getBandList(int i);
+    uint32_t getNumBands() const;
 
-    void setStartRow(nitf::Uint32 value);
-    void setNumRows(nitf::Uint32 value);
-    void setStartCol(nitf::Uint32 value);
-    void setNumCols(nitf::Uint32 value);
-    void setBandList(nitf::Uint32 * value);
-    void setNumBands(nitf::Uint32 value);
+    void setStartRow(uint32_t value);
+    void setNumRows(uint32_t value);
+    void setStartCol(uint32_t value);
+    void setNumCols(uint32_t value);
+    void setBandList(uint32_t * value);
+    void setNumBands(uint32_t value);
 
     /*!
      * Reference a DownSampler within the SubWindow

--- a/modules/c++/nitf/include/nitf/System.hpp
+++ b/modules/c++/nitf/include/nitf/System.hpp
@@ -33,14 +33,14 @@
 
 namespace nitf
 {
-typedef nitf_Uint64 Uint64;
-typedef nitf_Uint32 Uint32;
-typedef nitf_Uint16 Uint16;
-typedef nitf_Uint8 Uint8;
-typedef nitf_Int64 Int64;
-typedef nitf_Int32 Int32;
-typedef nitf_Int16 Int16;
-typedef nitf_Int8 Int8;
+typedef uint64_t Uint64;
+typedef uint32_t Uint32;
+typedef uint16_t Uint16;
+typedef uint8_t Uint8;
+typedef int64_t Int64;
+typedef int32_t Int32;
+typedef int16_t Int16;
+typedef int8_t Int8;
 typedef nitf_Off Off;
 typedef nitf_Version Version;
 typedef nitf_ConvType ConvType;

--- a/modules/c++/nitf/include/nitf/System.hpp
+++ b/modules/c++/nitf/include/nitf/System.hpp
@@ -22,10 +22,13 @@
 
 #ifndef __NITF_SYSTEM_HPP__
 #define __NITF_SYSTEM_HPP__
+#pragma once
 
 /*!
  *  \file System.hpp
  */
+
+#include <stdint.h>
 
 #include "nitf/System.h"
 #include "nitf/Field.h"
@@ -33,6 +36,17 @@
 
 namespace nitf
 {
+	// Keeping these here so that code using "nitf::Uint64" still compiles;
+	// we can't make others change to "uint64_t".
+	using Uint64 = uint64_t;
+	using Uint32 = uint32_t;
+	using Uint16 = uint16_t;
+	using Uint8 = uint8_t;
+	using Int64 = int64_t;
+	using Int32 = int32_t;
+	using Int16 = int16_t;
+	using Int8 = int8_t;
+
 typedef nitf_Off Off;
 typedef nitf_Version Version;
 typedef nitf_ConvType ConvType;

--- a/modules/c++/nitf/include/nitf/System.hpp
+++ b/modules/c++/nitf/include/nitf/System.hpp
@@ -33,14 +33,6 @@
 
 namespace nitf
 {
-typedef uint64_t Uint64;
-typedef uint32_t Uint32;
-typedef uint16_t Uint16;
-typedef uint8_t Uint8;
-typedef int64_t Int64;
-typedef int32_t Int32;
-typedef int16_t Int16;
-typedef int8_t Int8;
 typedef nitf_Off Off;
 typedef nitf_Version Version;
 typedef nitf_ConvType ConvType;

--- a/modules/c++/nitf/include/nitf/TextSegment.hpp
+++ b/modules/c++/nitf/include/nitf/TextSegment.hpp
@@ -73,16 +73,16 @@ public:
     void setSubheader(nitf::TextSubheader & value);
 
     //! Get the offset
-    nitf::Uint64 getOffset() const;
+    uint64_t getOffset() const;
 
     //! Set the offset
-    void setOffset(nitf::Uint64 value);
+    void setOffset(uint64_t value);
 
     //! Get the end
-    nitf::Uint64 getEnd() const;
+    uint64_t getEnd() const;
 
     //! Set the end
-    void setEnd(nitf::Uint64 value);
+    void setEnd(uint64_t value);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/include/nitf/WriteHandler.hpp
+++ b/modules/c++/nitf/include/nitf/WriteHandler.hpp
@@ -96,8 +96,8 @@ class StreamIOWriteHandler : public WriteHandler
 {
 public:
     //! Constructor
-    StreamIOWriteHandler(IOInterface& sourceHandle, nitf::Uint64 offset,
-            nitf::Uint64 bytes);
+    StreamIOWriteHandler(IOInterface& sourceHandle, uint64_t offset,
+            uint64_t bytes);
     ~StreamIOWriteHandler()
     {
     }

--- a/modules/c++/nitf/include/nitf/Writer.hpp
+++ b/modules/c++/nitf/include/nitf/Writer.hpp
@@ -202,7 +202,7 @@ public:
      * \param hdrLen Output parameter providing the total number of bytes the
      *     file header is on disk
      */
-    void writeHeader(nitf::Off& fileLenOff, nitf::Uint32& hdrLen);
+    void writeHeader(nitf::Off& fileLenOff, uint32_t& hdrLen);
 
     /*!
      * Writes out an image subheader.  No seeking is performed so the underlying
@@ -229,7 +229,7 @@ public:
      * \param version NITF file version to write (you probably want NITF_VER_21)
      */
     void writeDESubheader(nitf::DESubheader subheader,
-                          nitf::Uint32& userSublen,
+                          uint32_t& userSublen,
                           nitf::Version version);
 
     /*!
@@ -241,10 +241,10 @@ public:
      * \param fillDir Fill direction (NITF_WRITER_FILL_LEFT or
      *     NITF_WRITER_FILL_RIGHT)
      */
-    void writeInt64Field(nitf::Uint64 field,
-                         nitf::Uint32 length,
+    void writeInt64Field(uint64_t field,
+                         uint32_t length,
                          char fill,
-                         nitf::Uint32 fillDir);
+                         uint32_t fillDir);
 
 private:
     nitf_Error error;

--- a/modules/c++/nitf/source/BandInfo.cpp
+++ b/modules/c++/nitf/source/BandInfo.cpp
@@ -97,8 +97,8 @@ void BandInfo::init(const std::string& representation,
                     const std::string& subcategory,
                     const std::string& imageFilterCondition,
                     const std::string& imageFilterCode,
-                    nitf::Uint32 numLUTs,
-                    nitf::Uint32 bandEntriesPerLUT,
+                    uint32_t numLUTs,
+                    uint32_t bandEntriesPerLUT,
                     nitf::LookupTable& lut)
 {
     if (getNativeOrThrow()->lut)

--- a/modules/c++/nitf/source/BandSource.cpp
+++ b/modules/c++/nitf/source/BandSource.cpp
@@ -75,7 +75,7 @@ nitf::RowSource::RowSource(
 }
 
 NITF_BOOL nitf::RowSource::nextRow(void* algorithm,
-                                   nitf_Uint32 band,
+                                   uint32_t band,
                                    NITF_DATA* buffer,
                                    nitf_Error* error)
 {
@@ -132,8 +132,8 @@ nitf::DirectBlockSource::DirectBlockSource(nitf::ImageReader& imageReader, nitf:
 NITF_BOOL nitf::DirectBlockSource::nextBlock(void* callback,
                                              void* buf,
                                              const void* block,
-                                             nitf_Uint32 blockNumber,
-                                             nitf_Uint64 blockSize,
+                                             uint32_t blockNumber,
+                                             uint64_t blockSize,
                                              nitf_Error * error)
 {
     nitf::DirectBlockSource* const cb =

--- a/modules/c++/nitf/source/BandSource.cpp
+++ b/modules/c++/nitf/source/BandSource.cpp
@@ -55,10 +55,10 @@ nitf::FileSource::FileSource(const std::string& fname,
 }
 
 nitf::RowSource::RowSource(
-    nitf::Uint32 band,
-    nitf::Uint32 numRows,
-    nitf::Uint32 numCols,
-    nitf::Uint32 pixelSize,
+    uint32_t band,
+    uint32_t numRows,
+    uint32_t numCols,
+    uint32_t pixelSize,
     nitf::RowSourceCallback *callback)
     : mBand(band),
       mNumRows(numRows),
@@ -120,7 +120,7 @@ NITF_BOOL nitf::RowSource::nextRow(void* algorithm,
     return NITF_SUCCESS;
 }
 
-nitf::DirectBlockSource::DirectBlockSource(nitf::ImageReader& imageReader, nitf::Uint32 numBands)
+nitf::DirectBlockSource::DirectBlockSource(nitf::ImageReader& imageReader, uint32_t numBands)
 {
     setNative(nitf_DirectBlockSource_construct(this,
                                                &DirectBlockSource::nextBlock, 

--- a/modules/c++/nitf/source/BlockingInfo.cpp
+++ b/modules/c++/nitf/source/BlockingInfo.cpp
@@ -52,42 +52,42 @@ BlockingInfo::BlockingInfo()
 BlockingInfo::~BlockingInfo(){}
 
 
-nitf::Uint32 BlockingInfo::getNumBlocksPerRow() const
+uint32_t BlockingInfo::getNumBlocksPerRow() const
 {
     return getNativeOrThrow()->numBlocksPerRow;
 }
 
-void BlockingInfo::setNumBlocksPerRow(nitf::Uint32 value)
+void BlockingInfo::setNumBlocksPerRow(uint32_t value)
 {
     getNativeOrThrow()->numBlocksPerRow = value;
 }
 
-nitf::Uint32 BlockingInfo::getNumBlocksPerCol() const
+uint32_t BlockingInfo::getNumBlocksPerCol() const
 {
     return getNativeOrThrow()->numBlocksPerCol;
 }
 
-void BlockingInfo::setNumBlocksPerCol(nitf::Uint32 value)
+void BlockingInfo::setNumBlocksPerCol(uint32_t value)
 {
     getNativeOrThrow()->numBlocksPerCol = value;
 }
 
-nitf::Uint32 BlockingInfo::getNumRowsPerBlock() const
+uint32_t BlockingInfo::getNumRowsPerBlock() const
 {
     return getNativeOrThrow()->numRowsPerBlock;
 }
 
-void BlockingInfo::setNumRowsPerBlock(nitf::Uint32 value)
+void BlockingInfo::setNumRowsPerBlock(uint32_t value)
 {
     getNativeOrThrow()->numRowsPerBlock = value;
 }
 
-nitf::Uint32 BlockingInfo::getNumColsPerBlock() const
+uint32_t BlockingInfo::getNumColsPerBlock() const
 {
     return getNativeOrThrow()->numColsPerBlock;
 }
 
-void BlockingInfo::setNumColsPerBlock(nitf::Uint32 value)
+void BlockingInfo::setNumColsPerBlock(uint32_t value)
 {
     getNativeOrThrow()->numColsPerBlock = value;
 }

--- a/modules/c++/nitf/source/ByteProvider.cpp
+++ b/modules/c++/nitf/source/ByteProvider.cpp
@@ -232,7 +232,7 @@ void ByteProvider::getFileLayout(nitf::Record& inRecord,
     {
         nitf::DESegment deSegment = record.getDataExtensions()[ii];
         nitf::DESubheader subheader = deSegment.getSubheader();
-        nitf::Uint32 userSublen;
+        uint32_t userSublen;
         const size_t prevSize = byteStream->getSize();
         writer.writeDESubheader(subheader, userSublen, record.getVersion());
         desSubheaderLengths[ii] = byteStream->getSize() - prevSize;

--- a/modules/c++/nitf/source/ByteProvider.cpp
+++ b/modules/c++/nitf/source/ByteProvider.cpp
@@ -252,7 +252,7 @@ void ByteProvider::getFileLayout(nitf::Record& inRecord,
     // This initial write won't set a number of the lengths, so we'll seek
     // around to set those ourselves
     nitf_Off fileLenOff;
-    nitf_Uint32 hdrLen;
+    uint32_t hdrLen;
     record.setComplexityLevelIfUnset();
     writer.writeHeader(fileLenOff, hdrLen);
     const nitf::Off fileHeaderNumBytes = byteStream->getSize();

--- a/modules/c++/nitf/source/ComponentInfo.cpp
+++ b/modules/c++/nitf/source/ComponentInfo.cpp
@@ -42,7 +42,7 @@ ComponentInfo::ComponentInfo(nitf_ComponentInfo * x)
     getNativeOrThrow();
 }
 
-ComponentInfo::ComponentInfo(nitf::Uint32 subHeaderSize, nitf::Uint64 dataSize)
+ComponentInfo::ComponentInfo(uint32_t subHeaderSize, uint64_t dataSize)
 {
     setNative(nitf_ComponentInfo_construct(subHeaderSize, dataSize, &error));
     getNativeOrThrow();

--- a/modules/c++/nitf/source/CompressionInterface.cpp
+++ b/modules/c++/nitf/source/CompressionInterface.cpp
@@ -26,10 +26,10 @@ using namespace nitf;
 
 NITF_BOOL CompressionInterface::adapterStart(
     nitf_CompressionControl* object,
-    nitf_Uint64 offset,
-    nitf_Uint64 dataLength,
-    nitf_Uint64* blockMask,
-    nitf_Uint64* padMask, 
+    uint64_t offset,
+    uint64_t dataLength,
+    uint64_t* blockMask,
+    uint64_t* padMask, 
     nitf_Error* error)
 {
     try
@@ -63,7 +63,7 @@ NITF_BOOL CompressionInterface::adapterStart(
 NITF_BOOL CompressionInterface::adapterWriteBlock(
     nitf_CompressionControl* object, 
     nitf_IOInterface* io,
-    const nitf_Uint8* data,
+    const uint8_t* data,
     NITF_BOOL pad,
     NITF_BOOL noData,
     nitf_Error* error)

--- a/modules/c++/nitf/source/DESegment.cpp
+++ b/modules/c++/nitf/source/DESegment.cpp
@@ -87,22 +87,22 @@ void DESegment::setSubheader(nitf::DESubheader & value)
     value.setManaged(true);
 }
 
-nitf::Uint64 DESegment::getOffset() const
+uint64_t DESegment::getOffset() const
 {
     return getNativeOrThrow()->offset;
 }
 
-void DESegment::setOffset(nitf::Uint64 value)
+void DESegment::setOffset(uint64_t value)
 {
     getNativeOrThrow()->offset = value;
 }
 
-nitf::Uint64 DESegment::getEnd() const
+uint64_t DESegment::getEnd() const
 {
     return getNativeOrThrow()->end;
 }
 
-void DESegment::setEnd(nitf::Uint64 value)
+void DESegment::setEnd(uint64_t value)
 {
     getNativeOrThrow()->end = value;
 }

--- a/modules/c++/nitf/source/DESubheader.cpp
+++ b/modules/c++/nitf/source/DESubheader.cpp
@@ -129,12 +129,12 @@ void DESubheader::setSubheaderFields(nitf::TRE fields)
     fields.setManaged(true);
 }
 
-nitf::Uint32 DESubheader::getDataLength() const
+uint32_t DESubheader::getDataLength() const
 {
     return getNativeOrThrow()->dataLength;
 }
 
-void DESubheader::setDataLength(nitf::Uint32 value)
+void DESubheader::setDataLength(uint32_t value)
 {
     getNativeOrThrow()->dataLength = value;
 }

--- a/modules/c++/nitf/source/DecompressionInterface.cpp
+++ b/modules/c++/nitf/source/DecompressionInterface.cpp
@@ -28,10 +28,10 @@ using namespace nitf;
 NITF_BOOL DecompressionInterface::adapterStart(
     nitf_DecompressionControl* object,
     nitf_IOInterface* io,
-    nitf_Uint64 offset,
-    nitf_Uint64 fileLength,
+    uint64_t offset,
+    uint64_t fileLength,
     nitf_BlockingInfo* blockingDefinition,
-    nitf_Uint64* blockMask, 
+    uint64_t* blockMask, 
     nitf_Error* error)
 {
     try
@@ -67,10 +67,10 @@ NITF_BOOL DecompressionInterface::adapterStart(
     }
 }
 
-nitf_Uint8* DecompressionInterface::adapterReadBlock(
+uint8_t* DecompressionInterface::adapterReadBlock(
     nitf_DecompressionControl* object,
-    nitf_Uint32 blockNumber, 
-    nitf_Uint64* blockSize, 
+    uint32_t blockNumber, 
+    uint64_t* blockSize, 
     nitf_Error* error)
 {
     try
@@ -100,7 +100,7 @@ nitf_Uint8* DecompressionInterface::adapterReadBlock(
 
 NITF_BOOL DecompressionInterface::adapterFreeBlock(
     nitf_DecompressionControl* object,
-    nitf_Uint8* block, 
+    uint8_t* block, 
     nitf_Error* error)
 {
     try

--- a/modules/c++/nitf/source/DownSampler.cpp
+++ b/modules/c++/nitf/source/DownSampler.cpp
@@ -22,22 +22,22 @@
 
 #include "nitf/DownSampler.hpp"
 
-nitf::Uint32 nitf::DownSampler::getRowSkip()
+uint32_t nitf::DownSampler::getRowSkip()
 {
     return getNativeOrThrow()->rowSkip;
 }
 
-nitf::Uint32 nitf::DownSampler::getColSkip()
+uint32_t nitf::DownSampler::getColSkip()
 {
     return getNativeOrThrow()->colSkip;
 }
 
 void nitf::DownSampler::apply(NITF_DATA ** inputWindow,
-        NITF_DATA ** outputWindow, nitf::Uint32 numBands,
-        nitf::Uint32 numWindowRows, nitf::Uint32 numWindowCols,
-        nitf::Uint32 numInputCols, nitf::Uint32 numSubWindowCols,
-        nitf::Uint32 pixelType, nitf::Uint32 pixelSize,
-        nitf::Uint32 rowsInLastWindow, nitf::Uint32 colsInLastWindow)
+        NITF_DATA ** outputWindow, uint32_t numBands,
+        uint32_t numWindowRows, uint32_t numWindowCols,
+        uint32_t numInputCols, uint32_t numSubWindowCols,
+        uint32_t pixelType, uint32_t pixelSize,
+        uint32_t rowsInLastWindow, uint32_t colsInLastWindow)
 {
     nitf_DownSampler *ds = getNativeOrThrow();
     if (ds && ds->iface)
@@ -54,7 +54,7 @@ void nitf::DownSampler::apply(NITF_DATA ** inputWindow,
     }
 }
 
-nitf::PixelSkip::PixelSkip(nitf::Uint32 rowSkip, nitf::Uint32 colSkip)
+nitf::PixelSkip::PixelSkip(uint32_t rowSkip, uint32_t colSkip)
 {
     setNative(nitf_PixelSkip_construct(rowSkip, colSkip, &error));
     setManaged(false);
@@ -64,7 +64,7 @@ nitf::PixelSkip::~PixelSkip()
 {
 }
 
-nitf::MaxDownSample::MaxDownSample(nitf::Uint32 rowSkip, nitf::Uint32 colSkip)
+nitf::MaxDownSample::MaxDownSample(uint32_t rowSkip, uint32_t colSkip)
 {
     setNative(nitf_MaxDownSample_construct(rowSkip, colSkip, &error));
     setManaged(false);
@@ -74,8 +74,8 @@ nitf::MaxDownSample::~MaxDownSample()
 {
 }
 
-nitf::SumSq2DownSample::SumSq2DownSample(nitf::Uint32 rowSkip,
-        nitf::Uint32 colSkip)
+nitf::SumSq2DownSample::SumSq2DownSample(uint32_t rowSkip,
+        uint32_t colSkip)
 {
     setNative(nitf_SumSq2DownSample_construct(rowSkip, colSkip, &error));
     setManaged(false);
@@ -85,8 +85,8 @@ nitf::SumSq2DownSample::~SumSq2DownSample()
 {
 }
 
-nitf::Select2DownSample::Select2DownSample(nitf::Uint32 rowSkip,
-        nitf::Uint32 colSkip)
+nitf::Select2DownSample::Select2DownSample(uint32_t rowSkip,
+        uint32_t colSkip)
 {
     setNative(nitf_Select2DownSample_construct(rowSkip, colSkip, &error));
     setManaged(false);

--- a/modules/c++/nitf/source/GraphicSegment.cpp
+++ b/modules/c++/nitf/source/GraphicSegment.cpp
@@ -91,22 +91,22 @@ void GraphicSegment::setSubheader(nitf::GraphicSubheader & value)
     value.setManaged(true);
 }
 
-nitf::Uint64 GraphicSegment::getOffset() const
+uint64_t GraphicSegment::getOffset() const
 {
     return getNativeOrThrow()->offset;
 }
 
-void GraphicSegment::setOffset(nitf::Uint64 value)
+void GraphicSegment::setOffset(uint64_t value)
 {
     getNativeOrThrow()->offset = value;
 }
 
-nitf::Uint64 GraphicSegment::getEnd() const
+uint64_t GraphicSegment::getEnd() const
 {
     return getNativeOrThrow()->end;
 }
 
-void GraphicSegment::setEnd(nitf::Uint64 value)
+void GraphicSegment::setEnd(uint64_t value)
 {
     getNativeOrThrow()->end = value;
 }

--- a/modules/c++/nitf/source/ImageReader.cpp
+++ b/modules/c++/nitf/source/ImageReader.cpp
@@ -55,16 +55,16 @@ nitf::BlockingInfo ImageReader::getBlockingInfo()
     return cppBlockingInfo;
 }
 
-void ImageReader::read(nitf::SubWindow & subWindow, nitf::Uint8 ** user, int * padded)
+void ImageReader::read(nitf::SubWindow & subWindow, uint8_t ** user, int * padded)
 {
     NITF_BOOL x = nitf_ImageReader_read(getNativeOrThrow(), subWindow.getNative(), user, padded, &error);
     if (!x)
         throw nitf::NITFException(&error);
 }
 
-const nitf::Uint8* ImageReader::readBlock(nitf::Uint32 blockNumber, nitf::Uint64* blockSize)
+const uint8_t* ImageReader::readBlock(uint32_t blockNumber, uint64_t* blockSize)
 {
-    const nitf::Uint8* x = nitf_ImageReader_readBlock(
+    const uint8_t* x = nitf_ImageReader_readBlock(
         getNativeOrThrow(), blockNumber, blockSize, &error);
     if (!x)
         throw nitf::NITFException(&error);

--- a/modules/c++/nitf/source/ImageSegment.cpp
+++ b/modules/c++/nitf/source/ImageSegment.cpp
@@ -90,22 +90,22 @@ void ImageSegment::setSubheader(nitf::ImageSubheader & value)
     value.setManaged(true);
 }
 
-nitf::Uint64 ImageSegment::getImageOffset() const
+uint64_t ImageSegment::getImageOffset() const
 {
     return getNativeOrThrow()->imageOffset;
 }
 
-void ImageSegment::setImageOffset(nitf::Uint64 value)
+void ImageSegment::setImageOffset(uint64_t value)
 {
     getNativeOrThrow()->imageOffset = value;
 }
 
-nitf::Uint64 ImageSegment::getImageEnd() const
+uint64_t ImageSegment::getImageEnd() const
 {
     return getNativeOrThrow()->imageEnd;
 }
 
-void ImageSegment::setImageEnd(nitf::Uint64 value)
+void ImageSegment::setImageEnd(uint64_t value)
 {
     getNativeOrThrow()->imageEnd = value;
 }

--- a/modules/c++/nitf/source/ImageSegmentComputer.cpp
+++ b/modules/c++/nitf/source/ImageSegmentComputer.cpp
@@ -32,7 +32,7 @@
 namespace nitf
 {
 const size_t ImageSegmentComputer::ILOC_MAX = 99999;
-const Uint64 ImageSegmentComputer::NUM_BYTES_MAX = 9999999998LL;
+const uint64_t ImageSegmentComputer::NUM_BYTES_MAX = 9999999998LL;
 
 std::string ImageSegmentComputer::Segment::getILOC() const
 {
@@ -85,7 +85,7 @@ ImageSegmentComputer::ImageSegmentComputer(size_t numRows,
                                            size_t numCols,
                                            size_t numBytesPerPixel,
                                            size_t maxRows,
-                                           Uint64 maxSize,
+                                           uint64_t maxSize,
                                            size_t rowsPerBlock,
                                            size_t colsPerBlock) :
     mNumRows(numRows),
@@ -95,7 +95,7 @@ ImageSegmentComputer::ImageSegmentComputer(size_t numRows,
     mNumColsPaddedForBlocking(getActualDim(mNumCols, colsPerBlock)),
     mNumRowsPerBlock(rowsPerBlock),
     mMaxNumBytesPerSegment(maxSize),
-    mNumBytesTotal(static_cast<Uint64>(mNumBytesPerPixel) *
+    mNumBytesTotal(static_cast<uint64_t>(mNumBytesPerPixel) *
                  getActualDim(mNumRows, rowsPerBlock) *
                  mNumColsPaddedForBlocking)
 {
@@ -140,12 +140,12 @@ size_t ImageSegmentComputer::getActualDim(size_t dim, size_t numDimsPerBlock)
 void ImageSegmentComputer::computeImageInfo()
 {
     // Consider possible blocking when determining the maximum number of rows
-    const Uint64 bytesPerRow =
-            static_cast<Uint64>(mNumBytesPerPixel) *
+    const uint64_t bytesPerRow =
+            static_cast<uint64_t>(mNumBytesPerPixel) *
             mNumColsPaddedForBlocking;
 
-    const Uint64 maxRowsUint64 =
-            static_cast<Uint64>(mMaxNumBytesPerSegment) / bytesPerRow;
+    const uint64_t maxRowsUint64 =
+            static_cast<uint64_t>(mMaxNumBytesPerSegment) / bytesPerRow;
     if (maxRowsUint64 > std::numeric_limits<size_t>::max())
     {
         // This should not be possible

--- a/modules/c++/nitf/source/ImageSubheader.cpp
+++ b/modules/c++/nitf/source/ImageSubheader.cpp
@@ -65,8 +65,8 @@ ImageSubheader::~ImageSubheader(){}
 
 
 void ImageSubheader::setPixelInformation(std::string pvtype,
-                         nitf::Uint32 nbpp,
-                         nitf::Uint32 abpp,
+                         uint32_t nbpp,
+                         uint32_t abpp,
                          std::string justification,
                          std::string irep, std::string icat,
                          std::vector<nitf::BandInfo>& bands)
@@ -88,15 +88,15 @@ void ImageSubheader::setPixelInformation(std::string pvtype,
 
     NITF_BOOL x = nitf_ImageSubheader_setPixelInformation(getNativeOrThrow(),
         pvtype.c_str(), nbpp, abpp, justification.c_str(), irep.c_str(),
-        icat.c_str(), static_cast<nitf::Uint32>(bandCount), bandInfo, &error);
+        icat.c_str(), static_cast<uint32_t>(bandCount), bandInfo, &error);
     if (!x)
         throw nitf::NITFException(&error);
 }
 
-void ImageSubheader::setBlocking(nitf::Uint32 numRows,
-                     nitf::Uint32 numCols,
-                     nitf::Uint32 numRowsPerBlock,
-                     nitf::Uint32 numColsPerBlock,
+void ImageSubheader::setBlocking(uint32_t numRows,
+                     uint32_t numCols,
+                     uint32_t numRowsPerBlock,
+                     uint32_t numColsPerBlock,
                      const std::string& imode)
 {
     NITF_BOOL x = nitf_ImageSubheader_setBlocking(getNativeOrThrow(),
@@ -106,12 +106,12 @@ void ImageSubheader::setBlocking(nitf::Uint32 numRows,
         throw nitf::NITFException(&error);
 }
 
-void ImageSubheader::computeBlocking(nitf::Uint32 numRows,
-                                     nitf::Uint32 numCols,
-                                     nitf::Uint32& numRowsPerBlock,
-                                     nitf::Uint32& numColsPerBlock,
-                                     nitf::Uint32& numBlocksPerCol,
-                                     nitf::Uint32& numBlocksPerRow)
+void ImageSubheader::computeBlocking(uint32_t numRows,
+                                     uint32_t numCols,
+                                     uint32_t& numRowsPerBlock,
+                                     uint32_t& numColsPerBlock,
+                                     uint32_t& numBlocksPerCol,
+                                     uint32_t& numBlocksPerRow)
 {
     nitf_ImageSubheader_computeBlocking(numRows,
                                         numCols,
@@ -121,7 +121,7 @@ void ImageSubheader::computeBlocking(nitf::Uint32 numRows,
                                         &numBlocksPerRow);
 }
 
-void ImageSubheader::setDimensions(nitf::Uint32 numRows, nitf::Uint32 numCols)
+void ImageSubheader::setDimensions(uint32_t numRows, uint32_t numCols)
 {
     NITF_BOOL x = nitf_ImageSubheader_setDimensions(getNativeOrThrow(),
         numRows, numCols, &error);
@@ -129,15 +129,15 @@ void ImageSubheader::setDimensions(nitf::Uint32 numRows, nitf::Uint32 numCols)
         throw nitf::NITFException(&error);
 }
 
-nitf::Uint32 ImageSubheader::getBandCount()
+uint32_t ImageSubheader::getBandCount()
 {
-    nitf::Uint32 x = nitf_ImageSubheader_getBandCount(getNativeOrThrow(), &error);
+    uint32_t x = nitf_ImageSubheader_getBandCount(getNativeOrThrow(), &error);
     if (x == NITF_INVALID_BAND_COUNT)
         throw nitf::NITFException(&error);
     return x;
 }
 
-void ImageSubheader::createBands(nitf::Uint32 numBands)
+void ImageSubheader::createBands(uint32_t numBands)
 {
     if (!nitf_ImageSubheader_createBands(getNativeOrThrow(), numBands, &error))
         throw nitf::NITFException(&error);
@@ -321,7 +321,7 @@ nitf::Field ImageSubheader::getNumMultispectralImageBands()
     return nitf::Field(getNativeOrThrow()->numMultispectralImageBands);
 }
 
-nitf::BandInfo ImageSubheader::getBandInfo(nitf::Uint32 band)
+nitf::BandInfo ImageSubheader::getBandInfo(uint32_t band)
 {
     return nitf::BandInfo(nitf_ImageSubheader_getBandInfo(
         getNativeOrThrow(), band, &error));

--- a/modules/c++/nitf/source/ImageWriter.cpp
+++ b/modules/c++/nitf/source/ImageWriter.cpp
@@ -61,7 +61,7 @@ void ImageWriter::setDirectBlockWrite(int enable)
     }
 }
 
-void ImageWriter::setPadPixel(nitf::Uint8* value, nitf::Uint32 length)
+void ImageWriter::setPadPixel(uint8_t* value, uint32_t length)
 {
     if (!nitf_ImageWriter_setPadPixel(
                 getNativeOrThrow(), value, length, &error))

--- a/modules/c++/nitf/source/LabelSegment.cpp
+++ b/modules/c++/nitf/source/LabelSegment.cpp
@@ -89,22 +89,22 @@ void LabelSegment::setSubheader(nitf::LabelSubheader & value)
     value.setManaged(true);
 }
 
-nitf::Uint64 LabelSegment::getOffset() const
+uint64_t LabelSegment::getOffset() const
 {
     return getNativeOrThrow()->offset;
 }
 
-void LabelSegment::setOffset(nitf::Uint64 value)
+void LabelSegment::setOffset(uint64_t value)
 {
     getNativeOrThrow()->offset = value;
 }
 
-nitf::Uint64 LabelSegment::getEnd() const
+uint64_t LabelSegment::getEnd() const
 {
     return getNativeOrThrow()->end;
 }
 
-void LabelSegment::setEnd(nitf::Uint64 value)
+void LabelSegment::setEnd(uint64_t value)
 {
     getNativeOrThrow()->end = value;
 }

--- a/modules/c++/nitf/source/RESegment.cpp
+++ b/modules/c++/nitf/source/RESegment.cpp
@@ -88,22 +88,22 @@ void RESegment::setSubheader(nitf::RESubheader & value)
     value.setManaged(true);
 }
 
-nitf::Uint64 RESegment::getOffset() const
+uint64_t RESegment::getOffset() const
 {
     return getNativeOrThrow()->offset;
 }
 
-void RESegment::setOffset(nitf::Uint64 value)
+void RESegment::setOffset(uint64_t value)
 {
     getNativeOrThrow()->offset = value;
 }
 
-nitf::Uint64 RESegment::getEnd() const
+uint64_t RESegment::getEnd() const
 {
     return getNativeOrThrow()->end;
 }
 
-void RESegment::setEnd(nitf::Uint64 value)
+void RESegment::setEnd(uint64_t value)
 {
     getNativeOrThrow()->end = value;
 }

--- a/modules/c++/nitf/source/RESubheader.cpp
+++ b/modules/c++/nitf/source/RESubheader.cpp
@@ -107,12 +107,12 @@ char * RESubheader::getSubheaderFields() const
     return getNativeOrThrow()->subheaderFields;
 }
 
-nitf::Uint64 RESubheader::getDataLength() const
+uint64_t RESubheader::getDataLength() const
 {
     return getNativeOrThrow()->dataLength;
 }
 
-void RESubheader::setDataLength(nitf::Uint32 value)
+void RESubheader::setDataLength(uint32_t value)
 {
     getNativeOrThrow()->dataLength = value;
 }

--- a/modules/c++/nitf/source/Record.cpp
+++ b/modules/c++/nitf/source/Record.cpp
@@ -84,9 +84,9 @@ void Record::setHeader(nitf::FileHeader & value)
     value.setManaged(true);
 }
 
-nitf::Uint32 Record::getNumImages() const
+uint32_t Record::getNumImages() const
 {
-    nitf::Uint32 num = nitf_Record_getNumImages(getNativeOrThrow(), &error);
+    uint32_t num = nitf_Record_getNumImages(getNativeOrThrow(), &error);
     
     if (NITF_INVALID_NUM_SEGMENTS( num ))
         throw nitf::NITFException(&error);
@@ -94,10 +94,10 @@ nitf::Uint32 Record::getNumImages() const
     return num;
 }
     
-nitf::Uint32 Record::getNumGraphics() const
+uint32_t Record::getNumGraphics() const
 {
 
-    nitf::Uint32 num = nitf_Record_getNumGraphics(getNativeOrThrow(), &error);
+    uint32_t num = nitf_Record_getNumGraphics(getNativeOrThrow(), &error);
 
     if (NITF_INVALID_NUM_SEGMENTS( num ))
         throw nitf::NITFException(&error);
@@ -105,10 +105,10 @@ nitf::Uint32 Record::getNumGraphics() const
     return num;
 }
 
-nitf::Uint32 Record::getNumLabels() const
+uint32_t Record::getNumLabels() const
 {
 
-    nitf::Uint32 num = nitf_Record_getNumLabels(getNativeOrThrow(), &error);
+    uint32_t num = nitf_Record_getNumLabels(getNativeOrThrow(), &error);
 
     if (NITF_INVALID_NUM_SEGMENTS( num ))
         throw nitf::NITFException(&error);
@@ -116,9 +116,9 @@ nitf::Uint32 Record::getNumLabels() const
     return num;
 }
 
-nitf::Uint32 Record::getNumTexts() const
+uint32_t Record::getNumTexts() const
 {
-    nitf::Uint32 num = nitf_Record_getNumTexts(getNativeOrThrow(), &error);
+    uint32_t num = nitf_Record_getNumTexts(getNativeOrThrow(), &error);
 
     if (NITF_INVALID_NUM_SEGMENTS( num ))
         throw nitf::NITFException(&error);
@@ -126,9 +126,9 @@ nitf::Uint32 Record::getNumTexts() const
     return num;
 }
 
-nitf::Uint32 Record::getNumDataExtensions() const
+uint32_t Record::getNumDataExtensions() const
 {
-    nitf::Uint32 num = nitf_Record_getNumDataExtensions(getNativeOrThrow(), 
+    uint32_t num = nitf_Record_getNumDataExtensions(getNativeOrThrow(), 
                                                         &error);
 
     if (NITF_INVALID_NUM_SEGMENTS( num ))
@@ -137,9 +137,9 @@ nitf::Uint32 Record::getNumDataExtensions() const
     return num;
 }
 
-nitf::Uint32 Record::getNumReservedExtensions() const
+uint32_t Record::getNumReservedExtensions() const
 {
-    nitf::Uint32 num = nitf_Record_getNumReservedExtensions(getNativeOrThrow(), 
+    uint32_t num = nitf_Record_getNumReservedExtensions(getNativeOrThrow(), 
                                                             &error);
 
     if (NITF_INVALID_NUM_SEGMENTS( num ))
@@ -219,78 +219,78 @@ nitf::DESegment Record::newDataExtensionSegment(int index)
     return nitf::DESegment(x);
 }
 
-void Record::removeImageSegment(nitf::Uint32 segmentNumber)
+void Record::removeImageSegment(uint32_t segmentNumber)
 {
     if (NITF_SUCCESS != nitf_Record_removeImageSegment(getNativeOrThrow(), segmentNumber, &error))
         throw nitf::NITFException(&error);
 }
 
-void Record::removeGraphicSegment(nitf::Uint32 segmentNumber)
+void Record::removeGraphicSegment(uint32_t segmentNumber)
 {
     if (NITF_SUCCESS != nitf_Record_removeGraphicSegment(getNativeOrThrow(), segmentNumber, &error))
         throw nitf::NITFException(&error);
 }
 
-void Record::removeTextSegment(nitf::Uint32 segmentNumber)
+void Record::removeTextSegment(uint32_t segmentNumber)
 {
     if (NITF_SUCCESS != nitf_Record_removeTextSegment(getNativeOrThrow(), segmentNumber, &error))
         throw nitf::NITFException(&error);
 }
 
-void Record::removeLabelSegment(nitf::Uint32 segmentNumber)
+void Record::removeLabelSegment(uint32_t segmentNumber)
 {
     if (NITF_SUCCESS != nitf_Record_removeLabelSegment(getNativeOrThrow(), segmentNumber, &error))
         throw nitf::NITFException(&error);
 }
 
-void Record::removeDataExtensionSegment(nitf::Uint32 segmentNumber)
+void Record::removeDataExtensionSegment(uint32_t segmentNumber)
 {
     if (NITF_SUCCESS != nitf_Record_removeDataExtensionSegment(getNativeOrThrow(), segmentNumber, &error))
         throw nitf::NITFException(&error);
 }
 
-void Record::removeReservedExtensionSegment(nitf::Uint32 segmentNumber)
+void Record::removeReservedExtensionSegment(uint32_t segmentNumber)
 {
     if (NITF_SUCCESS != nitf_Record_removeReservedExtensionSegment(getNativeOrThrow(), segmentNumber, &error))
         throw nitf::NITFException(&error);
 }
 
-void Record::moveImageSegment(nitf::Uint32 oldIndex, int newIndex)
+void Record::moveImageSegment(uint32_t oldIndex, int newIndex)
 {
     if (NITF_SUCCESS != nitf_Record_moveImageSegment(getNativeOrThrow(),
         oldIndex, newIndex, &error))
         throw nitf::NITFException(&error);
 }
 
-void Record::moveTextSegment(nitf::Uint32 oldIndex, int newIndex)
+void Record::moveTextSegment(uint32_t oldIndex, int newIndex)
 {
     if (NITF_SUCCESS != nitf_Record_moveTextSegment(getNativeOrThrow(),
         oldIndex, newIndex, &error))
         throw nitf::NITFException(&error);
 }
 
-void Record::moveGraphicSegment(nitf::Uint32 oldIndex, int newIndex)
+void Record::moveGraphicSegment(uint32_t oldIndex, int newIndex)
 {
     if (NITF_SUCCESS != nitf_Record_moveGraphicSegment(getNativeOrThrow(),
         oldIndex, newIndex, &error))
         throw nitf::NITFException(&error);
 }
 
-void Record::moveDataExtensionSegment(nitf::Uint32 oldIndex, int newIndex)
+void Record::moveDataExtensionSegment(uint32_t oldIndex, int newIndex)
 {
     if (NITF_SUCCESS != nitf_Record_moveDataExtensionSegment(getNativeOrThrow(),
         oldIndex, newIndex, &error))
         throw nitf::NITFException(&error);
 }
 
-void Record::moveLabelSegment(nitf::Uint32 oldIndex, int newIndex)
+void Record::moveLabelSegment(uint32_t oldIndex, int newIndex)
 {
     if (NITF_SUCCESS != nitf_Record_moveLabelSegment(getNativeOrThrow(),
         oldIndex, newIndex, &error))
         throw nitf::NITFException(&error);
 }
 
-void Record::moveReservedExtensionSegment(nitf::Uint32 oldIndex, int newIndex)
+void Record::moveReservedExtensionSegment(uint32_t oldIndex, int newIndex)
 {
     if (NITF_SUCCESS != nitf_Record_moveReservedExtensionSegment(getNativeOrThrow(),
         oldIndex, newIndex, &error))

--- a/modules/c++/nitf/source/SubWindow.cpp
+++ b/modules/c++/nitf/source/SubWindow.cpp
@@ -106,7 +106,7 @@ nitf::Uint32 SubWindow::getBandList(int i)
 
 void SubWindow::setBandList(nitf::Uint32 * value)
 {
-    getNativeOrThrow()->bandList = (nitf_Uint32*)value;
+    getNativeOrThrow()->bandList = (uint32_t*)value;
 }
 
 nitf::Uint32 SubWindow::getNumBands() const

--- a/modules/c++/nitf/source/SubWindow.cpp
+++ b/modules/c++/nitf/source/SubWindow.cpp
@@ -59,62 +59,62 @@ SubWindow::~SubWindow()
     }
 }
 
-nitf::Uint32 SubWindow::getStartRow() const
+uint32_t SubWindow::getStartRow() const
 {
     return getNativeOrThrow()->startRow;
 }
 
-void SubWindow::setStartRow(nitf::Uint32 value)
+void SubWindow::setStartRow(uint32_t value)
 {
     getNativeOrThrow()->startRow = value;
 }
 
-nitf::Uint32 SubWindow::getNumRows() const
+uint32_t SubWindow::getNumRows() const
 {
     return getNativeOrThrow()->numRows;
 }
 
-void SubWindow::setNumRows(nitf::Uint32 value)
+void SubWindow::setNumRows(uint32_t value)
 {
     getNativeOrThrow()->numRows = value;
 }
 
-nitf::Uint32 SubWindow::getStartCol() const
+uint32_t SubWindow::getStartCol() const
 {
     return getNativeOrThrow()->startCol;
 }
 
-void SubWindow::setStartCol(nitf::Uint32 value)
+void SubWindow::setStartCol(uint32_t value)
 {
     getNativeOrThrow()->startCol = value;
 }
 
-nitf::Uint32 SubWindow::getNumCols() const
+uint32_t SubWindow::getNumCols() const
 {
     return getNativeOrThrow()->numCols;
 }
 
-void SubWindow::setNumCols(nitf::Uint32 value)
+void SubWindow::setNumCols(uint32_t value)
 {
     getNativeOrThrow()->numCols = value;
 }
 
-nitf::Uint32 SubWindow::getBandList(int i)
+uint32_t SubWindow::getBandList(int i)
 {
     return getNativeOrThrow()->bandList[i];
 }
 
-void SubWindow::setBandList(nitf::Uint32 * value)
+void SubWindow::setBandList(uint32_t * value)
 {
     getNativeOrThrow()->bandList = (uint32_t*)value;
 }
 
-nitf::Uint32 SubWindow::getNumBands() const
+uint32_t SubWindow::getNumBands() const
 {
     return getNativeOrThrow()->numBands;
 }
 
-void SubWindow::setNumBands(nitf::Uint32 value)
+void SubWindow::setNumBands(uint32_t value)
 {
     getNativeOrThrow()->numBands = value;
 }

--- a/modules/c++/nitf/source/TextSegment.cpp
+++ b/modules/c++/nitf/source/TextSegment.cpp
@@ -88,22 +88,22 @@ void TextSegment::setSubheader(nitf::TextSubheader & value)
     value.setManaged(true);
 }
 
-nitf::Uint64 TextSegment::getOffset() const
+uint64_t TextSegment::getOffset() const
 {
     return getNativeOrThrow()->offset;
 }
 
-void TextSegment::setOffset(nitf::Uint64 value)
+void TextSegment::setOffset(uint64_t value)
 {
     getNativeOrThrow()->offset = value;
 }
 
-nitf::Uint64 TextSegment::getEnd() const
+uint64_t TextSegment::getEnd() const
 {
     return getNativeOrThrow()->end;
 }
 
-void TextSegment::setEnd(nitf::Uint64 value)
+void TextSegment::setEnd(uint64_t value)
 {
     getNativeOrThrow()->end = value;
 }

--- a/modules/c++/nitf/source/WriteHandler.cpp
+++ b/modules/c++/nitf/source/WriteHandler.cpp
@@ -36,8 +36,8 @@ void nitf::WriteHandler::write(nitf::IOInterface& handle)
 }
 
 nitf::StreamIOWriteHandler::StreamIOWriteHandler(
-        nitf::IOInterface& sourceHandle, nitf::Uint64 offset,
-        nitf::Uint64 bytes)
+        nitf::IOInterface& sourceHandle, uint64_t offset,
+        uint64_t bytes)
 {
     setNative(nitf_StreamIOWriteHandler_construct(
             sourceHandle.getNative(), offset, bytes, &error));

--- a/modules/c++/nitf/source/Writer.cpp
+++ b/modules/c++/nitf/source/Writer.cpp
@@ -313,7 +313,7 @@ nitf::List Writer::getWarningList()
     return nitf::List(getNativeOrThrow()->warningList);
 }
 
-void Writer::writeHeader(nitf::Off& fileLenOff, nitf::Uint32& hdrLen)
+void Writer::writeHeader(nitf::Off& fileLenOff, uint32_t& hdrLen)
 {
     if (!nitf_Writer_writeHeader(getNativeOrThrow(),
                                  &fileLenOff,
@@ -339,7 +339,7 @@ void Writer::writeImageSubheader(nitf::ImageSubheader subheader,
 }
 
 void Writer::writeDESubheader(nitf::DESubheader subheader,
-                              nitf::Uint32& userSublen,
+                              uint32_t& userSublen,
                               nitf::Version version)
 {
     if (!nitf_Writer_writeDESubheader(getNativeOrThrow(),
@@ -352,10 +352,10 @@ void Writer::writeDESubheader(nitf::DESubheader subheader,
     }
 }
 
-void Writer::writeInt64Field(nitf::Uint64 field,
-                             nitf::Uint32 length,
+void Writer::writeInt64Field(uint64_t field,
+                             uint32_t length,
                              char fill,
-                             nitf::Uint32 fillDir)
+                             uint32_t fillDir)
 {
     if (!nitf_Writer_writeInt64Field(getNativeOrThrow(),
                                      field,

--- a/modules/c++/nitf/tests/test_buffered_read.cpp
+++ b/modules/c++/nitf/tests/test_buffered_read.cpp
@@ -35,7 +35,7 @@ void doRead(const std::string& inFile,
     nitf::Reader reader;
     nitf::BufferedReader io(inFile, bufferSize);
     nitf::Record record = reader.readIO(io);
-    std::vector<nitf_Uint8> image;
+    std::vector<uint8_t> image;
 
     /*  Set this to the end, so we'll know when we're done!  */
     nitf::List imageList(record.getImages());

--- a/modules/c++/nitf/tests/test_buffered_read.cpp
+++ b/modules/c++/nitf/tests/test_buffered_read.cpp
@@ -54,7 +54,7 @@ void doRead(const std::string& inFile,
         subWindow.setNumRows(subheader.getNumRows());
         subWindow.setNumCols(subheader.getNumCols());
         subWindow.setNumBands(subheader.getBandCount());
-        std::vector<nitf::Uint32> bandList;
+        std::vector<uint32_t> bandList;
         for (size_t ii = 0; ii < subWindow.getNumBands(); ++ii)
         {
             bandList.push_back(ii);
@@ -62,7 +62,7 @@ void doRead(const std::string& inFile,
         subWindow.setBandList(&bandList[0]);
 
         // Read in the image
-        const size_t numBitsPerPixel(static_cast<nitf::Uint64>(subheader.getActualBitsPerPixel()));
+        const size_t numBitsPerPixel(static_cast<uint64_t>(subheader.getActualBitsPerPixel()));
         const size_t numBytesPerPixel = NITF_NBPP_TO_BYTES(numBitsPerPixel);
 
         const size_t numBytesPerBand =
@@ -74,8 +74,8 @@ void doRead(const std::string& inFile,
 
         if (!image.empty())
         {
-            std::vector<nitf::Uint8 *> imagePtrs;
-            nitf::Uint8 *imagePtr(&image[0]);
+            std::vector<uint8_t *> imagePtrs;
+            uint8_t *imagePtr(&image[0]);
             for (size_t ii = 0;
                     ii < subWindow.getNumBands();
                     ++ii, imagePtr += numBytesPerBand)

--- a/modules/c++/nitf/tests/test_buffered_write.cpp
+++ b/modules/c++/nitf/tests/test_buffered_write.cpp
@@ -143,13 +143,13 @@ void manuallyWriteImageBands(nitf::ImageSegment & segment,
     nitf::ImageSubheader subheader = segment.getSubheader();
 
 
-    nitf::Uint32 nBits = subheader.getNumBitsPerPixel();
-    nitf::Uint32 nBands = subheader.getNumImageBands();
-    nitf::Uint32 xBands = subheader.getNumMultispectralImageBands();
+    uint32_t nBits = subheader.getNumBitsPerPixel();
+    uint32_t nBands = subheader.getNumImageBands();
+    uint32_t xBands = subheader.getNumMultispectralImageBands();
     nBands += xBands;
 
-    nitf::Uint32 nRows = subheader.getNumRows();
-    nitf::Uint32 nColumns = subheader.getNumCols();
+    uint32_t nRows = subheader.getNumRows();
+    uint32_t nColumns = subheader.getNumCols();
 
     //one row at a time
     size_t subWindowSize = nColumns * NITF_NBPP_TO_BYTES(nBits);
@@ -170,10 +170,10 @@ void manuallyWriteImageBands(nitf::ImageSegment & segment,
         << "IC -> " << subheader.getImageCompression().toString() << std::endl
         << "COMRAT -> " << subheader.getCompressionRate().toString() << std::endl;
 
-    nitf::Uint8** buffer = new nitf::Uint8*[nBands];
-    nitf::Uint32* bandList = new nitf::Uint32[nBands];
+    uint8_t** buffer = new uint8_t*[nBands];
+    uint32_t* bandList = new uint32_t[nBands];
 
-    for (nitf::Uint32 band = 0; band < nBands; band++)
+    for (uint32_t band = 0; band < nBands; band++)
         bandList[band] = band;
 
     nitf::SubWindow subWindow;
@@ -188,15 +188,15 @@ void manuallyWriteImageBands(nitf::ImageSegment & segment,
     subWindow.setNumBands(nBands);
 
     assert(buffer);
-    for (nitf::Uint32 i = 0; i < nBands; i++)
+    for (uint32_t i = 0; i < nBands; i++)
     {
-        buffer[i] = new nitf::Uint8[subWindowSize];
+        buffer[i] = new uint8_t[subWindowSize];
         assert(buffer[i]);
     }
 
     std::vector<nitf::IOHandle> handles;
     //make the files
-    for (nitf::Uint32 i = 0; i < nBands; i++)
+    for (uint32_t i = 0; i < nBands; i++)
     {
         std::string name = makeBandName(imageName, imageNumber, i);
         nitf::IOHandle toFile(name, NITF_ACCESS_WRITEONLY, NITF_CREATE);
@@ -204,22 +204,22 @@ void manuallyWriteImageBands(nitf::ImageSegment & segment,
     }
 
     //read all row blocks and write to disk
-    for (nitf::Uint32 i = 0; i < nRows; ++i)
+    for (uint32_t i = 0; i < nRows; ++i)
     {
         subWindow.setStartRow(i);
         deserializer.read(subWindow, buffer, &padded);
-        for (nitf::Uint32 j = 0; j < nBands; j++)
+        for (uint32_t j = 0; j < nBands; j++)
         {
             handles[j].write((const char*)buffer[j], subWindowSize);
         }
     }
 
     //close output handles
-    for (nitf::Uint32 i = 0; i < nBands; i++)
+    for (uint32_t i = 0; i < nBands; i++)
         handles[i].close();
 
     /* free buffers */
-    for (nitf::Uint32 i = 0; i < nBands; i++)
+    for (uint32_t i = 0; i < nBands; i++)
         delete [] buffer[i];
     delete [] buffer;
     delete [] bandList;

--- a/modules/c++/nitf/tests/test_create_nitf++.cpp
+++ b/modules/c++/nitf/tests/test_create_nitf++.cpp
@@ -1134,10 +1134,10 @@ bool testRead(const std::string& pathname, bool isMono = false,
     for (size_t ii = 0; ii < record.getNumImages(); ++ii)
     {
         nitf::ImageReader imageReader = reader.newImageReader(ii);
-        nitf::Uint64 blockSize;
+        uint64_t blockSize;
         // Read one block. It should match the first blockSize points of the
         // image. If it does, we got the blocking mode right.
-        const nitf::Uint8 *block = imageReader.readBlock(0, &blockSize);
+        const uint8_t *block = imageReader.readBlock(0, &blockSize);
         const size_t imageLength = NITRO_IMAGE.width * NITRO_IMAGE.height;
 
         // The image data is interleaved by pixel. When feeding it to the

--- a/modules/c++/nitf/tests/test_create_nitf_with_byte_provider.cpp
+++ b/modules/c++/nitf/tests/test_create_nitf_with_byte_provider.cpp
@@ -1146,10 +1146,10 @@ bool testRead(const std::string& pathname)
     for (size_t ii = 0; ii < record.getNumImages(); ++ii)
     {
         nitf::ImageReader imageReader = reader.newImageReader(ii);
-        nitf::Uint64 blockSize;
+        uint64_t blockSize;
         // Read one block. It should match the first blockSize points of the
         // image. If it does, we got the blocking mode right.
-        const nitf::Uint8 *block = imageReader.readBlock(0, &blockSize);
+        const uint8_t *block = imageReader.readBlock(0, &blockSize);
         const size_t imageLength = NITRO_IMAGE.width * NITRO_IMAGE.height;
 
         for (size_t jj = 0; jj < imageLength * NUM_BANDS; ++jj)

--- a/modules/c++/nitf/tests/test_direct_block_round_trip.cpp
+++ b/modules/c++/nitf/tests/test_direct_block_round_trip.cpp
@@ -32,14 +32,14 @@ class TestDirectBlockSource: public nitf::DirectBlockSource
 {
 public:
     TestDirectBlockSource(nitf::ImageReader& imageReader,
-                      nitf::Uint32 numBands)
+                      uint32_t numBands)
         : nitf::DirectBlockSource(imageReader, numBands){}
 
 protected:
     virtual void nextBlock(void* buf,
                            const void* block,
-                           nitf::Uint32 blockNumber,
-                           nitf::Uint64 blockSize)
+                           uint32_t blockNumber,
+                           uint64_t blockSize)
     {
         std::cout << "BLOCK NUMBER: " << blockNumber << " " << blockSize << std::endl;
         if (buf)
@@ -86,17 +86,17 @@ int main(int argc, char **argv)
         writer.prepare(output, record);
 
         nitf::ListIterator iter = record.getImages().begin();
-        nitf::Uint32 num = record.getNumImages();
+        uint32_t num = record.getNumImages();
 
         std::vector<nitf::ImageReader> imageReaders;
         std::vector<nitf::ImageWriter> imageWriters;
         std::map<std::string, void*> writerOptions;
         std::vector<mem::SharedPtr<nitf::DirectBlockSource> > bandSources;
 
-        //nitf::Uint32 numRes = 1;
+        //uint32_t numRes = 1;
         //writerOptions[C8_NUM_RESOLUTIONS_KEY] = &numRes;
 
-        for (nitf::Uint32 i = 0; i < num; i++)
+        for (uint32_t i = 0; i < num; i++)
         {
             //for the images, we'll use a DirectBlockSource for streaming
             nitf::ImageSegment imseg = *iter;
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
         }
 
         num = record.getNumGraphics();
-        for (nitf::Uint32 i = 0; i < num; i++)
+        for (uint32_t i = 0; i < num; i++)
         {
             nitf::SegmentReaderSource readerSource(reader.newGraphicReader(i));
             mem::SharedPtr< ::nitf::WriteHandler> segmentWriter(
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
         }
 
         num = record.getNumTexts();
-        for (nitf::Uint32 i = 0; i < num; i++)
+        for (uint32_t i = 0; i < num; i++)
         {
             nitf::SegmentReaderSource readerSource(reader.newTextReader(i));
             mem::SharedPtr< ::nitf::WriteHandler> segmentWriter(
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
         }
 
         num = record.getNumDataExtensions();
-        for (nitf::Uint32 i = 0; i < num; i++)
+        for (uint32_t i = 0; i < num; i++)
         {
             nitf::SegmentReaderSource readerSource(reader.newDEReader(i));
             mem::SharedPtr< ::nitf::WriteHandler> segmentWriter(

--- a/modules/c++/nitf/tests/test_fhdr_clone++.cpp
+++ b/modules/c++/nitf/tests/test_fhdr_clone++.cpp
@@ -28,7 +28,7 @@
 
 void printHdr(nitf::FileHeader header)
 {
-    nitf::Uint32 i;
+    uint32_t i;
     SHOW( header.getFileHeader().toString() );
     SHOW( header.getFileVersion().toString() );
     SHOW( header.getComplianceLevel().toString() );
@@ -43,39 +43,39 @@ void printHdr(nitf::FileHeader header)
     SHOW( header.getBackgroundColor().toString() );
     SHOW( header.getOriginatorName().toString() );
     SHOW( header.getOriginatorPhone().toString() );
-    SHOWI( (nitf::Uint32)header.getFileLength() );
-    SHOWI( (nitf::Uint32)header.getHeaderLength() );
+    SHOWI( (uint32_t)header.getFileLength() );
+    SHOWI( (uint32_t)header.getHeaderLength() );
 
     printf("The number of IMAGES contained in this file [%d]\n",
            (int)header.getNumImages());
 
-    for (i = 0; i < (nitf::Uint32)header.getNumImages(); i++)
+    for (i = 0; i < (uint32_t)header.getNumImages(); i++)
     {
         printf("\tThe length of IMAGE subheader [%d]: %d bytes\n",
-               i, (nitf::Uint32)header.getImageInfo(i).getLengthSubheader());
+               i, (uint32_t)header.getImageInfo(i).getLengthSubheader());
         printf("\tThe length of the IMAGE data: %d bytes\n",
-               (nitf::Uint32)header.getImageInfo(i).getLengthData());
+               (uint32_t)header.getImageInfo(i).getLengthData());
     }
 
     printf("The number of GRAPHICS contained in this file [%d]\n",
-           (nitf::Uint32)header.getNumGraphics());
+           (uint32_t)header.getNumGraphics());
 
-    for (i = 0; i < (nitf::Uint32)header.getNumGraphics(); i++)
+    for (i = 0; i < (uint32_t)header.getNumGraphics(); i++)
     {
         printf("\tThe length of GRAPHICS subheader [%d]: %d bytes\n",
-               i, (nitf::Uint32)header.getGraphicInfo(i).getLengthSubheader());
+               i, (uint32_t)header.getGraphicInfo(i).getLengthSubheader());
         printf("\tThe length of the GRAPHICS data: %d bytes\n\n",
-               (nitf::Uint32)header.getGraphicInfo(i).getLengthData());
+               (uint32_t)header.getGraphicInfo(i).getLengthData());
     }
     printf("The number of LABELS contained in this file [%d]\n",
-           (nitf::Uint32)header.getNumLabels());
+           (uint32_t)header.getNumLabels());
 
-    assert((nitf::Uint32)header.getNumLabels() == 0);
+    assert((uint32_t)header.getNumLabels() == 0);
 
     printf("The number of TEXTS contained in this file [%d]\n",
-           (nitf::Uint32)header.getNumTexts());
+           (uint32_t)header.getNumTexts());
 
-    for (i = 0; i < (nitf::Uint32)header.getNumTexts(); i++)
+    for (i = 0; i < (uint32_t)header.getNumTexts(); i++)
     {
         printf("\tThe length of TEXT subheader [%d]: %d bytes\n",
                i, (int)header.getTextInfo(i).getLengthSubheader());
@@ -83,31 +83,31 @@ void printHdr(nitf::FileHeader header)
                (int)header.getTextInfo(i).getLengthData());
     }
     printf("The number of DATA EXTENSIONS contained in this file [%d]\n",
-           (nitf::Uint32)header.getNumDataExtensions());
+           (uint32_t)header.getNumDataExtensions());
 
-    for (i = 0; i < (nitf::Uint32)header.getNumDataExtensions(); i++)
+    for (i = 0; i < (uint32_t)header.getNumDataExtensions(); i++)
     {
         printf("\tThe length of DATA EXTENSION subheader [%d]: %d bytes\n",
-               i, (nitf::Uint32)header.getDataExtensionInfo(i).getLengthSubheader());
+               i, (uint32_t)header.getDataExtensionInfo(i).getLengthSubheader());
         printf("\tThe length of the DATA EXTENSION data: %d bytes\n\n",
-               (nitf::Uint32)header.getDataExtensionInfo(i).getLengthData());
+               (uint32_t)header.getDataExtensionInfo(i).getLengthData());
 
     }
     printf("The number of RESERVED EXTENSIONS contained in this file [%d]\n",
-           (nitf::Uint32)header.getNumReservedExtensions());
+           (uint32_t)header.getNumReservedExtensions());
 
-    for (i = 0; i < (nitf::Uint32)header.getNumReservedExtensions(); i++)
+    for (i = 0; i < (uint32_t)header.getNumReservedExtensions(); i++)
     {
         printf("\tThe length of RESERVED EXTENSION subheader [%d]: %d bytes\n",
-               i, (nitf::Uint32)header.getReservedExtensionInfo(i).getLengthSubheader());
+               i, (uint32_t)header.getReservedExtensionInfo(i).getLengthSubheader());
         printf("\tThe length of the RESERVED EXTENSION data: %d bytes\n\n",
-               (nitf::Uint32)header.getReservedExtensionInfo(i).getLengthData());
+               (uint32_t)header.getReservedExtensionInfo(i).getLengthData());
 
     }
 
-    printf("The user-defined header length [%d]\n", (nitf::Uint32)header.getUserDefinedHeaderLength());
+    printf("The user-defined header length [%d]\n", (uint32_t)header.getUserDefinedHeaderLength());
 
-    printf("The extended header length [%d]\n", (nitf::Uint32)header.getExtendedHeaderLength());
+    printf("The extended header length [%d]\n", (uint32_t)header.getExtendedHeaderLength());
 
 }
 

--- a/modules/c++/nitf/tests/test_image_loading++.cpp
+++ b/modules/c++/nitf/tests/test_image_loading++.cpp
@@ -27,8 +27,8 @@ void writeImage(nitf::ImageSegment &segment,
                 nitf::Reader &reader,
                 const int imageNumber,
                 const char *imageName,
-                nitf_Uint32 rowSkipFactor,
-                nitf_Uint32 columnSkipFactor, bool optz)
+                uint32_t rowSkipFactor,
+                uint32_t columnSkipFactor, bool optz)
 {
     size_t subWindowSize;
     nitf::SubWindow subWindow;
@@ -162,8 +162,8 @@ void writeImage(nitf::ImageSegment &segment,
 int main(int argc, char **argv)
 {
     /* Skip factors */
-    nitf_Uint32 rowSkipFactor = 1;
-    nitf_Uint32 columnSkipFactor = 1;
+    uint32_t rowSkipFactor = 1;
+    uint32_t columnSkipFactor = 1;
 
     try
     {

--- a/modules/c++/nitf/tests/test_image_loading++.cpp
+++ b/modules/c++/nitf/tests/test_image_loading++.cpp
@@ -34,24 +34,24 @@ void writeImage(nitf::ImageSegment &segment,
     nitf::SubWindow subWindow;
     unsigned int i;
     int padded;
-    nitf::Uint8** buffer = NULL;
-    nitf::Uint32 band;
-    nitf::Uint32 * bandList;
+    uint8_t** buffer = NULL;
+    uint32_t band;
+    uint32_t * bandList;
 
     nitf::ImageReader deserializer = reader.newImageReader(imageNumber);
 
     // missing skip factor
     nitf::ImageSubheader subheader = segment.getSubheader();
 
-    nitf::Uint32 nBits   = subheader.getNumBitsPerPixel();
+    uint32_t nBits   = subheader.getNumBitsPerPixel();
 
-    nitf::Uint32 nBands  = subheader.getNumImageBands();
-    nitf::Uint32 xBands  = subheader.getNumMultispectralImageBands();
+    uint32_t nBands  = subheader.getNumImageBands();
+    uint32_t xBands  = subheader.getNumMultispectralImageBands();
     nBands += xBands;
 
 
-    nitf::Uint32 nRows   = subheader.getNumRows();
-    nitf::Uint32 nCols   = subheader.getNumCols();
+    uint32_t nRows   = subheader.getNumRows();
+    uint32_t nCols   = subheader.getNumCols();
     subWindowSize = (size_t)(nRows / rowSkipFactor) *
         (size_t)(nCols / columnSkipFactor) *
         (size_t)NITF_NBPP_TO_BYTES(nBits);
@@ -100,11 +100,11 @@ void writeImage(nitf::ImageSegment &segment,
 
     std::cout << "Allocating work buffer..." << std::endl;
 
-    buffer = new nitf::Uint8*[nBands];
+    buffer = new uint8_t*[nBands];
     assert(buffer);
 
     band = 0;
-    bandList = new nitf::Uint32[nBands];
+    bandList = new uint32_t[nBands];
 
     subWindow.setStartCol(0);
     subWindow.setStartRow(0);
@@ -119,7 +119,7 @@ void writeImage(nitf::ImageSegment &segment,
     for (band = 0; band < nBands; band++)
     {
         bandList[band] = band;
-        buffer[band] = new nitf::Uint8[subWindowSize];
+        buffer[band] = new uint8_t[subWindowSize];
         assert(buffer[band]);
     }
     subWindow.setBandList(bandList);

--- a/modules/c++/nitf/tests/test_round_trip.cpp
+++ b/modules/c++/nitf/tests/test_round_trip.cpp
@@ -39,8 +39,8 @@ namespace
 class RowStreamer : public nitf::RowSourceCallback
 {
 public:
-    RowStreamer(nitf::Uint32 band,
-                nitf::Uint32 numCols,
+    RowStreamer(uint32_t band,
+                uint32_t numCols,
                 nitf::ImageReader reader) :
         mReader(reader),
         mBand(band)
@@ -53,17 +53,17 @@ public:
         mWindow.setNumBands(1);
     }
 
-    virtual void nextRow(nitf::Uint32 band, void* buffer)
+    virtual void nextRow(uint32_t band, void* buffer)
     {
         int padded;
-        mReader.read(mWindow, (nitf::Uint8**) &buffer, &padded);
+        mReader.read(mWindow, (uint8_t**) &buffer, &padded);
         mWindow.setStartRow(mWindow.getStartRow() + 1);
     }
 
 private:
     nitf::ImageReader mReader;
     nitf::SubWindow mWindow;
-    nitf::Uint32 mBand;
+    uint32_t mBand;
 };
 
 // RAII for managing a list of RowStreamer's
@@ -78,8 +78,8 @@ public:
         }
     }
 
-    nitf::RowSourceCallback* add(nitf::Uint32 band,
-                                 nitf::Uint32 numCols,
+    nitf::RowSourceCallback* add(uint32_t band,
+                                 uint32_t numCols,
                                  nitf::ImageReader reader)
     {
         std::auto_ptr<RowStreamer>
@@ -126,9 +126,9 @@ int main(int argc, char **argv)
         writer.prepare(output, record);
 
         nitf::ListIterator iter = record.getImages().begin();
-        nitf::Uint32 num = record.getNumImages();
+        uint32_t num = record.getNumImages();
         RowStreamers rowStreamers;
-        for (nitf::Uint32 i = 0; i < num; i++)
+        for (uint32_t i = 0; i < num; i++)
         {
             //for the images, we'll use a RowSource for streaming
             nitf::ImageSegment imseg = *iter;
@@ -136,13 +136,13 @@ int main(int argc, char **argv)
             nitf::ImageReader iReader = reader.newImageReader(i);
             nitf::ImageWriter iWriter = writer.newImageWriter(i);
             nitf::ImageSource iSource;
-            nitf::Uint32 nBands = imseg.getSubheader().getNumImageBands();
-            nitf::Uint32 nRows = imseg.getSubheader().getNumRows();
-            nitf::Uint32 nCols = imseg.getSubheader().getNumCols();
-            nitf::Uint32 pixelSize = NITF_NBPP_TO_BYTES(
+            uint32_t nBands = imseg.getSubheader().getNumImageBands();
+            uint32_t nRows = imseg.getSubheader().getNumRows();
+            uint32_t nCols = imseg.getSubheader().getNumCols();
+            uint32_t pixelSize = NITF_NBPP_TO_BYTES(
                     imseg.getSubheader().getNumBitsPerPixel());
 
-            for (nitf::Uint32 i = 0; i < nBands; i++)
+            for (uint32_t i = 0; i < nBands; i++)
             {
                 nitf::RowSource rowSource(i, nRows, nCols, pixelSize,
                                           rowStreamers.add(i, nCols, iReader));
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
         }
 
         num = record.getNumGraphics();
-        for (nitf::Uint32 i = 0; i < num; i++)
+        for (uint32_t i = 0; i < num; i++)
         {
             nitf::SegmentReaderSource readerSource(reader.newGraphicReader(i));
             mem::SharedPtr< ::nitf::WriteHandler> segmentWriter(
@@ -161,7 +161,7 @@ int main(int argc, char **argv)
         }
 
         num = record.getNumTexts();
-        for (nitf::Uint32 i = 0; i < num; i++)
+        for (uint32_t i = 0; i < num; i++)
         {
             nitf::SegmentReaderSource readerSource(reader.newTextReader(i));
             mem::SharedPtr< ::nitf::WriteHandler> segmentWriter(
@@ -170,7 +170,7 @@ int main(int argc, char **argv)
         }
 
         num = record.getNumDataExtensions();
-        for (nitf::Uint32 i = 0; i < num; i++)
+        for (uint32_t i = 0; i < num; i++)
         {
             nitf::SegmentReaderSource readerSource(reader.newDEReader(i));
             mem::SharedPtr< ::nitf::WriteHandler> segmentWriter(

--- a/modules/c++/nitf/tests/test_writer_3++.cpp
+++ b/modules/c++/nitf/tests/test_writer_3++.cpp
@@ -121,13 +121,13 @@ void manuallyWriteImageBands(nitf::ImageSegment & segment,
     nitf::ImageSubheader subheader = segment.getSubheader();
 
 
-    nitf::Uint32 nBits = subheader.getNumBitsPerPixel();
-    nitf::Uint32 nBands = subheader.getNumImageBands();
-    nitf::Uint32 xBands = subheader.getNumMultispectralImageBands();
+    uint32_t nBits = subheader.getNumBitsPerPixel();
+    uint32_t nBands = subheader.getNumImageBands();
+    uint32_t xBands = subheader.getNumMultispectralImageBands();
     nBands += xBands;
 
-    nitf::Uint32 nRows = subheader.getNumRows();
-    nitf::Uint32 nColumns = subheader.getNumCols();
+    uint32_t nRows = subheader.getNumRows();
+    uint32_t nColumns = subheader.getNumCols();
 
     //one row at a time
     size_t subWindowSize = nColumns * NITF_NBPP_TO_BYTES(nBits);
@@ -148,10 +148,10 @@ void manuallyWriteImageBands(nitf::ImageSegment & segment,
         << "IC -> " << subheader.getImageCompression().toString() << std::endl
         << "COMRAT -> " << subheader.getCompressionRate().toString() << std::endl;
 
-    nitf::Uint8** buffer = new nitf::Uint8*[nBands];
-    nitf::Uint32* bandList = new nitf::Uint32[nBands];
+    uint8_t** buffer = new uint8_t*[nBands];
+    uint32_t* bandList = new uint32_t[nBands];
 
-    for (nitf::Uint32 band = 0; band < nBands; band++)
+    for (uint32_t band = 0; band < nBands; band++)
         bandList[band] = band;
 
     nitf::SubWindow subWindow;
@@ -166,15 +166,15 @@ void manuallyWriteImageBands(nitf::ImageSegment & segment,
     subWindow.setNumBands(nBands);
 
     assert(buffer);
-    for (nitf::Uint32 i = 0; i < nBands; i++)
+    for (uint32_t i = 0; i < nBands; i++)
     {
-        buffer[i] = new nitf::Uint8[subWindowSize];
+        buffer[i] = new uint8_t[subWindowSize];
         assert(buffer[i]);
     }
 
     std::vector<nitf::IOHandle> handles;
     //make the files
-    for (nitf::Uint32 i = 0; i < nBands; i++)
+    for (uint32_t i = 0; i < nBands; i++)
     {
         std::string name = makeBandName(imageName, imageNumber, i);
         nitf::IOHandle toFile(name, NITF_ACCESS_WRITEONLY, NITF_CREATE);
@@ -182,22 +182,22 @@ void manuallyWriteImageBands(nitf::ImageSegment & segment,
     }
 
     //read all row blocks and write to disk
-    for (nitf::Uint32 i = 0; i < nRows; ++i)
+    for (uint32_t i = 0; i < nRows; ++i)
     {
         subWindow.setStartRow(i);
         deserializer.read(subWindow, buffer, &padded);
-        for (nitf::Uint32 j = 0; j < nBands; j++)
+        for (uint32_t j = 0; j < nBands; j++)
         {
             handles[j].write((const char*)buffer[j], subWindowSize);
         }
     }
 
     //close output handles
-    for (nitf::Uint32 i = 0; i < nBands; i++)
+    for (uint32_t i = 0; i < nBands; i++)
         handles[i].close();
 
     /* free buffers */
-    for (nitf::Uint32 i = 0; i < nBands; i++)
+    for (uint32_t i = 0; i < nBands; i++)
         delete [] buffer[i];
     delete [] buffer;
     delete [] bandList;
@@ -215,9 +215,9 @@ nitf::Record doRead(const std::string& inFile)
     nitf::ListIterator iter = record.getImages().begin();
 
 
-    nitf::Uint32 num = record.getNumImages();
+    uint32_t num = record.getNumImages();
 
-    for (nitf::Uint32 i = 0; i < num; i++)
+    for (uint32_t i = 0; i < num; i++)
     {
         nitf::ImageSegment imageSegment = *iter;
         iter++;

--- a/modules/c++/nitf/tests/test_writer_5.cpp
+++ b/modules/c++/nitf/tests/test_writer_5.cpp
@@ -45,7 +45,7 @@ int main(int argc, char **argv)
         nitf::Record record = reader.read(input);
 
         //create a Writer and prepare it for the Record
-        nitf::Uint32 numOfBytes = (nitf::Uint32)record.getHeader().getFileLength();
+        uint32_t numOfBytes = (uint32_t)record.getHeader().getFileLength();
         std::vector<char> outBufVec(numOfBytes);
         char* const outBuf(outBufVec.empty() ? NULL : &outBufVec[0]);
         nitf::MemoryIO memOutput(outBuf, numOfBytes, false);

--- a/modules/c++/nitf/unittests/test_field++.cpp
+++ b/modules/c++/nitf/unittests/test_field++.cpp
@@ -33,23 +33,23 @@ TEST_CASE(testCastOperator)
 
     // Test unsigned values
     field.set(123);
-    const nitf::Uint8 valUint8 = field;
+    const uint8_t valUint8 = field;
     TEST_ASSERT_EQ(valUint8, 123);
 
     field.set(12345);
-    const nitf::Uint16 valUint16 = field;
+    const uint16_t valUint16 = field;
     TEST_ASSERT_EQ(valUint16, 12345);
 
     field.set(1234567890);
-    const nitf::Uint32 valUint32 = field;
+    const uint32_t valUint32 = field;
     TEST_ASSERT_EQ(valUint32, 1234567890);
 #if SIZEOF_SIZE_T == 4
     const size_t valSizeT = field;
     TEST_ASSERT_EQ(valSizeT, 1234567890);
 #endif
 
-    field.set(nitf::Uint64(1234567890987));
-    const nitf::Uint64 valUint64 = field;
+    field.set(uint64_t(1234567890987));
+    const uint64_t valUint64 = field;
     TEST_ASSERT_EQ(valUint64, 1234567890987);
 
 #if SIZEOF_SIZE_T == 8
@@ -59,15 +59,15 @@ TEST_CASE(testCastOperator)
 
     // Test signed values
     field.set(-123);
-    const nitf::Int8 valInt8 = field;
+    const int8_t valInt8 = field;
     TEST_ASSERT_EQ(valInt8, -123);
 
     field.set(-12345);
-    const nitf::Int16 valInt16 = field;
+    const int16_t valInt16 = field;
     TEST_ASSERT_EQ(valInt16, -12345);
 
     field.set(-1234567890);
-    const nitf::Int32 valInt32 = field;
+    const int32_t valInt32 = field;
     TEST_ASSERT_EQ(valInt32, -1234567890);
 #if SIZEOF_SIZE_T == 4
     const size_t valSSizeT = field;
@@ -77,7 +77,7 @@ TEST_CASE(testCastOperator)
     // TODO: I think the %lld isn't working, at least in VS, in
     //       nitf_Field_setInt64(), so need to do this via string
     field.set("-1234567890987");
-    const nitf::Int64 valInt64 = field;
+    const int64_t valInt64 = field;
     TEST_ASSERT_EQ(valInt64, -1234567890987);
 #if SIZEOF_SIZE_T == 8
     const size_t valSSizeT = field;

--- a/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
+++ b/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
@@ -19,9 +19,9 @@
 
 extern "C"{
    NITF_BOOL nitf_ImageIO_getMaskInfo(nitf_ImageIO* nitf,
-                                      nitf_Uint32* imageDataOffset, nitf_Uint32* blockRecordLength,
-                                      nitf_Uint32* padRecordLength, nitf_Uint32* padPixelValueLength,
-                                      nitf_Uint8** padValue, nitf_Uint64** blockMask, nitf_Uint64** padMask);
+                                      uint32_t* imageDataOffset, uint32_t* blockRecordLength,
+                                      uint32_t* padRecordLength, uint32_t* padPixelValueLength,
+                                      uint8_t** padValue, uint64_t** blockMask, uint64_t** padMask);
                      
 }
 const nitf::Int64 BLOCK_LENGTH = 256;
@@ -103,7 +103,7 @@ nitf::ImageSubheader setImageSubHeader(
    return imgSubHdr;
 }
 
-nitf::Int64 getNumberBlocksPresent(const nitf_Uint64* mask,
+nitf::Int64 getNumberBlocksPresent(const uint64_t* mask,
                                    const nitf::Int64  numRows,
                                    const nitf::Int64  numCols)
 {
@@ -243,13 +243,13 @@ TEST_CASE(testBlankSegmentsValid)
       output_io.close();
 
       {
-         nitf_Uint32 imageDataOffset=0;        /* Offset to actual image data past masks */
-         nitf_Uint32 blockRecordLength=0;      /* Block mask record length */
-         nitf_Uint32 padRecordLength=0;        /* Pad mask record length */
-         nitf_Uint32 padPixelValueLength=0;    /* Pad pixel value length in bytes */
-         nitf_Uint8  *padValue = NULL;         /* Pad value */
-         nitf_Uint64 *blockMask=NULL;          /* Block mask array */
-         nitf_Uint64 *padMask=NULL;            /* Pad mask array */
+         uint32_t imageDataOffset=0;        /* Offset to actual image data past masks */
+         uint32_t blockRecordLength=0;      /* Block mask record length */
+         uint32_t padRecordLength=0;        /* Pad mask record length */
+         uint32_t padPixelValueLength=0;    /* Pad pixel value length in bytes */
+         uint8_t  *padValue = NULL;         /* Pad value */
+         uint64_t *blockMask=NULL;          /* Block mask array */
+         uint64_t *padMask=NULL;            /* Pad mask array */
          nitf::Int64 imgCtr = 0;
          nitf::IOHandle input_io(tempNitf.pathname(),
                                  NITF_ACCESS_READONLY,

--- a/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
+++ b/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
@@ -24,9 +24,9 @@ extern "C"{
                                       uint8_t** padValue, uint64_t** blockMask, uint64_t** padMask);
                      
 }
-const nitf::Int64 BLOCK_LENGTH = 256;
-const nitf::Int64 ILOC_MAX = 99999;
-std::string generateILOC(const types::RowCol<nitf::Int64>& offset)
+const int64_t BLOCK_LENGTH = 256;
+const int64_t ILOC_MAX = 99999;
+std::string generateILOC(const types::RowCol<int64_t>& offset)
 {
    std::ostringstream oss;
 
@@ -38,11 +38,11 @@ std::string generateILOC(const types::RowCol<nitf::Int64>& offset)
 
 nitf::ImageSubheader setImageSubHeader(
     nitf::Record&                     record,
-    nitf::Int64                       imageIndex,
-    const types::RowCol<nitf::Int64>& fullDims,
-    const types::RowCol<nitf::Int64>& segmentDims,
-    const types::RowCol<nitf::Int64>& segmentOffset,
-    const types::RowCol<nitf::Int64>& globalSegmentOffset,
+    int64_t                       imageIndex,
+    const types::RowCol<int64_t>& fullDims,
+    const types::RowCol<int64_t>& segmentDims,
+    const types::RowCol<int64_t>& segmentOffset,
+    const types::RowCol<int64_t>& globalSegmentOffset,
     bool fileSeparate)
 {
    nitf::ImageSegment   imageSegment = record.newImageSegment();
@@ -56,8 +56,8 @@ nitf::ImageSubheader setImageSubHeader(
 
    imgSubHdr.getFilePartType().set("IM");
    imgSubHdr.getEncrypted().set(0);
-   imgSubHdr.getNumRows().set((nitf::Int64)segmentDims.row);
-   imgSubHdr.getNumCols().set((nitf::Int64)segmentDims.col);
+   imgSubHdr.getNumRows().set((int64_t)segmentDims.row);
+   imgSubHdr.getNumCols().set((int64_t)segmentDims.col);
    imgSubHdr.getNumImageComments().set(0);
    imgSubHdr.getImageCompression().set(compressionType);
    imgSubHdr.getCompressionRate().set("    ");
@@ -71,8 +71,8 @@ nitf::ImageSubheader setImageSubHeader(
    bandI.getNumLUTs().set(0);
    bands.push_back(bandI);
    const std::string pixelValueType = "INT";
-   const nitf::Int64 numBitsPerPixel = 8;
-   const nitf::Int64 actualBitsPerPixel = 8;
+   const int64_t numBitsPerPixel = 8;
+   const int64_t actualBitsPerPixel = 8;
    const std::string pixelJustification = "R";
    const std::string imageRepresentation = "MONO";
    const std::string imageCategory = "SOS";
@@ -87,30 +87,30 @@ nitf::ImageSubheader setImageSubHeader(
       bands);
    imgSubHdr.getImageSyncCode().set("0");
    imgSubHdr.getImageMode().set("B");
-   nitf::Int64 blocksPerRow = (segmentDims.col + (BLOCK_LENGTH - 1)) / BLOCK_LENGTH;
-   nitf::Int64 blocksPerCol = (segmentDims.row + (BLOCK_LENGTH - 1)) / BLOCK_LENGTH;
+   int64_t blocksPerRow = (segmentDims.col + (BLOCK_LENGTH - 1)) / BLOCK_LENGTH;
+   int64_t blocksPerCol = (segmentDims.row + (BLOCK_LENGTH - 1)) / BLOCK_LENGTH;
 
    imgSubHdr.getNumBlocksPerRow().set(blocksPerRow);
    imgSubHdr.getNumPixelsPerHorizBlock().set(BLOCK_LENGTH);
    imgSubHdr.getNumBlocksPerCol().set(blocksPerCol);
    imgSubHdr.getNumPixelsPerVertBlock().set(BLOCK_LENGTH);
 
-   imgSubHdr.getImageDisplayLevel().set((nitf::Int64)imageIndex+1);
-   imgSubHdr.getImageAttachmentLevel().set((nitf::Int64)imageIndex);
+   imgSubHdr.getImageDisplayLevel().set((int64_t)imageIndex+1);
+   imgSubHdr.getImageAttachmentLevel().set((int64_t)imageIndex);
 
    imgSubHdr.getImageLocation().set(generateILOC(segmentOffset));
 
    return imgSubHdr;
 }
 
-nitf::Int64 getNumberBlocksPresent(const uint64_t* mask,
-                                   const nitf::Int64  numRows,
-                                   const nitf::Int64  numCols)
+int64_t getNumberBlocksPresent(const uint64_t* mask,
+                                   const int64_t  numRows,
+                                   const int64_t  numCols)
 {
-   nitf::Int64 numBlocksPresent = 0;
-   for (nitf::Int64 row = 0, idx = 0; row < numRows; ++row)
+   int64_t numBlocksPresent = 0;
+   for (int64_t row = 0, idx = 0; row < numRows; ++row)
    {
-      for (nitf::Int64 col = 0; col < numCols; ++col, ++idx)
+      for (int64_t col = 0; col < numCols; ++col, ++idx)
       {
          if (mask[idx] != 0xFFFFFFFF)
          {
@@ -122,21 +122,21 @@ nitf::Int64 getNumberBlocksPresent(const uint64_t* mask,
    return numBlocksPresent;
 }
 
-void createSingleBandBuffer(std::vector<nitf::Uint8>& buffer,
+void createSingleBandBuffer(std::vector<uint8_t>& buffer,
                             const nitf::ImageSegmentComputer& segmentComputer,
-                            const types::RowCol<nitf::Int64>& fullDims,
-                            const nitf::Int64 segmentIdxToMakeEmpty)
+                            const types::RowCol<int64_t>& fullDims,
+                            const int64_t segmentIdxToMakeEmpty)
 {
-   const nitf::Int64 bytes = fullDims.area();
+   const int64_t bytes = fullDims.area();
    const std::vector<nitf::ImageSegmentComputer::Segment> &segments = segmentComputer.getSegments();
    /* All segments should be the same size in this test so this is safe */
-   const nitf::Int64 segmentSizeInBytes = segments[segmentIdxToMakeEmpty].numRows * fullDims.col;
+   const int64_t segmentSizeInBytes = segments[segmentIdxToMakeEmpty].numRows * fullDims.col;
 
    buffer.resize(bytes);
    memset(&buffer.front(), '\0', bytes);
-   for (nitf::Uint32 segIdx = 0; segIdx < segments.size(); ++segIdx)
+   for (uint32_t segIdx = 0; segIdx < segments.size(); ++segIdx)
    {
-      nitf::Uint8 *segStart = &buffer.front() + (segmentSizeInBytes * segIdx);
+      uint8_t *segStart = &buffer.front() + (segmentSizeInBytes * segIdx);
       /* Set only the center that way we are surrounded by empty blocks */
       if (segIdx != segmentIdxToMakeEmpty)
       {
@@ -145,17 +145,17 @@ void createSingleBandBuffer(std::vector<nitf::Uint8>& buffer,
    }
 }
 
-void createBuffers(std::vector<std::vector<nitf::Uint8> >& buffers,
+void createBuffers(std::vector<std::vector<uint8_t> >& buffers,
                    const nitf::ImageSegmentComputer& imageSegmentComputer,
-                   const types::RowCol<nitf::Int64>& fullDims)
+                   const types::RowCol<int64_t>& fullDims)
 {
-   const nitf::Int64 nSegments = imageSegmentComputer.getSegments().size();
+   const int64_t nSegments = imageSegmentComputer.getSegments().size();
    /*
    * Create the memory images single band and then make the
    * segment blank for each one at different segments.
    */
    buffers.resize(nSegments);
-   for (nitf::Int64 idx = 0; idx < nSegments; ++idx)
+   for (int64_t idx = 0; idx < nSegments; ++idx)
    {
       createSingleBandBuffer(buffers[idx],
                              imageSegmentComputer,
@@ -175,16 +175,16 @@ TEST_CASE(testBlankSegmentsValid)
     *
     * Create 3 segments for testing
     */
-   const nitf::Int64 BLOCK_LENGTH_SCALED = BLOCK_LENGTH*4;
-   const nitf::Int64 numberLines = BLOCK_LENGTH_SCALED * 3;
-   const nitf::Int64 numberElements = BLOCK_LENGTH_SCALED * 2;
-   const nitf::Int64 bytesPerSegment = BLOCK_LENGTH_SCALED * BLOCK_LENGTH_SCALED * 2;
-   const nitf::Int64 elementSize     = 1;
-   nitf::Int64 numberOfTests         = 0;
-   const types::RowCol<nitf::Int64> fullDims(numberLines, numberElements);
+   const int64_t BLOCK_LENGTH_SCALED = BLOCK_LENGTH*4;
+   const int64_t numberLines = BLOCK_LENGTH_SCALED * 3;
+   const int64_t numberElements = BLOCK_LENGTH_SCALED * 2;
+   const int64_t bytesPerSegment = BLOCK_LENGTH_SCALED * BLOCK_LENGTH_SCALED * 2;
+   const int64_t elementSize     = 1;
+   int64_t numberOfTests         = 0;
+   const types::RowCol<int64_t> fullDims(numberLines, numberElements);
    nitf::ImageSubheader img;
    nitf::Writer writer;
-   std::vector<std::vector<nitf::Uint8> > buffers;
+   std::vector<std::vector<uint8_t> > buffers;
    nitf::ImageSegmentComputer imageSegmentComputer(numberLines,
                                                    numberElements,
                                                    elementSize,
@@ -192,18 +192,18 @@ TEST_CASE(testBlankSegmentsValid)
                                                    bytesPerSegment,
                                                    BLOCK_LENGTH);
 
-   const nitf::Int64 numSegments = imageSegmentComputer.getSegments().size();
+   const int64_t numSegments = imageSegmentComputer.getSegments().size();
    const std::vector<nitf::ImageSegmentComputer::Segment> &segments = imageSegmentComputer.getSegments();
 
    numberOfTests = numSegments;
    TEST_ASSERT_EQ(numSegments, 3);
-   for (nitf::Int64 testSegmentIdx = 0; testSegmentIdx < numSegments; ++testSegmentIdx)
+   for (int64_t testSegmentIdx = 0; testSegmentIdx < numSegments; ++testSegmentIdx)
    {
-      types::RowCol<nitf::Int64> dims(segments[testSegmentIdx].numRows, numberElements);
+      types::RowCol<int64_t> dims(segments[testSegmentIdx].numRows, numberElements);
       TEST_ASSERT_EQ(dims.area(), bytesPerSegment);
    }
    createBuffers(buffers, imageSegmentComputer, fullDims);
-   for (nitf::Int64 testIdx = 0; testIdx < numberOfTests; ++testIdx)
+   for (int64_t testIdx = 0; testIdx < numberOfTests; ++testIdx)
    {
       nitf::Record record(NITF_VER_21);
       io::TempFile tempNitf;
@@ -212,24 +212,24 @@ TEST_CASE(testBlankSegmentsValid)
       nitf::IOHandle output_io(tempNitf.pathname(),
                                NITF_ACCESS_WRITEONLY,
                                NITF_CREATE);
-      std::vector<types::RowCol<nitf::Int64> > segmentDims(numSegments);
-      std::vector<types::RowCol<nitf::Int64> > segmentOffsets(numSegments);
-      for (nitf::Int64 ii = 0; ii < numSegments; ++ii)
+      std::vector<types::RowCol<int64_t> > segmentDims(numSegments);
+      std::vector<types::RowCol<int64_t> > segmentOffsets(numSegments);
+      for (int64_t ii = 0; ii < numSegments; ++ii)
       {
-         types::RowCol<nitf::Int64> dims;
-         types::RowCol<nitf::Int64> offset;
-         nitf::Int64 numRows = segments[ii].numRows;
-         dims = types::RowCol<nitf::Int64>(numRows, numberElements);
-         offset = types::RowCol<nitf::Int64>(segments[ii].rowOffset, 0);
-         segmentOffsets[ii] = types::RowCol<nitf::Int64>(segments[ii].firstRow, 0);
+         types::RowCol<int64_t> dims;
+         types::RowCol<int64_t> offset;
+         int64_t numRows = segments[ii].numRows;
+         dims = types::RowCol<int64_t>(numRows, numberElements);
+         offset = types::RowCol<int64_t>(segments[ii].rowOffset, 0);
+         segmentOffsets[ii] = types::RowCol<int64_t>(segments[ii].firstRow, 0);
 
          img = setImageSubHeader(record, ii, fullDims, dims, offset, segmentOffsets[ii], false);
       }
       writer.prepare(output_io, record);
 
-      for (nitf::Int64 ii = 0; ii < numSegments; ++ii)
+      for (int64_t ii = 0; ii < numSegments; ++ii)
       {
-         nitf::Uint8 *buf = &buffers[testIdx].front() + (ii * bytesPerSegment);
+         uint8_t *buf = &buffers[testIdx].front() + (ii * bytesPerSegment);
          nitf::ImageWriter imageWriter = writer.newImageWriter(ii);
          imageWriter.setWriteCaching(1);
          nitf::ImageSource iSource;
@@ -250,7 +250,7 @@ TEST_CASE(testBlankSegmentsValid)
          uint8_t  *padValue = NULL;         /* Pad value */
          uint64_t *blockMask=NULL;          /* Block mask array */
          uint64_t *padMask=NULL;            /* Pad mask array */
-         nitf::Int64 imgCtr = 0;
+         int64_t imgCtr = 0;
          nitf::IOHandle input_io(tempNitf.pathname(),
                                  NITF_ACCESS_READONLY,
                                  NITF_OPEN_EXISTING);
@@ -271,10 +271,10 @@ TEST_CASE(testBlankSegmentsValid)
                                                       &padRecordLength, &padPixelValueLength,
                                                       &padValue, &blockMask, &padMask) != 0);
 
-            const nitf::Int64 totalBlocks = blockingInfo.getNumBlocksPerRow()*blockingInfo.getNumBlocksPerCol();
+            const int64_t totalBlocks = blockingInfo.getNumBlocksPerRow()*blockingInfo.getNumBlocksPerCol();
             TEST_ASSERT_GREATER(blockRecordLength, 0);
 
-            const nitf::Int64 nBlocksPresent = getNumberBlocksPresent(blockMask,
+            const int64_t nBlocksPresent = getNumberBlocksPresent(blockMask,
                                                                       blockingInfo.getNumBlocksPerRow(),
                                                                       blockingInfo.getNumBlocksPerCol());
 

--- a/modules/c/cgm/tests/test_extract_cgm.c
+++ b/modules/c/cgm/tests/test_extract_cgm.c
@@ -52,7 +52,7 @@ void extractGraphics(nitf_Record *record, nitf_Reader *reader,
         while(nitf_ListIterator_notEqualTo(&iter, &end))
         {
             nitf_SegmentReader *segmentReader = NULL;
-            nitf_Uint8 *buf = NULL;
+            uint8_t *buf = NULL;
             size_t bytes;
             nitf_GraphicSegment *segment =
                     (nitf_GraphicSegment *) nitf_ListIterator_get(&iter);
@@ -60,7 +60,7 @@ void extractGraphics(nitf_Record *record, nitf_Reader *reader,
             segmentReader = nitf_Reader_newGraphicReader(reader, num, error);
             
             bytes = (size_t)(segment->end - segment->offset);
-            buf = (nitf_Uint8*)NITF_MALLOC(bytes);
+            buf = (uint8_t*)NITF_MALLOC(bytes);
             
             if (nitf_SegmentReader_read(segmentReader, buf, bytes, error))
             {

--- a/modules/c/j2k/include/j2k/Component.h
+++ b/modules/c/j2k/include/j2k/Component.h
@@ -27,14 +27,14 @@
 
 J2K_CXX_GUARD
 
-typedef nrt_Uint32  (*J2K_ICOMPONENT_GET_WIDTH)(J2K_USER_DATA*, nrt_Error*);
-typedef nrt_Uint32  (*J2K_ICOMPONENT_GET_HEIGHT)(J2K_USER_DATA*, nrt_Error*);
-typedef nrt_Uint32  (*J2K_ICOMPONENT_GET_PRECISION)(J2K_USER_DATA*, nrt_Error*);
+typedef uint32_t  (*J2K_ICOMPONENT_GET_WIDTH)(J2K_USER_DATA*, nrt_Error*);
+typedef uint32_t  (*J2K_ICOMPONENT_GET_HEIGHT)(J2K_USER_DATA*, nrt_Error*);
+typedef uint32_t  (*J2K_ICOMPONENT_GET_PRECISION)(J2K_USER_DATA*, nrt_Error*);
 typedef NRT_BOOL    (*J2K_ICOMPONENT_IS_SIGNED)(J2K_USER_DATA*, nrt_Error*);
-typedef nrt_Int32   (*J2K_ICOMPONENT_GET_OFFSET_X)(J2K_USER_DATA*, nrt_Error*);
-typedef nrt_Int32   (*J2K_ICOMPONENT_GET_OFFSET_Y)(J2K_USER_DATA*, nrt_Error*);
-typedef nrt_Uint32  (*J2K_ICOMPONENT_GET_SEPARATION_X)(J2K_USER_DATA*, nrt_Error*);
-typedef nrt_Uint32  (*J2K_ICOMPONENT_GET_SEPARATION_Y)(J2K_USER_DATA*, nrt_Error*);
+typedef int32_t   (*J2K_ICOMPONENT_GET_OFFSET_X)(J2K_USER_DATA*, nrt_Error*);
+typedef int32_t   (*J2K_ICOMPONENT_GET_OFFSET_Y)(J2K_USER_DATA*, nrt_Error*);
+typedef uint32_t  (*J2K_ICOMPONENT_GET_SEPARATION_X)(J2K_USER_DATA*, nrt_Error*);
+typedef uint32_t  (*J2K_ICOMPONENT_GET_SEPARATION_Y)(J2K_USER_DATA*, nrt_Error*);
 typedef void        (*J2K_ICOMPONENT_DESTRUCT)(J2K_USER_DATA *);
 
 typedef struct _j2k_IComponent
@@ -59,30 +59,30 @@ typedef struct _j2k_Component
 /**
  * Constructs a Component from scratch using the provided metadata
  */
-J2KAPI(j2k_Component*) j2k_Component_construct(nrt_Uint32 width,
-                                               nrt_Uint32 height,
-                                               nrt_Uint32 precision,
+J2KAPI(j2k_Component*) j2k_Component_construct(uint32_t width,
+                                               uint32_t height,
+                                               uint32_t precision,
                                                NRT_BOOL isSigned,
-                                               nrt_Uint32 offsetX,
-                                               nrt_Uint32 offsetY,
-                                               nrt_Uint32 separationX,
-                                               nrt_Uint32 separationY,
+                                               uint32_t offsetX,
+                                               uint32_t offsetY,
+                                               uint32_t separationX,
+                                               uint32_t separationY,
                                                nrt_Error *error);
 
 /**
  * Returns the width of the Component
  */
-J2KAPI(nrt_Uint32) j2k_Component_getWidth(j2k_Component*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Component_getWidth(j2k_Component*, nrt_Error*);
 
 /**
  * Returns the height of the Component
  */
-J2KAPI(nrt_Uint32) j2k_Component_getHeight(j2k_Component*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Component_getHeight(j2k_Component*, nrt_Error*);
 
 /**
  * Returns the number of bits per sample per component
  */
-J2KAPI(nrt_Uint32) j2k_Component_getPrecision(j2k_Component*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Component_getPrecision(j2k_Component*, nrt_Error*);
 
 /**
  * Returns whether the data is signed
@@ -92,22 +92,22 @@ J2KAPI(NRT_BOOL) j2k_Component_isSigned(j2k_Component*, nrt_Error*);
 /**
  * Returns the X offset into the reference grid
  */
-J2KAPI(nrt_Int32) j2k_Component_getOffsetX(j2k_Component*, nrt_Error*);
+J2KAPI(int32_t) j2k_Component_getOffsetX(j2k_Component*, nrt_Error*);
 
 /**
  * Returns the Y offset into the reference grid
  */
-J2KAPI(nrt_Int32) j2k_Component_getOffsetY(j2k_Component*, nrt_Error*);
+J2KAPI(int32_t) j2k_Component_getOffsetY(j2k_Component*, nrt_Error*);
 
 /**
  * Returns the width separation between samples on the reference grid
  */
-J2KAPI(nrt_Uint32) j2k_Component_getSeparationX(j2k_Component*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Component_getSeparationX(j2k_Component*, nrt_Error*);
 
 /**
  * Returns the height separation between samples on the reference grid
  */
-J2KAPI(nrt_Uint32) j2k_Component_getSeparationY(j2k_Component*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Component_getSeparationY(j2k_Component*, nrt_Error*);
 
 /**
  * Destroys the Component

--- a/modules/c/j2k/include/j2k/Container.h
+++ b/modules/c/j2k/include/j2k/Container.h
@@ -28,14 +28,14 @@
 
 J2K_CXX_GUARD
 
-typedef nrt_Uint32      (*J2K_ICONTAINER_GET_GRID_WIDTH)(J2K_USER_DATA*, nrt_Error*);
-typedef nrt_Uint32      (*J2K_ICONTAINER_GET_GRID_HEIGHT)(J2K_USER_DATA*, nrt_Error*);
-typedef nrt_Uint32      (*J2K_ICONTAINER_GET_NUM_COMPONENTS)(J2K_USER_DATA*, nrt_Error*);
-typedef j2k_Component*  (*J2K_ICONTAINER_GET_COMPONENT)(J2K_USER_DATA*, nrt_Uint32, nrt_Error*);
-typedef nrt_Uint32      (*J2K_ICONTAINER_GET_TILESX)(J2K_USER_DATA*, nrt_Error*);
-typedef nrt_Uint32      (*J2K_ICONTAINER_GET_TILESY)(J2K_USER_DATA*, nrt_Error*);
-typedef nrt_Uint32      (*J2K_ICONTAINER_GET_TILE_WIDTH)(J2K_USER_DATA*, nrt_Error*);
-typedef nrt_Uint32      (*J2K_ICONTAINER_GET_TILE_HEIGHT)(J2K_USER_DATA*, nrt_Error*);
+typedef uint32_t      (*J2K_ICONTAINER_GET_GRID_WIDTH)(J2K_USER_DATA*, nrt_Error*);
+typedef uint32_t      (*J2K_ICONTAINER_GET_GRID_HEIGHT)(J2K_USER_DATA*, nrt_Error*);
+typedef uint32_t      (*J2K_ICONTAINER_GET_NUM_COMPONENTS)(J2K_USER_DATA*, nrt_Error*);
+typedef j2k_Component*  (*J2K_ICONTAINER_GET_COMPONENT)(J2K_USER_DATA*, uint32_t, nrt_Error*);
+typedef uint32_t      (*J2K_ICONTAINER_GET_TILESX)(J2K_USER_DATA*, nrt_Error*);
+typedef uint32_t      (*J2K_ICONTAINER_GET_TILESY)(J2K_USER_DATA*, nrt_Error*);
+typedef uint32_t      (*J2K_ICONTAINER_GET_TILE_WIDTH)(J2K_USER_DATA*, nrt_Error*);
+typedef uint32_t      (*J2K_ICONTAINER_GET_TILE_HEIGHT)(J2K_USER_DATA*, nrt_Error*);
 typedef int             (*J2K_ICONTAINER_GET_IMAGE_TYPE)(J2K_USER_DATA*, nrt_Error*);
 typedef void            (*J2K_ICONTAINER_DESTRUCT)(J2K_USER_DATA *);
 
@@ -64,69 +64,69 @@ typedef struct _j2k_Container
 /**
  * Constructs a Container from scratch using the provided metadata
  */
-J2KAPI(j2k_Container*) j2k_Container_construct(nrt_Uint32 gridWidth,
-                                               nrt_Uint32 gridHeight,
-                                               nrt_Uint32 numComponents,
+J2KAPI(j2k_Container*) j2k_Container_construct(uint32_t gridWidth,
+                                               uint32_t gridHeight,
+                                               uint32_t numComponents,
                                                j2k_Component** components,
-                                               nrt_Uint32 tileWidth,
-                                               nrt_Uint32 tileHeight,
+                                               uint32_t tileWidth,
+                                               uint32_t tileHeight,
                                                int imageType,
                                                nrt_Error *error);
 
 /**
  * Returns the reference grid width
  */
-J2KAPI(nrt_Uint32) j2k_Container_getGridWidth(j2k_Container*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Container_getGridWidth(j2k_Container*, nrt_Error*);
 
 /**
  * Returns the reference grid height
  */
-J2KAPI(nrt_Uint32) j2k_Container_getGridHeight(j2k_Container*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Container_getGridHeight(j2k_Container*, nrt_Error*);
 
 /**
  * Returns the number of components/bands
  */
-J2KAPI(nrt_Uint32) j2k_Container_getNumComponents(j2k_Container*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Container_getNumComponents(j2k_Container*, nrt_Error*);
 
 /**
  * Returns the i'th Component
  */
-J2KAPI(j2k_Component*) j2k_Container_getComponent(j2k_Container*, nrt_Uint32, nrt_Error*);
+J2KAPI(j2k_Component*) j2k_Container_getComponent(j2k_Container*, uint32_t, nrt_Error*);
 
 /**
  * Returns the actual image width (in samples) - i.e. the max component width
  */
-J2KAPI(nrt_Uint32) j2k_Container_getWidth(j2k_Container*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Container_getWidth(j2k_Container*, nrt_Error*);
 
 /**
  * Returns the actual image height (in samples) - i.e. the max component height
  */
-J2KAPI(nrt_Uint32) j2k_Container_getHeight(j2k_Container*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Container_getHeight(j2k_Container*, nrt_Error*);
 
 /**
  * Returns the max component precision
  */
-J2KAPI(nrt_Uint32) j2k_Container_getPrecision(j2k_Container*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Container_getPrecision(j2k_Container*, nrt_Error*);
 
 /**
  * Returns the number of column tiles (X-direction)
  */
-J2KAPI(nrt_Uint32) j2k_Container_getTilesX(j2k_Container*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Container_getTilesX(j2k_Container*, nrt_Error*);
 
 /**
  * Returns the number of row tiles (Y-direction)
  */
-J2KAPI(nrt_Uint32) j2k_Container_getTilesY(j2k_Container*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Container_getTilesY(j2k_Container*, nrt_Error*);
 
 /**
  * Returns the tile width
  */
-J2KAPI(nrt_Uint32) j2k_Container_getTileWidth(j2k_Container*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Container_getTileWidth(j2k_Container*, nrt_Error*);
 
 /**
  * Returns the tile height
  */
-J2KAPI(nrt_Uint32) j2k_Container_getTileHeight(j2k_Container*, nrt_Error*);
+J2KAPI(uint32_t) j2k_Container_getTileHeight(j2k_Container*, nrt_Error*);
 
 /**
  * Returns the image type

--- a/modules/c/j2k/include/j2k/Reader.h
+++ b/modules/c/j2k/include/j2k/Reader.h
@@ -28,12 +28,12 @@
 J2K_CXX_GUARD
 
 typedef J2K_BOOL        (*J2K_IREADER_CAN_READ_TILES)(J2K_USER_DATA*, nrt_Error*);
-typedef nrt_Uint64      (*J2K_IREADER_READ_TILE)(J2K_USER_DATA*, nrt_Uint32 tileX,
-                                                nrt_Uint32 tileY, nrt_Uint8 **buf,
+typedef uint64_t      (*J2K_IREADER_READ_TILE)(J2K_USER_DATA*, uint32_t tileX,
+                                                uint32_t tileY, uint8_t **buf,
                                                 nrt_Error*);
-typedef nrt_Uint64      (*J2K_IREADER_READ_REGION)(J2K_USER_DATA*, nrt_Uint32 x0,
-                                                  nrt_Uint32 y0, nrt_Uint32 x1,
-                                                  nrt_Uint32 y1, nrt_Uint8 **buf,
+typedef uint64_t      (*J2K_IREADER_READ_REGION)(J2K_USER_DATA*, uint32_t x0,
+                                                  uint32_t y0, uint32_t x1,
+                                                  uint32_t y1, uint8_t **buf,
                                                   nrt_Error*);
 typedef j2k_Container*  (*J2K_IREADER_GET_CONTAINER)(J2K_USER_DATA*, nrt_Error*);
 typedef void            (*J2K_IREADER_DESTRUCT)(J2K_USER_DATA *);
@@ -71,16 +71,16 @@ J2KAPI(J2K_BOOL) j2k_Reader_canReadTiles(j2k_Reader*, nrt_Error*);
 /**
  * Reads an individual tile at the given indices
  */
-J2KAPI(nrt_Uint64) j2k_Reader_readTile(j2k_Reader*, nrt_Uint32 tileX,
-                                          nrt_Uint32 tileY, nrt_Uint8 **buf,
+J2KAPI(uint64_t) j2k_Reader_readTile(j2k_Reader*, uint32_t tileX,
+                                          uint32_t tileY, uint8_t **buf,
                                           nrt_Error*);
 
 /**
  * Reads image data from the desired region
  */
-J2KAPI(nrt_Uint64) j2k_Reader_readRegion(j2k_Reader*, nrt_Uint32 x0,
-                                          nrt_Uint32 y0, nrt_Uint32 x1,
-                                          nrt_Uint32 y1, nrt_Uint8 **buf,
+J2KAPI(uint64_t) j2k_Reader_readRegion(j2k_Reader*, uint32_t x0,
+                                          uint32_t y0, uint32_t x1,
+                                          uint32_t y1, uint8_t **buf,
                                           nrt_Error*);
 
 /**

--- a/modules/c/j2k/include/j2k/Writer.h
+++ b/modules/c/j2k/include/j2k/Writer.h
@@ -27,9 +27,9 @@
 
 J2K_CXX_GUARD
 
-typedef J2K_BOOL        (*J2K_IWRITER_SET_TILE)(J2K_USER_DATA*, nrt_Uint32,
-                                                nrt_Uint32, const nrt_Uint8 *,
-                                                nrt_Uint32, nrt_Error*);
+typedef J2K_BOOL        (*J2K_IWRITER_SET_TILE)(J2K_USER_DATA*, uint32_t,
+                                                uint32_t, const uint8_t *,
+                                                uint32_t, nrt_Error*);
 typedef J2K_BOOL        (*J2K_IWRITER_WRITE)(J2K_USER_DATA*, nrt_IOInterface*,
                                              nrt_Error*);
 typedef j2k_Container*  (*J2K_IWRITER_GET_CONTAINER)(J2K_USER_DATA*, nrt_Error*);
@@ -47,7 +47,7 @@ typedef struct _j2k_WriterOptions
 {
     /* TODO add more options as we see fit */
     double compressionRatio;
-    nrt_Uint32 numResolutions;
+    uint32_t numResolutions;
 } j2k_WriterOptions;
 
 typedef struct _j2k_Writer
@@ -70,9 +70,9 @@ J2KAPI(j2k_Writer*) j2k_Writer_construct(j2k_Container*, j2k_WriterOptions*,
  * It is assumed that the passed-in buffer will be available for deletion
  * immediately after the call returns.
  */
-J2KAPI(J2K_BOOL) j2k_Writer_setTile(j2k_Writer*, nrt_Uint32 tileX,
-                                    nrt_Uint32 tileY, const nrt_Uint8 *buf,
-                                    nrt_Uint32 bufSize, nrt_Error*);
+J2KAPI(J2K_BOOL) j2k_Writer_setTile(j2k_Writer*, uint32_t tileX,
+                                    uint32_t tileY, const uint8_t *buf,
+                                    uint32_t bufSize, nrt_Error*);
 
 /**
  * Writes to the IOInterface

--- a/modules/c/j2k/shared/J2KCompress.c
+++ b/modules/c/j2k/shared/J2KCompress.c
@@ -125,7 +125,7 @@ NITFPRIV(nitf_CompressionControl*) implOpen(nitf_ImageSubheader *subheader,
     char irep[NITF_IREP_SZ+1];
     int imageType;
     J2K_BOOL isSigned = 0;
-    nrt_Uint32 idx;
+    uint32_t idx;
 
     /* reset the options */
     memset(&options, 0, sizeof(j2k_WriterOptions));

--- a/modules/c/j2k/shared/J2KCompress.c
+++ b/modules/c/j2k/shared/J2KCompress.c
@@ -30,15 +30,15 @@ NITF_CXX_GUARD
 NITFPRIV(nitf_CompressionControl*) implOpen(nitf_ImageSubheader*, nrt_HashTable*, nitf_Error*);
 
 NITFPRIV(NITF_BOOL) implStart(nitf_CompressionControl *control,
-                              nitf_Uint64 offset,
-                              nitf_Uint64 dataLength,
-                              nitf_Uint64 *blockMask,
-                              nitf_Uint64 *padMask,
+                              uint64_t offset,
+                              uint64_t dataLength,
+                              uint64_t *blockMask,
+                              uint64_t *padMask,
                               nitf_Error *error);
 
 NITFPRIV(NITF_BOOL) implWriteBlock(nitf_CompressionControl * control,
                                    nitf_IOInterface *io,
-                                   const nitf_Uint8 *data,
+                                   const uint8_t *data,
                                    NITF_BOOL pad,
                                    NITF_BOOL noData,
                                    nitf_Error *error);
@@ -65,9 +65,9 @@ typedef struct _ImplControl
     nitf_BlockingInfo blockInfo; /* Kept for convenience */
     j2k_Container *container;    /* j2k Container */
     j2k_Writer *writer;          /* j2k Writer */
-    nitf_Uint64 offset;
-    nitf_Uint64 dataLength;
-    nitf_Uint32 curBlock;
+    uint64_t offset;
+    uint64_t dataLength;
+    uint32_t curBlock;
     nitf_Field *comratField;     /* kept so we can update it */
 }ImplControl;
 
@@ -109,15 +109,15 @@ NITFPRIV(nitf_CompressionControl*) implOpen(nitf_ImageSubheader *subheader,
     j2k_Component **components = NULL;
     j2k_WriterOptions options;
 
-    nitf_Uint32 nRows;
-    nitf_Uint32 nCols;
-    nitf_Uint32 nBands;
-    nitf_Uint32 nbpp;
-    nitf_Uint32 abpp;
-    nitf_Uint32 nbpr;
-    nitf_Uint32 nbpc;
-    nitf_Uint32 nppbh;
-    nitf_Uint32 nppbv;
+    uint32_t nRows;
+    uint32_t nCols;
+    uint32_t nBands;
+    uint32_t nbpp;
+    uint32_t abpp;
+    uint32_t nbpr;
+    uint32_t nbpc;
+    uint32_t nppbh;
+    uint32_t nppbv;
     char pvtype[NITF_PVTYPE_SZ+1];
     char ic[NITF_IC_SZ+1];
     //char comrat[NITF_COMRAT_SZ+1];
@@ -136,12 +136,12 @@ NITFPRIV(nitf_CompressionControl*) implOpen(nitf_ImageSubheader *subheader,
     }
 
     if(!nitf_Field_get(subheader->NITF_NROWS, &nRows,
-                    NITF_CONV_INT, sizeof(nitf_Uint32), error))
+                    NITF_CONV_INT, sizeof(uint32_t), error))
     {
         goto CATCH_ERROR;
     }
     if(!nitf_Field_get(subheader->NITF_NCOLS, &nCols,
-                    NITF_CONV_INT, sizeof(nitf_Uint32), error))
+                    NITF_CONV_INT, sizeof(uint32_t), error))
     {
         goto CATCH_ERROR;
     }
@@ -152,32 +152,32 @@ NITFPRIV(nitf_CompressionControl*) implOpen(nitf_ImageSubheader *subheader,
     }
 
     if(!nitf_Field_get(subheader->NITF_NBPP, &nbpp,
-                    NITF_CONV_INT, sizeof(nitf_Uint32), error))
+                    NITF_CONV_INT, sizeof(uint32_t), error))
     {
         goto CATCH_ERROR;
     }
     if(!nitf_Field_get(subheader->NITF_ABPP, &abpp,
-                    NITF_CONV_INT, sizeof(nitf_Uint32), error))
+                    NITF_CONV_INT, sizeof(uint32_t), error))
     {
         goto CATCH_ERROR;
     }
     if(!nitf_Field_get(subheader->NITF_NPPBH, &nppbh,
-                    NITF_CONV_INT, sizeof(nitf_Uint32), error))
+                    NITF_CONV_INT, sizeof(uint32_t), error))
     {
         goto CATCH_ERROR;
     }
     if(!nitf_Field_get(subheader->NITF_NPPBV, &nppbv,
-                    NITF_CONV_INT, sizeof(nitf_Uint32), error))
+                    NITF_CONV_INT, sizeof(uint32_t), error))
     {
         goto CATCH_ERROR;
     }
     if(!nitf_Field_get(subheader->NITF_NBPR, &nbpr,
-                    NITF_CONV_INT, sizeof(nitf_Uint32), error))
+                    NITF_CONV_INT, sizeof(uint32_t), error))
     {
         goto CATCH_ERROR;
     }
     if(!nitf_Field_get(subheader->NITF_NBPC, &nbpc,
-                    NITF_CONV_INT, sizeof(nitf_Uint32), error))
+                    NITF_CONV_INT, sizeof(uint32_t), error))
     {
         goto CATCH_ERROR;
     }
@@ -336,10 +336,10 @@ NITFPRIV(nitf_CompressionControl*) implOpen(nitf_ImageSubheader *subheader,
 }
 
 NITFPRIV(NITF_BOOL) implStart(nitf_CompressionControl *control,
-                              nitf_Uint64 offset,
-                              nitf_Uint64 dataLength,
-                              nitf_Uint64 *blockMask,
-                              nitf_Uint64 *padMask,
+                              uint64_t offset,
+                              uint64_t dataLength,
+                              uint64_t *blockMask,
+                              uint64_t *padMask,
                               nitf_Error *error)
 {
     ImplControl *implControl = (ImplControl*)control;
@@ -353,14 +353,14 @@ NITFPRIV(NITF_BOOL) implStart(nitf_CompressionControl *control,
 
 NITFPRIV(NITF_BOOL) implWriteBlock(nitf_CompressionControl * control,
                                    nitf_IOInterface *io,
-                                   const nitf_Uint8 *data,
+                                   const uint8_t *data,
                                    NITF_BOOL pad,
                                    NITF_BOOL noData,
                                    nitf_Error *error)
 {
     ImplControl *implControl = (ImplControl*)control;
-    nitf_Uint32 tileX, tileY, tileWidth, tileHeight, tilesX;
-    nitf_Uint32 nComponents, nBytes, bufSize;
+    uint32_t tileX, tileY, tileWidth, tileHeight, tilesX;
+    uint32_t nComponents, nBytes, bufSize;
 
     /* TODO this needs to change... won't work on separated images */
     tileWidth = j2k_Container_getTileWidth(implControl->container, error);
@@ -394,9 +394,9 @@ NITFPRIV(NITF_BOOL) implEnd( nitf_CompressionControl * control,
     ImplControl *implControl = (ImplControl*)control;
     nitf_Off offset;
     size_t compressedSize, rawSize;
-    nitf_Uint32 comratInt;
+    uint32_t comratInt;
     float comrat;
-    nitf_Uint32 width, height, nComponents, nBytes, nBits;
+    uint32_t width, height, nComponents, nBytes, nBits;
 
     width = j2k_Container_getWidth(implControl->container, error);
     height = j2k_Container_getHeight(implControl->container, error);
@@ -422,7 +422,7 @@ NITFPRIV(NITF_BOOL) implEnd( nitf_CompressionControl * control,
         digit from the right (i.e. xy.z).
      */
     comrat = (1.0f * compressedSize * nBits) / rawSize;
-    comratInt = (nitf_Uint32)(comrat * 10.0f + 0.5f);
+    comratInt = (uint32_t)(comrat * 10.0f + 0.5f);
 
     /* write the comrat field */
     NITF_SNPRINTF(implControl->comratField->raw,

--- a/modules/c/j2k/shared/J2KDecompress.c
+++ b/modules/c/j2k/shared/J2KDecompress.c
@@ -32,17 +32,17 @@ NITFPRIV(nitf_DecompressionControl*) implOpen(nitf_ImageSubheader * subheader,
                                               nitf_Error * error);
 NITFPRIV(NITF_BOOL) implStart(nitf_DecompressionControl* control,
                               nitf_IOInterface*  io,
-                              nitf_Uint64        offset,
-                              nitf_Uint64        fileLength,
+                              uint64_t        offset,
+                              uint64_t        fileLength,
                               nitf_BlockingInfo* blockInfo,
-                              nitf_Uint64*       blockMask,
+                              uint64_t*       blockMask,
                               nitf_Error*        error);
-NITFPRIV(nitf_Uint8*) implReadBlock(nitf_DecompressionControl *control,
-                                    nitf_Uint32 blockNumber,
-                                    nitf_Uint64* blockSize,
+NITFPRIV(uint8_t*) implReadBlock(nitf_DecompressionControl *control,
+                                    uint32_t blockNumber,
+                                    uint64_t* blockSize,
                                     nitf_Error* error);
 NITFPRIV(int) implFreeBlock(nitf_DecompressionControl* control,
-                            nitf_Uint8* block,
+                            uint8_t* block,
                             nitf_Error* error);
 
 NITFPRIV(void) implClose(nitf_DecompressionControl** control);
@@ -63,8 +63,8 @@ typedef struct _ImplControl
 {
     nitf_BlockingInfo blockInfo; /* Kept for convenience */
     j2k_Reader *reader;          /* j2k Reader */
-    nitf_Uint64 offset;          /* File offset to data */
-    nitf_Uint64 fileLength;      /* Length of compressed data in file */
+    uint64_t offset;          /* File offset to data */
+    uint64_t fileLength;      /* Length of compressed data in file */
 }
 ImplControl;
 
@@ -83,7 +83,7 @@ NITFAPI(void) C8_cleanup(void)
 
 
 NITFPRIV(int) implFreeBlock(nitf_DecompressionControl* control,
-                            nitf_Uint8* block,
+                            uint8_t* block,
                             nitf_Error* error)
 {
     if (block)
@@ -106,9 +106,9 @@ NITFAPI(void*) C8_construct(char *compressionType,
     return((void *) &interfaceTable);
 }
 
-NITFPRIV(nitf_Uint8*) implReadBlock(nitf_DecompressionControl *control,
-                                    nitf_Uint32 blockNumber,
-                                    nitf_Uint64* blockSize,
+NITFPRIV(uint8_t*) implReadBlock(nitf_DecompressionControl *control,
+                                    uint32_t blockNumber,
+                                    uint64_t* blockSize,
                                     nitf_Error* error)
 {
     ImplControl *implControl = (ImplControl*)control;
@@ -119,7 +119,7 @@ NITFPRIV(nitf_Uint8*) implReadBlock(nitf_DecompressionControl *control,
     if (j2k_Reader_canReadTiles(implControl->reader, error))
     {
         /* use j2k_Reader_readTile */
-        nitf_Uint32 tileX, tileY;
+        uint32_t tileX, tileY;
 
         tileY = blockNumber / implControl->blockInfo.numBlocksPerRow;
         tileX = blockNumber % implControl->blockInfo.numBlocksPerRow;
@@ -134,7 +134,7 @@ NITFPRIV(nitf_Uint8*) implReadBlock(nitf_DecompressionControl *control,
     else
     {
         /* use j2k_Reader_readRegion using the block info */
-        nitf_Uint32 tileX, tileY, x0, x1, y0, y1, totalRows, totalCols;
+        uint32_t tileX, tileY, x0, x1, y0, y1, totalRows, totalCols;
 
         tileY = blockNumber / implControl->blockInfo.numBlocksPerRow;
         tileX = blockNumber % implControl->blockInfo.numBlocksPerRow;
@@ -227,10 +227,10 @@ NITFPRIV(nitf_DecompressionControl*) implOpen(nitf_ImageSubheader * subheader,
 
 NITFPRIV(NITF_BOOL) implStart(nitf_DecompressionControl* control,
                               nitf_IOInterface*  io,
-                              nitf_Uint64        offset,
-                              nitf_Uint64        fileLength,
+                              uint64_t        offset,
+                              uint64_t        fileLength,
                               nitf_BlockingInfo* blockInfo,
-                              nitf_Uint64*       blockMask,
+                              uint64_t*       blockMask,
                               nitf_Error*        error)
 {
     ImplControl *implControl = NULL;

--- a/modules/c/j2k/shared/J2KDecompress.c
+++ b/modules/c/j2k/shared/J2KDecompress.c
@@ -112,8 +112,8 @@ NITFPRIV(nitf_Uint8*) implReadBlock(nitf_DecompressionControl *control,
                                     nitf_Error* error)
 {
     ImplControl *implControl = (ImplControl*)control;
-    nrt_Uint8 *buf = NULL;
-    nrt_Uint64 bufSize;
+    uint8_t *buf = NULL;
+    uint64_t bufSize;
     j2k_Container* container = NULL;
 
     if (j2k_Reader_canReadTiles(implControl->reader, error))

--- a/modules/c/j2k/source/Component.c
+++ b/modules/c/j2k/source/Component.c
@@ -22,19 +22,19 @@
 
 #include "j2k/Component.h"
 
-J2KAPI(nrt_Uint32) j2k_Component_getWidth(j2k_Component *component,
+J2KAPI(uint32_t) j2k_Component_getWidth(j2k_Component *component,
                                           nrt_Error *error)
 {
     return component->iface->getWidth(component->data, error);
 }
 
-J2KAPI(nrt_Uint32) j2k_Component_getHeight(j2k_Component *component,
+J2KAPI(uint32_t) j2k_Component_getHeight(j2k_Component *component,
                                            nrt_Error *error)
 {
     return component->iface->getHeight(component->data, error);
 }
 
-J2KAPI(nrt_Uint32) j2k_Component_getPrecision(j2k_Component *component,
+J2KAPI(uint32_t) j2k_Component_getPrecision(j2k_Component *component,
                                               nrt_Error *error)
 {
     return component->iface->getPrecision(component->data, error);
@@ -46,25 +46,25 @@ J2KAPI(NRT_BOOL) j2k_Component_isSigned(j2k_Component *component,
     return component->iface->isSigned(component->data, error);
 }
 
-J2KAPI(nrt_Int32) j2k_Component_getOffsetX(j2k_Component *component,
+J2KAPI(int32_t) j2k_Component_getOffsetX(j2k_Component *component,
                                             nrt_Error *error)
 {
     return component->iface->getOffsetX(component->data, error);
 }
 
-J2KAPI(nrt_Int32) j2k_Component_getOffsetY(j2k_Component *component,
+J2KAPI(int32_t) j2k_Component_getOffsetY(j2k_Component *component,
                                             nrt_Error *error)
 {
     return component->iface->getOffsetY(component->data, error);
 }
 
-J2KAPI(nrt_Uint32) j2k_Component_getSeparationX(j2k_Component *component,
+J2KAPI(uint32_t) j2k_Component_getSeparationX(j2k_Component *component,
                                                 nrt_Error *error)
 {
     return component->iface->getSeparationX(component->data, error);
 }
 
-J2KAPI(nrt_Uint32) j2k_Component_getSeparationY(j2k_Component *component,
+J2KAPI(uint32_t) j2k_Component_getSeparationY(j2k_Component *component,
                                                 nrt_Error *error)
 {
     return component->iface->getSeparationY(component->data, error);

--- a/modules/c/j2k/source/Container.c
+++ b/modules/c/j2k/source/Container.c
@@ -23,35 +23,35 @@
 #include "j2k/Container.h"
 
 
-J2KAPI(nrt_Uint32) j2k_Container_getGridWidth(j2k_Container *container,
+J2KAPI(uint32_t) j2k_Container_getGridWidth(j2k_Container *container,
                                           nrt_Error *error)
 {
     return container->iface->getGridWidth(container->data, error);
 }
 
-J2KAPI(nrt_Uint32) j2k_Container_getGridHeight(j2k_Container *container,
+J2KAPI(uint32_t) j2k_Container_getGridHeight(j2k_Container *container,
                                            nrt_Error *error)
 {
     return container->iface->getGridHeight(container->data, error);
 }
 
-J2KAPI(nrt_Uint32) j2k_Container_getNumComponents(j2k_Container *container,
+J2KAPI(uint32_t) j2k_Container_getNumComponents(j2k_Container *container,
                                                   nrt_Error *error)
 {
     return container->iface->getNumComponents(container->data, error);
 }
 
 J2KAPI(j2k_Component*) j2k_Container_getComponent(j2k_Container *container,
-                                                  nrt_Uint32 idx,
+                                                  uint32_t idx,
                                                   nrt_Error *error)
 {
     return container->iface->getComponent(container->data, idx, error);
 }
 
-J2KAPI(nrt_Uint32) j2k_Container_getWidth(j2k_Container *container,
+J2KAPI(uint32_t) j2k_Container_getWidth(j2k_Container *container,
                                           nrt_Error *error)
 {
-    nrt_Uint32 nComponents, i, width, cWidth;
+    uint32_t nComponents, i, width, cWidth;
     nComponents = j2k_Container_getNumComponents(container, error);
     width = 0;
     for(i = 0; i < nComponents; ++i)
@@ -64,10 +64,10 @@ J2KAPI(nrt_Uint32) j2k_Container_getWidth(j2k_Container *container,
     return width;
 }
 
-J2KAPI(nrt_Uint32) j2k_Container_getHeight(j2k_Container *container,
+J2KAPI(uint32_t) j2k_Container_getHeight(j2k_Container *container,
                                            nrt_Error *error)
 {
-    nrt_Uint32 nComponents, i, height, cHeight;
+    uint32_t nComponents, i, height, cHeight;
     nComponents = j2k_Container_getNumComponents(container, error);
     height = 0;
     for(i = 0; i < nComponents; ++i)
@@ -80,10 +80,10 @@ J2KAPI(nrt_Uint32) j2k_Container_getHeight(j2k_Container *container,
     return height;
 }
 
-J2KAPI(nrt_Uint32) j2k_Container_getPrecision(j2k_Container *container,
+J2KAPI(uint32_t) j2k_Container_getPrecision(j2k_Container *container,
                                               nrt_Error *error)
 {
-    nrt_Uint32 nComponents, i, precision, cPrecision;
+    uint32_t nComponents, i, precision, cPrecision;
     nComponents = j2k_Container_getNumComponents(container, error);
     precision = 0;
     for(i = 0; i < nComponents; ++i)
@@ -96,22 +96,22 @@ J2KAPI(nrt_Uint32) j2k_Container_getPrecision(j2k_Container *container,
     return precision;
 }
 
-J2KAPI(nrt_Uint32) j2k_Container_getTilesX(j2k_Container *container, nrt_Error *error)
+J2KAPI(uint32_t) j2k_Container_getTilesX(j2k_Container *container, nrt_Error *error)
 {
     return container->iface->getTilesX(container->data, error);
 }
 
-J2KAPI(nrt_Uint32) j2k_Container_getTilesY(j2k_Container *container, nrt_Error *error)
+J2KAPI(uint32_t) j2k_Container_getTilesY(j2k_Container *container, nrt_Error *error)
 {
     return container->iface->getTilesY(container->data, error);
 }
 
-J2KAPI(nrt_Uint32) j2k_Container_getTileWidth(j2k_Container *container, nrt_Error *error)
+J2KAPI(uint32_t) j2k_Container_getTileWidth(j2k_Container *container, nrt_Error *error)
 {
     return container->iface->getTileWidth(container->data, error);
 }
 
-J2KAPI(nrt_Uint32) j2k_Container_getTileHeight(j2k_Container *container, nrt_Error *error)
+J2KAPI(uint32_t) j2k_Container_getTileHeight(j2k_Container *container, nrt_Error *error)
 {
     return container->iface->getTileHeight(container->data, error);
 }

--- a/modules/c/j2k/source/JasPerImpl.c
+++ b/modules/c/j2k/source/JasPerImpl.c
@@ -67,12 +67,12 @@ static jas_stream_ops_t IOInterface = {JasPerIO_read, JasPerIO_write,
                                        JasPerIO_seek, JasPerIO_close};
 
 
-J2KPRIV( nrt_Uint64)     JasPerReader_readTile(J2K_USER_DATA *, nrt_Uint32,
-                                               nrt_Uint32, nrt_Uint8 **,
+J2KPRIV( uint64_t)     JasPerReader_readTile(J2K_USER_DATA *, uint32_t,
+                                               uint32_t, uint8_t **,
                                                nrt_Error *);
-J2KPRIV( nrt_Uint64)     JasPerReader_readRegion(J2K_USER_DATA *, nrt_Uint32,
-                                                 nrt_Uint32, nrt_Uint32,
-                                                 nrt_Uint32, nrt_Uint8 **,
+J2KPRIV( uint64_t)     JasPerReader_readRegion(J2K_USER_DATA *, uint32_t,
+                                                 uint32_t, uint32_t,
+                                                 uint32_t, uint8_t **,
                                                  nrt_Error *);
 J2KPRIV( j2k_Container*) JasPerReader_getContainer(J2K_USER_DATA *, nrt_Error *);
 J2KPRIV(void)            JasPerReader_destruct(J2K_USER_DATA *);
@@ -83,8 +83,8 @@ static j2k_IReader ReaderInterface = {NULL, &JasPerReader_readTile,
                                       &JasPerReader_destruct };
 
 J2KPRIV( NRT_BOOL)       JasPerWriter_setTile(J2K_USER_DATA *,
-                                              nrt_Uint32, nrt_Uint32,
-                                              const nrt_Uint8 *, nrt_Uint32,
+                                              uint32_t, uint32_t,
+                                              const uint8_t *, uint32_t,
                                               nrt_Error *);
 J2KPRIV( NRT_BOOL)       JasPerWriter_write(J2K_USER_DATA *, nrt_IOInterface *,
                                             nrt_Error *);
@@ -310,7 +310,7 @@ JasPer_readHeader(JasPerReaderImpl *impl, nrt_Error *error)
     if (!impl->container)
     {
         /* initialize the container */
-        nrt_Uint32 idx, nComponents, width, height;
+        uint32_t idx, nComponents, width, height;
         j2k_Component **components = NULL;
         int imageType;
 
@@ -390,7 +390,7 @@ JasPer_initImage(JasPerWriterImpl *impl, j2k_WriterOptions *writerOps,
     jas_clrspc_t colorSpace;
     jas_image_cmptparm_t *cmptParams = NULL;
     j2k_Component *component = NULL;
-    nrt_Uint32 i, nComponents, height, width, nBits;
+    uint32_t i, nComponents, height, width, nBits;
     int imageType;
     J2K_BOOL isSigned;
 
@@ -472,7 +472,7 @@ JasPer_initImage(JasPerWriterImpl *impl, j2k_WriterOptions *writerOps,
 /******************************************************************************/
 
 #define PRIV_READ_MATRIX(_SZ, _X0, _Y0, _X1, _Y1) { \
-nrt_Uint32 rowIdx, colIdx, rowCt, colCt; \
+uint32_t rowIdx, colIdx, rowCt, colCt; \
 nrt_Uint##_SZ* data##_SZ = (nrt_Uint##_SZ*)bufPtr; \
 jas_matrix_t* matrix##_SZ = NULL; \
 rowCt = _Y1 - _Y0; colCt = _X1 - _X0; \
@@ -491,17 +491,17 @@ for (rowIdx = 0; rowIdx < rowCt; ++rowIdx){ \
 jas_matrix_destroy (matrix##_SZ); }
 
 
-J2KPRIV( nrt_Uint64)
-JasPerReader_readRegion(J2K_USER_DATA *data, nrt_Uint32 x0, nrt_Uint32 y0,
-                  nrt_Uint32 x1, nrt_Uint32 y1, nrt_Uint8 **buf,
+J2KPRIV( uint64_t)
+JasPerReader_readRegion(J2K_USER_DATA *data, uint32_t x0, uint32_t y0,
+                  uint32_t x1, uint32_t y1, uint8_t **buf,
                   nrt_Error *error)
 {
     JasPerReaderImpl *impl = (JasPerReaderImpl*) data;
     jas_stream_t *stream = NULL;
     jas_image_t *image = NULL;
-    nrt_Uint32 i, cmptIdx, nBytes, nComponents;
-    nrt_Uint64 bufSize, componentSize;
-    nrt_Uint8 *bufPtr = NULL;
+    uint32_t i, cmptIdx, nBytes, nComponents;
+    uint64_t bufSize, componentSize;
+    uint8_t *bufPtr = NULL;
 
     if (!JasPer_setup(impl, &stream, &image, error))
     {
@@ -514,13 +514,13 @@ JasPerReader_readRegion(J2K_USER_DATA *data, nrt_Uint32 x0, nrt_Uint32 y0,
         y1 = j2k_Container_getHeight(impl->container, error);
 
     nBytes = (j2k_Container_getPrecision(impl->container, error) - 1) / 8 + 1;
-    componentSize = (nrt_Uint64)(x1 - x0) * (y1 - y0) * nBytes;
+    componentSize = (uint64_t)(x1 - x0) * (y1 - y0) * nBytes;
     nComponents = j2k_Container_getNumComponents(impl->container, error);
     bufSize = componentSize * nComponents;
 
     if (buf && !*buf)
     {
-        *buf = (nrt_Uint8*)J2K_MALLOC(bufSize);
+        *buf = (uint8_t*)J2K_MALLOC(bufSize);
         if (!*buf)
         {
             nrt_Error_init(error, NRT_STRERROR(NRT_ERRNO), NRT_CTXT,
@@ -532,7 +532,7 @@ JasPerReader_readRegion(J2K_USER_DATA *data, nrt_Uint32 x0, nrt_Uint32 y0,
     bufPtr = *buf;
     for (cmptIdx = 0; cmptIdx < nComponents; ++cmptIdx)
     {
-        nrt_Uint32 nRows, nCols;
+        uint32_t nRows, nCols;
         nRows = jas_image_cmptheight(image, cmptIdx) *
                 jas_image_cmptvstep(image, cmptIdx);
         nCols = jas_image_cmptwidth(image, cmptIdx) *
@@ -583,12 +583,12 @@ JasPerReader_readRegion(J2K_USER_DATA *data, nrt_Uint32 x0, nrt_Uint32 y0,
     return bufSize;
 }
 
-J2KPRIV( nrt_Uint64)
-JasPerReader_readTile(J2K_USER_DATA *data, nrt_Uint32 tileX, nrt_Uint32 tileY,
-                nrt_Uint8 **buf, nrt_Error *error)
+J2KPRIV( uint64_t)
+JasPerReader_readTile(J2K_USER_DATA *data, uint32_t tileX, uint32_t tileY,
+                uint8_t **buf, nrt_Error *error)
 {
     JasPerReaderImpl *impl = (JasPerReaderImpl*) data;
-    nrt_Uint32 width, height;
+    uint32_t width, height;
 
     width = j2k_Container_getWidth(impl->container, error);
     height = j2k_Container_getHeight(impl->container, error);
@@ -631,7 +631,7 @@ JasPerReader_destruct(J2K_USER_DATA * data)
 /******************************************************************************/
 
 #define PRIV_WRITE_MATRIX(_SZ) { \
-nrt_Uint32 rowIdx, colIdx, cmpIdx; \
+uint32_t rowIdx, colIdx, cmpIdx; \
 nrt_Uint##_SZ* data##_SZ = (nrt_Uint##_SZ*)buf; \
 jas_matrix_t* matrix##_SZ = jas_matrix_create(tileHeight, tileWidth); \
 if (!matrix##_SZ){ \
@@ -658,13 +658,13 @@ jas_matrix_destroy (matrix##_SZ); }
 
 
 J2KPRIV( NRT_BOOL)
-JasPerWriter_setTile(J2K_USER_DATA *data, nrt_Uint32 tileX, nrt_Uint32 tileY,
-                     const nrt_Uint8 *buf, nrt_Uint32 tileSize,
+JasPerWriter_setTile(J2K_USER_DATA *data, uint32_t tileX, uint32_t tileY,
+                     const uint8_t *buf, uint32_t tileSize,
                      nrt_Error *error)
 {
     JasPerWriterImpl *impl = (JasPerWriterImpl*) data;
     NRT_BOOL rc = NRT_SUCCESS;
-    nrt_Uint32 i, nComponents, tileHeight, tileWidth, nBits, nBytes;
+    uint32_t i, nComponents, tileHeight, tileWidth, nBits, nBytes;
 
     nComponents = j2k_Container_getNumComponents(impl->container, error);
     tileWidth = j2k_Container_getTileWidth(impl->container, error);

--- a/modules/c/j2k/source/KakaduImpl.cpp
+++ b/modules/c/j2k/source/KakaduImpl.cpp
@@ -38,15 +38,15 @@
 /* TYPES & DECLARATIONS                                                       */
 /******************************************************************************/
 
-J2KPRIV( nrt_Uint32) KakaduContainer_getTilesX(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32) KakaduContainer_getTilesY(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32) KakaduContainer_getTileWidth(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32) KakaduContainer_getTileHeight(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32) KakaduContainer_getWidth(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32) KakaduContainer_getHeight(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32) KakaduContainer_getNumComponents(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32) KakaduContainer_getComponentBytes(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32) KakaduContainer_getComponentBits(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) KakaduContainer_getTilesX(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) KakaduContainer_getTilesY(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) KakaduContainer_getTileWidth(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) KakaduContainer_getTileHeight(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) KakaduContainer_getWidth(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) KakaduContainer_getHeight(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) KakaduContainer_getNumComponents(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) KakaduContainer_getComponentBytes(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) KakaduContainer_getComponentBits(J2K_USER_DATA *, nrt_Error *);
 J2KPRIV( int)        KakaduContainer_getImageType(J2K_USER_DATA *, nrt_Error *);
 J2KPRIV( J2K_BOOL)   KakaduContainer_isSigned(J2K_USER_DATA *, nrt_Error *);
 J2KPRIV(void)        KakaduContainer_destruct(J2K_USER_DATA *);
@@ -65,12 +65,12 @@ static j2k_IContainer ContainerInterface = { &KakaduContainer_getTilesX,
                                              &KakaduContainer_destruct};
 
 J2KPRIV( NRT_BOOL  )     KakaduReader_canReadTiles(J2K_USER_DATA *,  nrt_Error *);
-J2KPRIV( nrt_Uint64)     KakaduReader_readTile(J2K_USER_DATA *, nrt_Uint32,
-                                               nrt_Uint32, nrt_Uint8 **,
+J2KPRIV( uint64_t)     KakaduReader_readTile(J2K_USER_DATA *, uint32_t,
+                                               uint32_t, uint8_t **,
                                                nrt_Error *);
-J2KPRIV( nrt_Uint64)     KakaduReader_readRegion(J2K_USER_DATA *, nrt_Uint32,
-                                                 nrt_Uint32, nrt_Uint32,
-                                                 nrt_Uint32, nrt_Uint8 **,
+J2KPRIV( uint64_t)     KakaduReader_readRegion(J2K_USER_DATA *, uint32_t,
+                                                 uint32_t, uint32_t,
+                                                 uint32_t, uint8_t **,
                                                  nrt_Error *);
 J2KPRIV( j2k_Container*) KakaduReader_getContainer(J2K_USER_DATA *, nrt_Error *);
 J2KPRIV(void)            KakaduReader_destruct(J2K_USER_DATA *);
@@ -82,8 +82,8 @@ static j2k_IReader ReaderInterface = {&KakaduReader_canReadTiles,
                                       &KakaduReader_destruct };
 
 J2KPRIV( NRT_BOOL)       KakaduWriter_setTile(J2K_USER_DATA *,
-                                              nrt_Uint32, nrt_Uint32,
-                                              nrt_Uint8 *, nrt_Uint32,
+                                              uint32_t, uint32_t,
+                                              uint8_t *, uint32_t,
                                               nrt_Error *);
 J2KPRIV( NRT_BOOL)       KakaduWriter_write(J2K_USER_DATA *, nrt_IOInterface *,
                                             nrt_Error *);
@@ -197,7 +197,7 @@ protected:
 
 
 
-void copyLine(nrt_Uint8 *dest, kdu_line_buf &src, int bitsPerSample,
+void copyLine(uint8_t *dest, kdu_line_buf &src, int bitsPerSample,
               int outputBytes)
 {
     int samples = src.get_width();
@@ -241,7 +241,7 @@ void copyLine(nrt_Uint8 *dest, kdu_line_buf &src, int bitsPerSample,
 
 #if 0
 void
-copyBlock(nrt_Uint8 *dest, kdu_block *block, int bitsPerSample, int outputBytes)
+copyBlock(uint8_t *dest, kdu_block *block, int bitsPerSample, int outputBytes)
 {
     size_t samples = (size_t)block->size.x * block->size.y;
     size_t i;
@@ -276,12 +276,12 @@ public:
     {
     }
 
-    UserContainer(nrt_Uint32 width,
-                  nrt_Uint32 height,
-                  nrt_Uint32 bands,
-                  nrt_Uint32 actualBitsPerPixel,
-                  nrt_Uint32 tileWidth,
-                  nrt_Uint32 tileHeight,
+    UserContainer(uint32_t width,
+                  uint32_t height,
+                  uint32_t bands,
+                  uint32_t actualBitsPerPixel,
+                  uint32_t tileWidth,
+                  uint32_t tileHeight,
                   int imageType = J2K_TYPE_UNKNOWN,
                   bool isSigned = false) :
                       mWidth(width),
@@ -295,47 +295,47 @@ public:
     {
     }
 
-    nrt_Uint32 getNumComponents() const
+    uint32_t getNumComponents() const
     {
         return mComponents;
     }
 
-    nrt_Uint32 getWidth() const
+    uint32_t getWidth() const
     {
         return mWidth;
     }
 
-    nrt_Uint32 getHeight() const
+    uint32_t getHeight() const
     {
         return mHeight;
     }
 
-    nrt_Uint32 getComponentBytes() const
+    uint32_t getComponentBytes() const
     {
         return (getActualBitsPerPixel() - 1) / 8 + 1;
     }
 
-    nrt_Uint32 getActualBitsPerPixel() const
+    uint32_t getActualBitsPerPixel() const
     {
         return mBitsPerPixel;
     }
 
-    nrt_Uint32 getTileWidth() const
+    uint32_t getTileWidth() const
     {
         return mTileWidth;
     }
 
-    nrt_Uint32 getTileHeight() const
+    uint32_t getTileHeight() const
     {
         return mTileHeight;
     }
 
-    nrt_Uint32 getTilesX() const
+    uint32_t getTilesX() const
     {
         return mWidth / mTileWidth + (mWidth % mTileWidth == 0 ? 0 : 1);
     }
 
-    nrt_Uint32 getTilesY() const
+    uint32_t getTilesY() const
     {
         return mHeight / mTileHeight + (mHeight % mTileHeight == 0 ? 0 : 1);
     }
@@ -353,8 +353,8 @@ public:
 
 protected:
     friend class Reader;
-    nrt_Uint32 mHeight, mWidth, mComponents, mBitsPerPixel;
-    nrt_Uint32 mTileWidth, mTileHeight;
+    uint32_t mHeight, mWidth, mComponents, mBitsPerPixel;
+    uint32_t mTileWidth, mTileHeight;
     int mType;
     bool mSigned;
 };
@@ -395,18 +395,18 @@ public:
         return mContainer;
     }
 
-    nrt_Uint64 readTile(nrt_Uint32 tileX, nrt_Uint32 tileY, nrt_Uint8 **buf)
+    uint64_t readTile(uint32_t tileX, uint32_t tileY, uint8_t **buf)
     {
         UserContainer *container = getUserContainer();
-        nrt_Uint32 nComps = container->getNumComponents();
-        nrt_Uint32 sampleSize = container->getComponentBytes();
-        nrt_Uint64 lineSize = (nrt_Uint64)container->getTileWidth() * sampleSize;
-        nrt_Uint64 compSize = lineSize * container->getTileHeight();
+        uint32_t nComps = container->getNumComponents();
+        uint32_t sampleSize = container->getComponentBytes();
+        uint64_t lineSize = (uint64_t)container->getTileWidth() * sampleSize;
+        uint64_t compSize = lineSize * container->getTileHeight();
 
-        nrt_Uint64 bufSize = compSize * nComps;
+        uint64_t bufSize = compSize * nComps;
         if (buf && !*buf)
         {
-            *buf = (nrt_Uint8*)J2K_MALLOC(bufSize);
+            *buf = (uint8_t*)J2K_MALLOC(bufSize);
             if (!*buf)
                 throw std::string("Out of memory");
         }
@@ -417,8 +417,8 @@ public:
         int tileComponents = tile.get_num_components();
         assert(tileComponents == nComps);
 
-        nrt_Uint8 *bufPtr = *buf;
-        for(nrt_Uint32 i = 0; i < nComps; ++i)
+        uint8_t *bufPtr = *buf;
+        for(uint32_t i = 0; i < nComps; ++i)
         {
             kdu_tile_comp tileComponent = tile.access_component(i);
             kdu_resolution tileRes = tileComponent.access_resolution();
@@ -451,9 +451,9 @@ public:
 
 #if 0
             int minBand;
-            nrt_Uint32 nBands = tileRes.get_valid_band_indices(minBand);
+            uint32_t nBands = tileRes.get_valid_band_indices(minBand);
 
-            for(nrt_Uint32 b = minBand; nBands > 0; --nBands, ++b)
+            for(uint32_t b = minBand; nBands > 0; --nBands, ++b)
             {
                 kdu_subband tileBand = tileRes.access_subband(b);
                 kdu_dims validBlocks;
@@ -518,14 +518,14 @@ protected:
 
         kdu_dims compSize;
         mCodestream->get_dims(-1, compSize, true);
-        container->mWidth = (nrt_Uint32)(compSize.size.x);
-        container->mHeight = (nrt_Uint32)(compSize.size.y);
+        container->mWidth = (uint32_t)(compSize.size.x);
+        container->mHeight = (uint32_t)(compSize.size.y);
         container->mBitsPerPixel = mCodestream->get_bit_depth(-1, true);
 
         kdu_dims partition;
         mCodestream->get_tile_partition(partition);
-        container->mTileWidth = (nrt_Uint32)partition.size.x;
-        container->mTileHeight = (nrt_Uint32)partition.size.y;
+        container->mTileWidth = (uint32_t)partition.size.x;
+        container->mTileHeight = (uint32_t)partition.size.y;
 
 //        kdu_dims indices;
 //        mCodestream->get_valid_tiles(indices);
@@ -543,63 +543,63 @@ protected:
 /* CONTAINER                                                                  */
 /******************************************************************************/
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 KakaduContainer_getTilesX(J2K_USER_DATA *data, nrt_Error *error)
 {
     j2k::kakadu::UserContainer *impl = (j2k::kakadu::UserContainer*) data;
     return impl->getTilesX();
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 KakaduContainer_getTilesY(J2K_USER_DATA *data, nrt_Error *error)
 {
     j2k::kakadu::UserContainer *impl = (j2k::kakadu::UserContainer*) data;
     return impl->getTilesY();
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 KakaduContainer_getTileWidth(J2K_USER_DATA *data, nrt_Error *error)
 {
     j2k::kakadu::UserContainer *impl = (j2k::kakadu::UserContainer*) data;
     return impl->getTileWidth();
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 KakaduContainer_getTileHeight(J2K_USER_DATA *data, nrt_Error *error)
 {
     j2k::kakadu::UserContainer *impl = (j2k::kakadu::UserContainer*) data;
     return impl->getTileHeight();
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 KakaduContainer_getWidth(J2K_USER_DATA *data, nrt_Error *error)
 {
     j2k::kakadu::UserContainer *impl = (j2k::kakadu::UserContainer*) data;
     return impl->getWidth();
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 KakaduContainer_getHeight(J2K_USER_DATA *data, nrt_Error *error)
 {
     j2k::kakadu::UserContainer *impl = (j2k::kakadu::UserContainer*) data;
     return impl->getHeight();
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 KakaduContainer_getNumComponents(J2K_USER_DATA *data, nrt_Error *error)
 {
     j2k::kakadu::UserContainer *impl = (j2k::kakadu::UserContainer*) data;
     return impl->getNumComponents();
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 KakaduContainer_getComponentBytes(J2K_USER_DATA *data, nrt_Error *error)
 {
     j2k::kakadu::UserContainer *impl = (j2k::kakadu::UserContainer*) data;
     return impl->getComponentBytes();
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 KakaduContainer_getComponentBits(J2K_USER_DATA *data, nrt_Error *error)
 {
     j2k::kakadu::UserContainer *impl = (j2k::kakadu::UserContainer*) data;
@@ -640,9 +640,9 @@ KakaduReader_canReadTiles(J2K_USER_DATA *data, nrt_Error *error)
     return NRT_SUCCESS;
 }
 
-J2KPRIV( nrt_Uint64)
-KakaduReader_readTile(J2K_USER_DATA *data, nrt_Uint32 tileX, nrt_Uint32 tileY,
-                  nrt_Uint8 **buf, nrt_Error *error)
+J2KPRIV( uint64_t)
+KakaduReader_readTile(J2K_USER_DATA *data, uint32_t tileX, uint32_t tileY,
+                  uint8_t **buf, nrt_Error *error)
 {
     j2k::kakadu::Reader *reader = (j2k::kakadu::Reader*) data;
 
@@ -657,9 +657,9 @@ KakaduReader_readTile(J2K_USER_DATA *data, nrt_Uint32 tileX, nrt_Uint32 tileY,
     }
 }
 
-J2KPRIV( nrt_Uint64)
-KakaduReader_readRegion(J2K_USER_DATA *data, nrt_Uint32 x0, nrt_Uint32 y0,
-                    nrt_Uint32 x1, nrt_Uint32 y1, nrt_Uint8 **buf,
+J2KPRIV( uint64_t)
+KakaduReader_readRegion(J2K_USER_DATA *data, uint32_t x0, uint32_t y0,
+                    uint32_t x1, uint32_t y1, uint8_t **buf,
                     nrt_Error *error)
 {
     j2k::kakadu::Reader *reader = (j2k::kakadu::Reader*) data;
@@ -689,8 +689,8 @@ KakaduReader_destruct(J2K_USER_DATA * data)
 /******************************************************************************/
 
 J2KPRIV( NRT_BOOL)
-KakaduWriter_setTile(J2K_USER_DATA *data, nrt_Uint32 tileX, nrt_Uint32 tileY,
-                     nrt_Uint8 *buf, nrt_Uint32 tileSize, nrt_Error *error)
+KakaduWriter_setTile(J2K_USER_DATA *data, uint32_t tileX, uint32_t tileY,
+                     uint8_t *buf, uint32_t tileSize, nrt_Error *error)
 {
     nrt_Error_init(error, "Writer->setTile not yet implemented",
                    NRT_CTXT, NRT_ERR_INVALID_OBJECT);
@@ -804,12 +804,12 @@ J2KAPI(j2k_Reader*) j2k_Reader_openIO(nrt_IOInterface *io, nrt_Error *error)
     }
 }
 
-J2KAPI(j2k_Container*) j2k_Container_construct(nrt_Uint32 width,
-        nrt_Uint32 height,
-        nrt_Uint32 bands,
-        nrt_Uint32 actualBitsPerPixel,
-        nrt_Uint32 tileWidth,
-        nrt_Uint32 tileHeight,
+J2KAPI(j2k_Container*) j2k_Container_construct(uint32_t width,
+        uint32_t height,
+        uint32_t bands,
+        uint32_t actualBitsPerPixel,
+        uint32_t tileWidth,
+        uint32_t tileHeight,
         int imageType,
         int isSigned,
         nrt_Error *error)

--- a/modules/c/j2k/source/OpenJPEGImpl.c
+++ b/modules/c/j2k/source/OpenJPEGImpl.c
@@ -83,12 +83,12 @@ J2KPRIV(OPJ_SIZE_T) implStreamWrite(void *buf, OPJ_SIZE_T bytes, void *data);
 
 
 J2KPRIV( NRT_BOOL  )     OpenJPEGReader_canReadTiles(J2K_USER_DATA *,  nrt_Error *);
-J2KPRIV( nrt_Uint64)     OpenJPEGReader_readTile(J2K_USER_DATA *, nrt_Uint32,
-                                                 nrt_Uint32, nrt_Uint8 **,
+J2KPRIV( uint64_t)     OpenJPEGReader_readTile(J2K_USER_DATA *, uint32_t,
+                                                 uint32_t, uint8_t **,
                                                  nrt_Error *);
-J2KPRIV( nrt_Uint64)     OpenJPEGReader_readRegion(J2K_USER_DATA *, nrt_Uint32,
-                                                   nrt_Uint32, nrt_Uint32,
-                                                   nrt_Uint32, nrt_Uint8 **,
+J2KPRIV( uint64_t)     OpenJPEGReader_readRegion(J2K_USER_DATA *, uint32_t,
+                                                   uint32_t, uint32_t,
+                                                   uint32_t, uint8_t **,
                                                    nrt_Error *);
 J2KPRIV( j2k_Container*) OpenJPEGReader_getContainer(J2K_USER_DATA *, nrt_Error *);
 J2KPRIV(void)            OpenJPEGReader_destruct(J2K_USER_DATA *);
@@ -100,8 +100,8 @@ static j2k_IReader ReaderInterface = {&OpenJPEGReader_canReadTiles,
                                       &OpenJPEGReader_destruct };
 
 J2KPRIV( NRT_BOOL)       OpenJPEGWriter_setTile(J2K_USER_DATA *,
-                                                nrt_Uint32, nrt_Uint32,
-                                                const nrt_Uint8 *, nrt_Uint32,
+                                                uint32_t, uint32_t,
+                                                const uint8_t *, uint32_t,
                                                 nrt_Error *);
 J2KPRIV( NRT_BOOL)       OpenJPEGWriter_write(J2K_USER_DATA *, nrt_IOInterface *,
                                               nrt_Error *);
@@ -389,7 +389,7 @@ OpenJPEG_readHeader(OpenJPEGReaderImpl *impl, nrt_Error *error)
     if (!impl->container)
     {
         /* initialize the container */
-        nrt_Uint32 idx;
+        uint32_t idx;
         j2k_Component **components = NULL;
         int imageType;
 
@@ -460,8 +460,8 @@ J2KPRIV( NRT_BOOL) OpenJPEG_initImage(OpenJPEGWriterImpl *impl,
                                       nrt_Error *error)
 {
     NRT_BOOL rc = NRT_SUCCESS;
-    nrt_Uint32 i, nComponents, height, width, tileHeight, tileWidth;
-    nrt_Uint32 nBytes;
+    uint32_t i, nComponents, height, width, tileHeight, tileWidth;
+    uint32_t nBytes;
     j2k_Component *component = NULL;
     size_t uncompressedSize;
     int imageType;
@@ -658,21 +658,21 @@ OpenJPEGReader_canReadTiles(J2K_USER_DATA *data, nrt_Error *error)
     return NRT_SUCCESS;
 }
 
-J2KPRIV( nrt_Uint64)
-OpenJPEGReader_readTile(J2K_USER_DATA *data, nrt_Uint32 tileX, nrt_Uint32 tileY,
-                  nrt_Uint8 **buf, nrt_Error *error)
+J2KPRIV( uint64_t)
+OpenJPEGReader_readTile(J2K_USER_DATA *data, uint32_t tileX, uint32_t tileY,
+                  uint8_t **buf, nrt_Error *error)
 {
     OpenJPEGReaderImpl *impl = (OpenJPEGReaderImpl*) data;
 
     opj_stream_t *stream = NULL;
     opj_image_t *image = NULL;
     opj_codec_t *codec = NULL;
-    nrt_Uint32 bufSize;
+    uint32_t bufSize;
     const OPJ_UINT32 tileWidth = j2k_Container_getTileWidth(impl->container, error);
     const OPJ_UINT32 tileHeight = j2k_Container_getTileHeight(impl->container, error);
     size_t numBitsPerPixel = 0;
     size_t numBytesPerPixel = 0;
-    nrt_Uint64 fullBufSize = 0;
+    uint64_t fullBufSize = 0;
 
     if (!OpenJPEG_setup(impl, &stream, &codec, error))
     {
@@ -756,7 +756,7 @@ OpenJPEGReader_readTile(J2K_USER_DATA *data, nrt_Uint32 tileX, nrt_Uint32 tileY,
 
             if (buf && !*buf)
             {
-                *buf = (nrt_Uint8*)J2K_MALLOC(fullBufSize);
+                *buf = (uint8_t*)J2K_MALLOC(fullBufSize);
                 if (!*buf)
                 {
                     nrt_Error_init(error, NRT_STRERROR(NRT_ERRNO), NRT_CTXT,
@@ -785,13 +785,13 @@ OpenJPEGReader_readTile(J2K_USER_DATA *data, nrt_Uint32 tileX, nrt_Uint32 tileY,
                 size_t srcOffset = lastRow * srcStride;
                 size_t destOffset = lastRow * destStride;
                 OPJ_UINT32 ii;
-                nrt_Uint8* bufPtr = *buf;
+                uint8_t* bufPtr = *buf;
 
                 for (ii = 0;
                      ii < thisTileHeight;
                      ++ii, srcOffset -= srcStride, destOffset -= destStride)
                 {
-                    nrt_Uint8* const dest = bufPtr + destOffset;
+                    uint8_t* const dest = bufPtr + destOffset;
                     memmove(dest, bufPtr + srcOffset, srcStride);
                     memset(dest + srcStride, 0, numLeftoverBytes);
                 }
@@ -813,9 +813,9 @@ OpenJPEGReader_readTile(J2K_USER_DATA *data, nrt_Uint32 tileX, nrt_Uint32 tileY,
     return fullBufSize;
 }
 
-J2KPRIV( nrt_Uint64)
-OpenJPEGReader_readRegion(J2K_USER_DATA *data, nrt_Uint32 x0, nrt_Uint32 y0,
-                          nrt_Uint32 x1, nrt_Uint32 y1, nrt_Uint8 **buf,
+J2KPRIV( uint64_t)
+OpenJPEGReader_readRegion(J2K_USER_DATA *data, uint32_t x0, uint32_t y0,
+                          uint32_t x1, uint32_t y1, uint8_t **buf,
                           nrt_Error *error)
 {
     OpenJPEGReaderImpl *impl = (OpenJPEGReaderImpl*) data;
@@ -823,9 +823,9 @@ OpenJPEGReader_readRegion(J2K_USER_DATA *data, nrt_Uint32 x0, nrt_Uint32 y0,
     opj_stream_t *stream = NULL;
     opj_image_t *image = NULL;
     opj_codec_t *codec = NULL;
-    nrt_Uint64 bufSize;
-    nrt_Uint64 offset = 0;
-    nrt_Uint32 componentBytes, nComponents;
+    uint64_t bufSize;
+    uint64_t offset = 0;
+    uint32_t componentBytes, nComponents;
 
     if (!OpenJPEG_setup(impl, &stream, &codec, error))
     {
@@ -853,10 +853,10 @@ OpenJPEGReader_readRegion(J2K_USER_DATA *data, nrt_Uint32 x0, nrt_Uint32 y0,
 
     nComponents = j2k_Container_getNumComponents(impl->container, error);
     componentBytes = (j2k_Container_getPrecision(impl->container, error) - 1) / 8 + 1;
-    bufSize = (nrt_Uint64)(x1 - x0) * (y1 - y0) * componentBytes * nComponents;
+    bufSize = (uint64_t)(x1 - x0) * (y1 - y0) * componentBytes * nComponents;
     if (buf && !*buf)
     {
-        *buf = (nrt_Uint8*)J2K_MALLOC(bufSize);
+        *buf = (uint8_t*)J2K_MALLOC(bufSize);
         if (!*buf)
         {
             nrt_Error_init(error, NRT_STRERROR(NRT_ERRNO), NRT_CTXT,
@@ -942,15 +942,15 @@ OpenJPEGReader_destruct(J2K_USER_DATA * data)
 /******************************************************************************/
 
 J2KPRIV( NRT_BOOL)
-OpenJPEGWriter_setTile(J2K_USER_DATA *data, nrt_Uint32 tileX, nrt_Uint32 tileY,
-                       const nrt_Uint8 *buf, nrt_Uint32 tileSize,
+OpenJPEGWriter_setTile(J2K_USER_DATA *data, uint32_t tileX, uint32_t tileY,
+                       const uint8_t *buf, uint32_t tileSize,
                        nrt_Error *error)
 {
     OpenJPEGWriterImpl *impl = (OpenJPEGWriterImpl*) data;
     NRT_BOOL rc = NRT_SUCCESS;
-    nrt_Uint32 xTiles, yTiles, tileIndex, width, height, tileWidth, tileHeight;
-    nrt_Uint32 thisTileWidth, thisTileHeight, thisTileSize, nComponents, nBytes;
-    nrt_Uint8* newTileBuf = NULL;
+    uint32_t xTiles, yTiles, tileIndex, width, height, tileWidth, tileHeight;
+    uint32_t thisTileWidth, thisTileHeight, thisTileSize, nComponents, nBytes;
+    uint8_t* newTileBuf = NULL;
 
     xTiles = j2k_Container_getTilesX(impl->container, error);
     yTiles = j2k_Container_getTilesY(impl->container, error);
@@ -1010,7 +1010,7 @@ OpenJPEGWriter_setTile(J2K_USER_DATA *data, nrt_Uint32 tileX, nrt_Uint32 tileY,
             const size_t srcStride = tileWidth * nBytes;
             const size_t destStride = thisTileWidth * nBytes;
 
-            newTileBuf = (nrt_Uint8*) J2K_MALLOC(thisTileSize);
+            newTileBuf = (uint8_t*) J2K_MALLOC(thisTileSize);
             if(!newTileBuf)
             {
                 nrt_Error_init(error, NRT_STRERROR(NRT_ERRNO), NRT_CTXT, NRT_ERR_MEMORY);

--- a/modules/c/j2k/source/Reader.c
+++ b/modules/c/j2k/source/Reader.c
@@ -30,16 +30,16 @@ J2KAPI(NRT_BOOL) j2k_Reader_canReadTiles(j2k_Reader *reader, nrt_Error *error)
     return NRT_FAILURE;
 }
 
-J2KAPI(nrt_Uint64) j2k_Reader_readTile(j2k_Reader *reader,
-        nrt_Uint32 tileX, nrt_Uint32 tileY,
-        nrt_Uint8 **buf, nrt_Error *error)
+J2KAPI(uint64_t) j2k_Reader_readTile(j2k_Reader *reader,
+        uint32_t tileX, uint32_t tileY,
+        uint8_t **buf, nrt_Error *error)
 {
     return reader->iface->readTile(reader->data, tileX, tileY, buf, error);
 }
 
-J2KAPI(nrt_Uint64) j2k_Reader_readRegion(j2k_Reader *reader,
-        nrt_Uint32 x0, nrt_Uint32 y0, nrt_Uint32 x1, nrt_Uint32 y1,
-        nrt_Uint8 **buf, nrt_Error *error)
+J2KAPI(uint64_t) j2k_Reader_readRegion(j2k_Reader *reader,
+        uint32_t x0, uint32_t y0, uint32_t x1, uint32_t y1,
+        uint8_t **buf, nrt_Error *error)
 {
     return reader->iface->readRegion(reader->data, x0, y0, x1, y1, buf, error);
 }

--- a/modules/c/j2k/source/SimpleComponentImpl.c
+++ b/modules/c/j2k/source/SimpleComponentImpl.c
@@ -25,25 +25,25 @@
 
 typedef struct _ComponentImpl
 {
-    nrt_Uint32 width;
-    nrt_Uint32 height;
-    nrt_Uint32 precision;
+    uint32_t width;
+    uint32_t height;
+    uint32_t precision;
     NRT_BOOL isSigned;
-    nrt_Int32 x0;
-    nrt_Int32 y0;
-    nrt_Uint32 xSeparation;
-    nrt_Uint32 ySeparation;
+    int32_t x0;
+    int32_t y0;
+    uint32_t xSeparation;
+    uint32_t ySeparation;
 
 } ComponentImpl;
 
-J2KPRIV( nrt_Uint32) Component_getWidth(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32) Component_getHeight(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32) Component_getPrecision(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) Component_getWidth(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) Component_getHeight(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) Component_getPrecision(J2K_USER_DATA *, nrt_Error *);
 J2KPRIV( J2K_BOOL)   Component_isSigned(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Int32)  Component_getOffsetX(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Int32)  Component_getOffsetY(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32) Component_getSeparationX(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32) Component_getSeparationY(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( int32_t)  Component_getOffsetX(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( int32_t)  Component_getOffsetY(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) Component_getSeparationX(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t) Component_getSeparationY(J2K_USER_DATA *, nrt_Error *);
 J2KPRIV(void)        Component_destruct(J2K_USER_DATA *);
 
 static j2k_IComponent ComponentInterface = { &Component_getWidth,
@@ -56,21 +56,21 @@ static j2k_IComponent ComponentInterface = { &Component_getWidth,
                                              &Component_getSeparationY,
                                              &Component_destruct};
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 Component_getWidth(J2K_USER_DATA *data, nrt_Error *error)
 {
     ComponentImpl *impl = (ComponentImpl*) data;
     return impl->width;
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 Component_getHeight(J2K_USER_DATA *data, nrt_Error *error)
 {
     ComponentImpl *impl = (ComponentImpl*) data;
     return impl->height;
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 Component_getPrecision(J2K_USER_DATA *data, nrt_Error *error)
 {
     ComponentImpl *impl = (ComponentImpl*) data;
@@ -84,28 +84,28 @@ Component_isSigned(J2K_USER_DATA *data, nrt_Error *error)
     return impl->isSigned;
 }
 
-J2KPRIV( nrt_Int32)
+J2KPRIV( int32_t)
 Component_getOffsetX(J2K_USER_DATA *data, nrt_Error *error)
 {
     ComponentImpl *impl = (ComponentImpl*) data;
     return impl->x0;
 }
 
-J2KPRIV( nrt_Int32)
+J2KPRIV( int32_t)
 Component_getOffsetY(J2K_USER_DATA *data, nrt_Error *error)
 {
     ComponentImpl *impl = (ComponentImpl*) data;
     return impl->y0;
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 Component_getSeparationX(J2K_USER_DATA *data, nrt_Error *error)
 {
     ComponentImpl *impl = (ComponentImpl*) data;
     return impl->xSeparation;
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 Component_getSeparationY(J2K_USER_DATA *data, nrt_Error *error)
 {
     ComponentImpl *impl = (ComponentImpl*) data;
@@ -123,14 +123,14 @@ Component_destruct(J2K_USER_DATA * data)
 }
 
 
-J2KAPI(j2k_Component*) j2k_Component_construct(nrt_Uint32 width,
-                                               nrt_Uint32 height,
-                                               nrt_Uint32 precision,
+J2KAPI(j2k_Component*) j2k_Component_construct(uint32_t width,
+                                               uint32_t height,
+                                               uint32_t precision,
                                                NRT_BOOL isSigned,
-                                               nrt_Uint32 offsetX,
-                                               nrt_Uint32 offsetY,
-                                               nrt_Uint32 separationX,
-                                               nrt_Uint32 separationY,
+                                               uint32_t offsetX,
+                                               uint32_t offsetY,
+                                               uint32_t separationX,
+                                               uint32_t separationY,
                                                nrt_Error *error)
 {
     j2k_Component *component = NULL;

--- a/modules/c/j2k/source/SimpleContainerImpl.c
+++ b/modules/c/j2k/source/SimpleContainerImpl.c
@@ -25,26 +25,26 @@
 
 typedef struct _ContainerImpl
 {
-    nrt_Uint32 gridWidth;
-    nrt_Uint32 gridHeight;
-    nrt_Uint32 nComponents;
+    uint32_t gridWidth;
+    uint32_t gridHeight;
+    uint32_t nComponents;
     j2k_Component **components;
-    nrt_Uint32 xTiles;
-    nrt_Uint32 yTiles;
-    nrt_Uint32 tileWidth;
-    nrt_Uint32 tileHeight;
+    uint32_t xTiles;
+    uint32_t yTiles;
+    uint32_t tileWidth;
+    uint32_t tileHeight;
     int imageType;
 } ContainerImpl;
 
 
-J2KPRIV( nrt_Uint32)    Container_getGridWidth(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32)    Container_getGridHeight(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32)    Container_getNumComponents(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( j2k_Component*)Container_getComponent(J2K_USER_DATA *, nrt_Uint32, nrt_Error *);
-J2KPRIV( nrt_Uint32)    Container_getTilesX(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32)    Container_getTilesY(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32)    Container_getTileWidth(J2K_USER_DATA *, nrt_Error *);
-J2KPRIV( nrt_Uint32)    Container_getTileHeight(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t)    Container_getGridWidth(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t)    Container_getGridHeight(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t)    Container_getNumComponents(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( j2k_Component*)Container_getComponent(J2K_USER_DATA *, uint32_t, nrt_Error *);
+J2KPRIV( uint32_t)    Container_getTilesX(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t)    Container_getTilesY(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t)    Container_getTileWidth(J2K_USER_DATA *, nrt_Error *);
+J2KPRIV( uint32_t)    Container_getTileHeight(J2K_USER_DATA *, nrt_Error *);
 J2KPRIV( int)           Container_getImageType(J2K_USER_DATA *, nrt_Error *);
 J2KPRIV(void)           Container_destruct(J2K_USER_DATA *);
 
@@ -59,21 +59,21 @@ static j2k_IContainer ContainerInterface = { &Container_getGridWidth,
                                              &Container_getImageType,
                                              &Container_destruct};
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 Container_getGridWidth(J2K_USER_DATA *data, nrt_Error *error)
 {
     ContainerImpl *impl = (ContainerImpl*) data;
     return impl->gridWidth;
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 Container_getGridHeight(J2K_USER_DATA *data, nrt_Error *error)
 {
     ContainerImpl *impl = (ContainerImpl*) data;
     return impl->gridHeight;
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 Container_getNumComponents(J2K_USER_DATA *data, nrt_Error *error)
 {
     ContainerImpl *impl = (ContainerImpl*) data;
@@ -81,7 +81,7 @@ Container_getNumComponents(J2K_USER_DATA *data, nrt_Error *error)
 }
 
 J2KPRIV( j2k_Component*)
-Container_getComponent(J2K_USER_DATA *data, nrt_Uint32 idx, nrt_Error *error)
+Container_getComponent(J2K_USER_DATA *data, uint32_t idx, nrt_Error *error)
 {
     ContainerImpl *impl = (ContainerImpl*) data;
     if (idx >= impl->nComponents)
@@ -93,28 +93,28 @@ Container_getComponent(J2K_USER_DATA *data, nrt_Uint32 idx, nrt_Error *error)
     return impl->components[idx];
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 Container_getTilesX(J2K_USER_DATA *data, nrt_Error *error)
 {
     ContainerImpl *impl = (ContainerImpl*) data;
     return impl->xTiles;
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 Container_getTilesY(J2K_USER_DATA *data, nrt_Error *error)
 {
     ContainerImpl *impl = (ContainerImpl*) data;
     return impl->yTiles;
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 Container_getTileWidth(J2K_USER_DATA *data, nrt_Error *error)
 {
     ContainerImpl *impl = (ContainerImpl*) data;
     return impl->tileWidth;
 }
 
-J2KPRIV( nrt_Uint32)
+J2KPRIV( uint32_t)
 Container_getTileHeight(J2K_USER_DATA *data, nrt_Error *error)
 {
     ContainerImpl *impl = (ContainerImpl*) data;
@@ -136,7 +136,7 @@ Container_destruct(J2K_USER_DATA * data)
         ContainerImpl *impl = (ContainerImpl*) data;
         if (impl->components)
         {
-            nrt_Uint32 i = 0;
+            uint32_t i = 0;
             for(; i < impl->nComponents; ++i)
             {
                 j2k_Component *c = impl->components[i];
@@ -151,12 +151,12 @@ Container_destruct(J2K_USER_DATA * data)
 }
 
 
-J2KAPI(j2k_Container*) j2k_Container_construct(nrt_Uint32 gridWidth,
-                                               nrt_Uint32 gridHeight,
-                                               nrt_Uint32 numComponents,
+J2KAPI(j2k_Container*) j2k_Container_construct(uint32_t gridWidth,
+                                               uint32_t gridHeight,
+                                               uint32_t numComponents,
                                                j2k_Component** components,
-                                               nrt_Uint32 tileWidth,
-                                               nrt_Uint32 tileHeight,
+                                               uint32_t tileWidth,
+                                               uint32_t tileHeight,
                                                int imageType,
                                                nrt_Error *error)
 {

--- a/modules/c/j2k/source/Writer.c
+++ b/modules/c/j2k/source/Writer.c
@@ -40,7 +40,7 @@ J2KAPI(NRT_BOOL) j2k_Writer_setOptions(j2k_WriterOptions* options,
         }
         if(numResolutions)
         {
-            options->numResolutions = *((nrt_Uint32*)numResolutions->data);
+            options->numResolutions = *((uint32_t*)numResolutions->data);
         }
     }
 
@@ -48,10 +48,10 @@ J2KAPI(NRT_BOOL) j2k_Writer_setOptions(j2k_WriterOptions* options,
 }
 
 J2KAPI(NRT_BOOL) j2k_Writer_setTile(j2k_Writer *writer,
-                                    nrt_Uint32 tileX,
-                                    nrt_Uint32 tileY,
-                                    const nrt_Uint8 *buf,
-                                    nrt_Uint32 bufSize,
+                                    uint32_t tileX,
+                                    uint32_t tileY,
+                                    const uint8_t *buf,
+                                    uint32_t bufSize,
                                     nrt_Error *error)
 {
     return writer->iface->setTile(writer->data, tileX, tileY, buf, bufSize, error);

--- a/modules/c/j2k/tests/test_j2k_create.c
+++ b/modules/c/j2k/tests/test_j2k_create.c
@@ -23,7 +23,7 @@
 #include <import/nrt.h>
 #include <import/j2k.h>
 
-J2K_BOOL readFile(const char* filename, char **buf, nrt_Uint64 *bufSize,
+J2K_BOOL readFile(const char* filename, char **buf, uint64_t *bufSize,
                   nrt_Error *error)
 {
     J2K_BOOL rc = J2K_TRUE;
@@ -75,9 +75,9 @@ int main(int argc, char **argv)
     j2k_Writer *writer = NULL;
     j2k_WriterOptions options;
     char *buf = NULL;
-    nrt_Uint64 bufSize;
+    uint64_t bufSize;
     nrt_IOInterface *outIO = NULL;
-    nrt_Uint32 width, height, precision, tileWidth, tileHeight;
+    uint32_t width, height, precision, tileWidth, tileHeight;
 
     for (argIt = 1; argIt < argc; ++argIt)
     {
@@ -136,8 +136,8 @@ int main(int argc, char **argv)
         goto CATCH_ERROR;
     }
 
-    if (!j2k_Writer_setTile(writer, 0, 0, (nrt_Uint8*)buf,
-                            (nrt_Uint32)bufSize, &error))
+    if (!j2k_Writer_setTile(writer, 0, 0, (uint8_t*)buf,
+                            (uint32_t)bufSize, &error))
     {
         goto CATCH_ERROR;
     }

--- a/modules/c/j2k/tests/test_j2k_header.c
+++ b/modules/c/j2k/tests/test_j2k_header.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
 {
     int rc = 0;
     int argIt;
-    nrt_Uint32 cmpIt, nComponents;
+    uint32_t cmpIt, nComponents;
     nrt_Error error;
     j2k_Container *container = NULL;
     j2k_Reader *reader = NULL;

--- a/modules/c/j2k/tests/test_j2k_nitf.c
+++ b/modules/c/j2k/tests/test_j2k_nitf.c
@@ -24,9 +24,9 @@
 #include <import/nitf.h>
 #include <import/j2k.h>
 
-NRT_BOOL writeFile(nrt_Uint32 x0, nrt_Uint32 y0,
-                   nrt_Uint32 x1, nrt_Uint32 y1, nrt_Uint8 *buf,
-                   nrt_Uint64 bufSize, const char* prefix, nrt_Error *error)
+NRT_BOOL writeFile(uint32_t x0, uint32_t y0,
+                   uint32_t x1, uint32_t y1, uint8_t *buf,
+                   uint64_t bufSize, const char* prefix, nrt_Error *error)
 {
     NRT_BOOL rc = NRT_SUCCESS;
     char filename[NRT_MAX_PATH];
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
     nrt_IOInterface *io = NULL;
     nitf_Reader *reader = NULL;
     nitf_Record *record = NULL;
-    nrt_Uint8 *buf = NULL;
+    uint8_t *buf = NULL;
 
     for (argIt = 1; argIt < argc; ++argIt)
     {
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
             {
                 j2k_Reader *j2kReader = NULL;
                 j2k_Container *container = NULL;
-                nrt_Uint32 cmpIt, nComponents;
+                uint32_t cmpIt, nComponents;
                 printf("Image %d contains J2K compressed data\n", (i + 1));
                 printf("Offset: %d\n", segment->imageOffset);
                 if (!nrt_IOInterface_seek(io, segment->imageOffset,
@@ -161,8 +161,8 @@ int main(int argc, char **argv)
                 if (dump)
                 {
                     char namePrefix[NRT_MAX_PATH];
-                    nrt_Uint32 width, height;
-                    nrt_Uint64 bufSize;
+                    uint32_t width, height;
+                    uint64_t bufSize;
                     if (buf)
                     {
                         NRT_FREE(buf);

--- a/modules/c/j2k/tests/test_j2k_read_region.c
+++ b/modules/c/j2k/tests/test_j2k_read_region.c
@@ -23,9 +23,9 @@
 #include <import/nrt.h>
 #include <import/j2k.h>
 
-NRT_BOOL writeFile(nrt_Uint32 x0, nrt_Uint32 y0,
-                   nrt_Uint32 x1, nrt_Uint32 y1, nrt_Uint8 *buf,
-                   nrt_Uint64 bufSize, nrt_Error *error)
+NRT_BOOL writeFile(uint32_t x0, uint32_t y0,
+                   uint32_t x1, uint32_t y1, uint8_t *buf,
+                   uint64_t bufSize, nrt_Error *error)
 {
     NRT_BOOL rc = NRT_SUCCESS;
     char filename[NRT_MAX_PATH];
@@ -66,12 +66,12 @@ int main(int argc, char **argv)
     nrt_Error error;
     j2k_Reader *reader = NULL;
     j2k_Container *container = NULL;
-    nrt_Uint64 bufSize;
-    nrt_Uint32 x0 = 0;
-    nrt_Uint32 y0 = 0;
-    nrt_Uint32 x1 = 0;
-    nrt_Uint32 y1 = 0;
-    nrt_Uint8 *buf = NULL;
+    uint64_t bufSize;
+    uint32_t x0 = 0;
+    uint32_t y0 = 0;
+    uint32_t x1 = 0;
+    uint32_t y1 = 0;
+    uint8_t *buf = NULL;
 
     for (argIt = 1; argIt < argc; ++argIt)
     {

--- a/modules/c/j2k/tests/test_j2k_read_tile.c
+++ b/modules/c/j2k/tests/test_j2k_read_tile.c
@@ -23,8 +23,8 @@
 #include <import/nrt.h>
 #include <import/j2k.h>
 
-NRT_BOOL writeFile(j2k_Container *container, nrt_Uint32 tileX,
-                   nrt_Uint32 tileY, nrt_Uint8 *buf, nrt_Uint32 bufSize,
+NRT_BOOL writeFile(j2k_Container *container, uint32_t tileX,
+                   uint32_t tileY, uint8_t *buf, uint32_t bufSize,
                    nrt_Error *error)
 {
     NRT_BOOL rc = NRT_SUCCESS;
@@ -69,10 +69,10 @@ int main(int argc, char **argv)
     j2k_Container *container = NULL;
     int argIt = 0;
     char *fname = NULL;
-    nrt_Uint32 tileX = 0;
-    nrt_Uint32 tileY = 0;
-    nrt_Uint32 bufSize;
-    nrt_Uint8 *buf = NULL;
+    uint32_t tileX = 0;
+    uint32_t tileY = 0;
+    uint32_t bufSize;
+    uint8_t *buf = NULL;
 
     for (argIt = 1; argIt < argc; ++argIt)
     {

--- a/modules/c/jpeg/source/LibjpegDecompress.c
+++ b/modules/c/jpeg/source/LibjpegDecompress.c
@@ -36,7 +36,7 @@
 
 /* borrowed from ImageIO.c */
 #ifndef NITF_IMAGE_IO_NO_BLOCK
-#   define NITF_IMAGE_IO_NO_BLOCK             ((nitf_Uint32) 0xffffffff)
+#   define NITF_IMAGE_IO_NO_BLOCK             ((uint32_t) 0xffffffff)
 #endif
 
 #define INPUT_BUF_SIZE  4096
@@ -146,7 +146,7 @@ typedef struct _JPEGMarkerItem
 {
     char name[4];
     nitf_Off off;
-    nitf_Uint32 block;
+    uint32_t block;
 
 }
 JPEGMarkerItem;
@@ -219,7 +219,7 @@ NITFPRIV(void) JPEGMarkerItem_printList(
  *  \return One on success, zero on failure
  */
 NITFPRIV(int) implFreeBlock(nitf_DecompressionControl* control,
-                            nitf_Uint8* block,
+                            uint8_t* block,
                             nitf_Error* error);
 
 NITFPRIV(nitf_DecompressionControl*) implOpen(nitf_ImageSubheader* subheader,
@@ -243,10 +243,10 @@ NITFPRIV(nitf_DecompressionControl*) implOpen(nitf_ImageSubheader* subheader,
  */
 NITFPRIV(NITF_BOOL) implStart(nitf_DecompressionControl* control,
                               nitf_IOInterface*  io,
-                              nitf_Uint64 offset,
-                              nitf_Uint64 fileLength,
+                              uint64_t offset,
+                              uint64_t fileLength,
                               nitf_BlockingInfo* blockInfo,
-                              nitf_Uint64* blockMask,
+                              uint64_t* blockMask,
                               nitf_Error* error);
 
 /*!
@@ -275,9 +275,9 @@ NITFPRIV(void) implClose(nitf_DecompressionControl** control);
  *
  */
 
-NITFPRIV(nitf_Uint8*) implReadBlock(nitf_DecompressionControl* control,
-                                    nitf_Uint32 blockNumber,
-                                    nitf_Uint64* blockSize,
+NITFPRIV(uint8_t*) implReadBlock(nitf_DecompressionControl* control,
+                                    uint32_t blockNumber,
+                                    uint64_t* blockSize,
                                     nitf_Error* error);
 
 
@@ -297,7 +297,7 @@ static const char *ident[] =
     };
 
 /*! Simple little typedef to make life easier for me  */
-typedef nitf_Uint8* DATA_BUFFER;
+typedef uint8_t* DATA_BUFFER;
 
 /*!
  *  \struct ImplControl
@@ -322,7 +322,7 @@ typedef struct _JPEGImplControl
     nitf_IOInterface* ioInterface;
     nitf_List*        markerList;
     int*              quantTable;
-    nitf_Uint32       length;       /* Total length of the block in bytes */
+    uint32_t       length;       /* Total length of the block in bytes */
 }
 JPEGImplControl;
 
@@ -480,7 +480,7 @@ static nitf_DecompressionInterface interfaceTable =
 };
 
 NITFPRIV(int) implFreeBlock(nitf_DecompressionControl* control,
-                            nitf_Uint8* block,
+                            uint8_t* block,
                             nitf_Error* error)
 {
     if (block)
@@ -513,10 +513,10 @@ NITFPRIV(NITF_BOOL) readByte(nitf_IOInterface* io,
 }
 
 NITFPRIV(NITF_BOOL) readShort(nitf_IOInterface* io,
-        nitf_Uint16* native,
+        uint16_t* native,
         nitf_Error* error)
 {
-    nitf_Uint16 raw;
+    uint16_t raw;
     if (!nitf_IOInterface_read(io, (char*)&raw, 2, error))
     {
         return NITF_FAILURE;
@@ -587,7 +587,7 @@ NITFPRIV(int) readMarker(nitf_IOInterface* io, nitf_Error* error)
 
 
 NITFPRIV(NITF_BOOL) readSOI(nitf_IOInterface* io,
-        nitf_Uint64* bytesRead,
+        uint64_t* bytesRead,
         nitf_Error* error)
 {
     unsigned char needFF;
@@ -623,15 +623,15 @@ NITFPRIV(NITF_BOOL) readSOI(nitf_IOInterface* io,
     SOI, APP6, DQT
 
 NITFPRIV(NITF_BOOL) readSOF(nitf_IOInterface* io,
-                            nitf_Uint64* bytesRead,
+                            uint64_t* bytesRead,
                             nitf_Error* error)
 {
 
     char precision;
     char nf;
-    nitf_Uint16 x;
-    nitf_Uint16 y;
-    nitf_Uint16 numBytesInHdr;
+    uint16_t x;
+    uint16_t y;
+    uint16_t numBytesInHdr;
     if (! readShort(io, &numBytesInHdr, error) )
         return NITF_FAILURE;
 
@@ -683,12 +683,12 @@ NITFPRIV(NITF_BOOL) readSOF(nitf_IOInterface* io,
     SOI, APP6, DQT, SOF0, DHT
 */
 NITFPRIV(NITF_BOOL) readSOS(nitf_IOInterface* io,
-                            nitf_Uint64* bytesRead,
+                            uint64_t* bytesRead,
                             nitf_Error* error)
 {
 
     /*  Need to read bytes in header  */
-    nitf_Uint16 numBytesInHdr;
+    uint16_t numBytesInHdr;
     /*  If this isnt happening, throw up  */
     if (! readShort(io, &numBytesInHdr, error) )
         return NITF_FAILURE;
@@ -716,11 +716,11 @@ NITFPRIV(NITF_BOOL) readSOS(nitf_IOInterface* io,
 
 
 NITFPRIV(NITF_BOOL) readHuffTable(nitf_IOInterface* io,
-                                  nitf_Uint64* bytesRead,
+                                  uint64_t* bytesRead,
                                   nitf_Error* error)
 {
     /*  Need to read a header length */
-    nitf_Uint16 numBytesInHdr;
+    uint16_t numBytesInHdr;
     /*  Read it or die  */
     if (! readShort(io, &numBytesInHdr, error) )
         return NITF_FAILURE;
@@ -744,11 +744,11 @@ NITFPRIV(NITF_BOOL) readHuffTable(nitf_IOInterface* io,
 }
 
 NITFPRIV(NITF_BOOL) readQuantTable(nitf_IOInterface* io,
-                                   nitf_Uint64* bytesRead,
+                                   uint64_t* bytesRead,
                                    nitf_Error* error)
 {
     /*  Declare something to read into  */
-    nitf_Uint16 numBytesInHdr;
+    uint16_t numBytesInHdr;
     /*  Now start reading... */
     if (! readShort(io, &numBytesInHdr, error) )
         return NITF_FAILURE;
@@ -802,14 +802,14 @@ NITFPRIV(NITF_BOOL) pushMarker(nitf_List* markerList,
 */
 NITFPRIV(NITF_BOOL) scanOffsets(nitf_IOInterface* io,
                                 nitf_List* markerList,
-                                nitf_Uint64 fileLength,
+                                uint64_t fileLength,
                                 nitf_Error* error)
 {
 
-    nitf_Uint64 bytesRead = 0;
+    uint64_t bytesRead = 0;
 
     /*  Book keeping block  */
-    nitf_Uint64 origin = nitf_IOInterface_tell(io, error);
+    uint64_t origin = nitf_IOInterface_tell(io, error);
     assert(NITF_IO_SUCCESS(origin));
     /*  End book keeping block  */
     DPRINTA1("File length: %ld\n",  fileLength);
@@ -846,7 +846,7 @@ NITFPRIV(NITF_BOOL) scanOffsets(nitf_IOInterface* io,
             {
                 off_t where = nitf_IOInterface_tell(io, error);
 
-                nitf_Uint64 totalBytes = (fileLength - bytesRead) +
+                uint64_t totalBytes = (fileLength - bytesRead) +
                     (where - origin);
                 assert( fileLength == totalBytes);
                 switch (tokenType)
@@ -993,10 +993,10 @@ NITFPRIV(nitf_DecompressionControl*) implOpen(nitf_ImageSubheader* subheader,
  */
 NITFPRIV(NITF_BOOL) implStart(nitf_DecompressionControl* control,
                               nitf_IOInterface* io,
-                              nitf_Uint64 offset,
-                              nitf_Uint64 fileLength,
+                              uint64_t offset,
+                              uint64_t fileLength,
                               nitf_BlockingInfo* blockInfo,
-                              nitf_Uint64* blockMask,
+                              uint64_t* blockMask,
                               nitf_Error* error)
 {
     JPEGImplControl* implControl = (JPEGImplControl*) control;
@@ -1040,7 +1040,7 @@ NITFPRIV(NITF_BOOL) implStart(nitf_DecompressionControl* control,
     }
 
     {
-        nitf_Uint32 nextBlock = 0;
+        uint32_t nextBlock = 0;
         nitf_ListIterator x = nitf_List_begin((implControl->markerList));
         nitf_ListIterator e = nitf_List_end((implControl->markerList));
         while (nitf_ListIterator_notEqualTo(&x, &e))
@@ -1085,13 +1085,13 @@ NITFPRIV(NITF_BOOL) implStart(nitf_DecompressionControl* control,
 typedef struct _JPEGIOManager
 {
     struct jpeg_source_mgr pub;         /* public fields */
-    nitf_Uint8 buffer[INPUT_BUF_SIZE];  /* start of buffer */
+    uint8_t buffer[INPUT_BUF_SIZE];  /* start of buffer */
     boolean start_of_file;              /* have we gotten any data yet? */
     nitf_IOInterface* ioInterface;      /* source IO */
     nitf_Off ioStart;                   /* the io interface start offset (tell) */
     nitf_Off ioEnd;                     /* the io interface end offset (size) */
-    nitf_Uint32 blockLength;            /* the length of the block */
-    nitf_Uint32 bytesRead;              /* the number of bytes read so far */
+    uint32_t blockLength;            /* the length of the block */
+    uint32_t bytesRead;              /* the number of bytes read so far */
     nitf_Error *error;
 } JPEGIOManager;
 
@@ -1128,7 +1128,7 @@ NITFPRIV(void) JPEGTerminateSource(j_decompress_ptr cinfo)
 NITFPRIV(boolean) JPEGFillInputBuffer (j_decompress_ptr cinfo)
 {
     JPEGIOManager* src = (JPEGIOManager*)cinfo->src;
-    nitf_Uint32 toRead;
+    uint32_t toRead;
     nitf_Off ioOff;
 
     toRead = src->blockLength - src->bytesRead;
@@ -1141,11 +1141,11 @@ NITFPRIV(boolean) JPEGFillInputBuffer (j_decompress_ptr cinfo)
     ioOff = src->ioStart + src->bytesRead;
     if (ioOff + toRead > src->ioEnd)
     {
-        nitf_Int32 ioDiff = src->ioEnd - ioOff;
+        int32_t ioDiff = src->ioEnd - ioOff;
         if (ioDiff < 0)
             toRead = 0;
         else
-            toRead = (nitf_Uint32)ioDiff;
+            toRead = (uint32_t)ioDiff;
     }
 
     if (toRead == 0)
@@ -1214,7 +1214,7 @@ NITFPRIV(NITF_BOOL) JPEGCreateIOSource(j_decompress_ptr cinfo,
         }
         cinfo->src = (struct jpeg_source_mgr*)src;
 
-        /*src->buffer = (nitf_Uint8*)NITF_MALLOC(INPUT_BUF_SIZE);
+        /*src->buffer = (uint8_t*)NITF_MALLOC(INPUT_BUF_SIZE);
         if (src->buffer == NULL)
         {
             nitf_Error_init(error,
@@ -1253,7 +1253,7 @@ NITFPRIV(NITF_BOOL) JPEGCreateIOSource(j_decompress_ptr cinfo,
  *  generated during implOpen.
  */
 NITFPRIV(NITF_BOOL) findBlockSOI(JPEGImplControl* control,
-                                 nitf_Uint32 blockNumber,
+                                 uint32_t blockNumber,
                                  off_t* soi,
                                  nitf_Error* error)
 {
@@ -1290,9 +1290,9 @@ NITFPRIV(NITF_BOOL) findBlockSOI(JPEGImplControl* control,
     return NITF_SUCCESS;
 }
 
-NITFPRIV(nitf_Uint8*) implReadBlock(nitf_DecompressionControl* control,
-                                    nitf_Uint32 blockNumber,
-                                    nitf_Uint64* blockSize,
+NITFPRIV(uint8_t*) implReadBlock(nitf_DecompressionControl* control,
+                                    uint32_t blockNumber,
+                                    uint64_t* blockSize,
                                     nitf_Error* error)
 {
     /*
@@ -1317,7 +1317,7 @@ NITFPRIV(nitf_Uint8*) implReadBlock(nitf_DecompressionControl* control,
     if (!findBlockSOI(control, blockNumber, &soi, error))
 #ifdef ZERO_BLOCK
     {
-        nitf_Uint8 *zeros; /* Buffer of zeros */
+        uint8_t *zeros; /* Buffer of zeros */
 
         zeros = NITF_MALLOC(implControl->length);
         if (zeros == NULL)
@@ -1369,7 +1369,7 @@ NITFPRIV(nitf_Uint8*) implReadBlock(nitf_DecompressionControl* control,
     if (ret != JPEG_HEADER_OK)
 #ifdef ZERO_BLOCK
     {
-        nitf_Uint8 *zeros; /* Buffer of zeros */
+        uint8_t *zeros; /* Buffer of zeros */
 
         zeros = NITF_MALLOC(implControl->length);
         if (zeros == NULL)
@@ -1409,7 +1409,7 @@ NITFPRIV(nitf_Uint8*) implReadBlock(nitf_DecompressionControl* control,
     if (!block)
 #ifdef ZERO_BLOCK
     {
-        nitf_Uint8 *zeros; /* Buffer of zeros */
+        uint8_t *zeros; /* Buffer of zeros */
 
         zeros = NITF_MALLOC(implControl->length);
         if (zeros == NULL)
@@ -1464,7 +1464,7 @@ NITFPRIV(nitf_Uint8*) implReadBlock(nitf_DecompressionControl* control,
         JPEGBlock_reorder(block);
     }
 
-    uncompressed = (nitf_Uint8*)(block->uncompressed);
+    uncompressed = (uint8_t*)(block->uncompressed);
     block->uncompressed = NULL;
     *blockSize = _BLOCK_SIZE(block);
     JPEGBlock_destruct(&block);

--- a/modules/c/nitf/apps/image_footprint_kml.c
+++ b/modules/c/nitf/apps/image_footprint_kml.c
@@ -109,7 +109,7 @@ int main(int argc, char** argv)
     nitf_Error error;
     char file[NITF_MAX_PATH];
     int i;
-    nitf_Uint32 num;
+    uint32_t num;
 
     if ( argc != 2 )
     {

--- a/modules/c/nitf/apps/show_nitf.c
+++ b/modules/c/nitf/apps/show_nitf.c
@@ -80,7 +80,7 @@ void measureComplexity(nitf_Record* record)
 void printTRE(nitf_TRE* tre)
 {
     nitf_Error error;
-    nitf_Uint32 treLength;
+    uint32_t treLength;
     nitf_TREEnumerator* it = NULL;
     const char* treID = NULL;
 
@@ -183,11 +183,11 @@ void showSecurityGroup(nitf_FileSecurity* securityGroup)
 void showFileHeader(nitf_Record * record)
 {
     unsigned int i;
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_Error error;
-    nitf_Uint32 len;
-    nitf_Uint64 dataLen;
-    nitf_Uint32 dataLen32;
+    uint32_t len;
+    uint64_t dataLen;
+    uint32_t dataLen32;
     nitf_Version fver;
     nitf_FileHeader *header;
 

--- a/modules/c/nitf/include/nitf/BandInfo.h
+++ b/modules/c/nitf/include/nitf/BandInfo.h
@@ -116,8 +116,8 @@ NITFAPI(NITF_BOOL) nitf_BandInfo_init(nitf_BandInfo * bandInfo, /*!< The band in
                                       const char *subcategory,          /*!< The band subcategory */
                                       const char *imageFilterCondition, /*!< The band filter condition */
                                       const char *imageFilterCode,      /*!< The band standard image filter code */
-                                      nitf_Uint32 numLUTs,      /*!< The number of look-up tables */
-                                      nitf_Uint32 bandEntriesPerLUT,    /*!< The number of entries/LUT */
+                                      uint32_t numLUTs,      /*!< The number of look-up tables */
+                                      uint32_t bandEntriesPerLUT,    /*!< The number of entries/LUT */
                                       nitf_LookupTable * lut,   /*!< The look-up tables */
                                       nitf_Error * error        /*!< Error object for error returns */
                                      );

--- a/modules/c/nitf/include/nitf/ComponentInfo.h
+++ b/modules/c/nitf/include/nitf/ComponentInfo.h
@@ -54,8 +54,8 @@ nitf_ComponentInfo;
  *  \return Return the newly created object.
  */
 NITFAPI(nitf_ComponentInfo *)
-nitf_ComponentInfo_construct(nitf_Uint32 subheaderFieldWidth,
-                             nitf_Uint32 dataFieldWidth,
+nitf_ComponentInfo_construct(uint32_t subheaderFieldWidth,
+                             uint32_t dataFieldWidth,
                              nitf_Error * error);
 
 /*!

--- a/modules/c/nitf/include/nitf/DESegment.h
+++ b/modules/c/nitf/include/nitf/DESegment.h
@@ -39,8 +39,8 @@ NITF_CXX_GUARD
 typedef struct _nitf_DESegment
 {
     nitf_DESubheader *subheader;
-    nitf_Uint64 offset;
-    nitf_Uint64 end;
+    uint64_t offset;
+    uint64_t end;
 }
 nitf_DESegment;
 

--- a/modules/c/nitf/include/nitf/DESubheader.h
+++ b/modules/c/nitf/include/nitf/DESubheader.h
@@ -54,7 +54,7 @@ typedef struct _nitf_DESubheader
     nitf_Field *dataItemOverflowed;
     nitf_Field *subheaderFieldsLength;
     nitf_TRE *subheaderFields;
-    nitf_Uint64 dataLength;
+    uint64_t dataLength;
 
     nitf_Extensions *userDefinedSection;
 }

--- a/modules/c/nitf/include/nitf/DirectBlockSource.h
+++ b/modules/c/nitf/include/nitf/DirectBlockSource.h
@@ -55,8 +55,8 @@ NITF_CXX_GUARD
 typedef NITF_BOOL(*NITF_DIRECT_BLOCK_SOURCE_NEXT_BLOCK) (void* algorithm,
                                                          void* buf,
                                                          const void* block,
-                                                         nitf_Uint32 blockNumber,
-                                                         nitf_Uint64 blockSize,
+                                                         uint32_t blockNumber,
+                                                         uint64_t blockSize,
                                                          nitf_Error * error);
 
 /*
@@ -70,7 +70,7 @@ NITFAPI(nitf_BandSource *) nitf_DirectBlockSource_construct(void * algorithm,
                                                             NITF_DIRECT_BLOCK_SOURCE_NEXT_BLOCK
                                                             nextBlock,
                                                             nitf_ImageReader* imageReader,
-                                                            nitf_Uint32 numBands,
+                                                            uint32_t numBands,
                                                             nitf_Error * error);
 
 NITF_CXX_ENDGUARD

--- a/modules/c/nitf/include/nitf/DownSampler.h
+++ b/modules/c/nitf/include/nitf/DownSampler.h
@@ -27,19 +27,19 @@
 #include "nitf/System.h"
 
 /*! \def NITF_PIXEL_TYPE_INT - Integer */
-#   define NITF_PIXEL_TYPE_INT ((nitf_Uint32) 0x00080000)
+#   define NITF_PIXEL_TYPE_INT ((uint32_t) 0x00080000)
 
 /*! \def NITF_PIXEL_TYPE_B - Bi-valued */
-#   define NITF_PIXEL_TYPE_B ((nitf_Uint32) 0x00100000)
+#   define NITF_PIXEL_TYPE_B ((uint32_t) 0x00100000)
 
 /*! \def NITF_PIXEL_TYPE_SI - Two's complement signed integer */
-#   define NITF_PIXEL_TYPE_SI ((nitf_Uint32) 0x00200000)
+#   define NITF_PIXEL_TYPE_SI ((uint32_t) 0x00200000)
 
 /*! \def NITF_PIXEL_TYPE_R - Floating point */
-#   define NITF_PIXEL_TYPE_R ((nitf_Uint32) 0x00400000)
+#   define NITF_PIXEL_TYPE_R ((uint32_t) 0x00400000)
 
 /*! \def NITF_PIXEL_TYPE_C - Complex floating point */
-#   define NITF_PIXEL_TYPE_C ((nitf_Uint32) 0x00800000)
+#   define NITF_PIXEL_TYPE_C ((uint32_t) 0x00800000)
 
 
 NITF_CXX_GUARD
@@ -86,15 +86,15 @@ typedef NITF_BOOL(*NITF_IDOWNSAMPLER_APPLY) (struct _nitf_DownSampler *
         object,
         NITF_DATA ** inputWindows,
         NITF_DATA ** outputWindows,
-        nitf_Uint32 numBands,
-        nitf_Uint32 numWindowRows,
-        nitf_Uint32 numWindowCols,
-        nitf_Uint32 numInputCols,
-        nitf_Uint32 numSubWindowCols,
-        nitf_Uint32 pixelType,
-        nitf_Uint32 pixelSize,
-        nitf_Uint32 rowsInLastWindow,
-        nitf_Uint32 colsInLastWindow,
+        uint32_t numBands,
+        uint32_t numWindowRows,
+        uint32_t numWindowCols,
+        uint32_t numInputCols,
+        uint32_t numSubWindowCols,
+        uint32_t pixelType,
+        uint32_t pixelSize,
+        uint32_t rowsInLastWindow,
+        uint32_t colsInLastWindow,
         nitf_Error * error);
 
 
@@ -152,49 +152,49 @@ nitf_IDownSampler;
 typedef struct _nitf_DownSampler
 {
     nitf_IDownSampler *iface;   /* The functional interface  */
-    nitf_Uint32 rowSkip;        /* The number of rows in the down-sample window */
-    nitf_Uint32 colSkip;        /* The number of cols in the down-sample window */
+    uint32_t rowSkip;        /* The number of rows in the down-sample window */
+    uint32_t colSkip;        /* The number of cols in the down-sample window */
     NITF_BOOL multiBand;        /* The down-sampler method is muli-band */
-    nitf_Uint32 minBands;       /* Minimum number of bands in multi-band method */
-    nitf_Uint32 maxBands;       /* Maxmum number of bands in multi-band method */
-    nitf_Uint32 types;          /* Mask of type/pixel size flags */
+    uint32_t minBands;       /* Minimum number of bands in multi-band method */
+    uint32_t maxBands;       /* Maxmum number of bands in multi-band method */
+    uint32_t types;          /* Mask of type/pixel size flags */
     NITF_DATA *data;            /* To be overloaded by derived class  */
 }
 nitf_DownSampler;
 
 
 /*! \def NITF_DOWNSAMPLER_TYPE_INT_1BYTE - Integer, one byte pixel */
-#   define NITF_DOWNSAMPLER_TYPE_INT_1BYTE ((nitf_Uint32) 0x00000001)
+#   define NITF_DOWNSAMPLER_TYPE_INT_1BYTE ((uint32_t) 0x00000001)
 /*! \def NITF_DOWNSAMPLER_TYPE_INT_2BYTE - Integer, two byte pixel */
-#   define NITF_DOWNSAMPLER_TYPE_INT_2BYTE ((nitf_Uint32) 0x00000002)
+#   define NITF_DOWNSAMPLER_TYPE_INT_2BYTE ((uint32_t) 0x00000002)
 /*! \def NITF_DOWNSAMPLER_TYPE_INT_4BYTE - Integer, eight byte pixel */
-#   define NITF_DOWNSAMPLER_TYPE_INT_4BYTE ((nitf_Uint32) 0x00000004)
+#   define NITF_DOWNSAMPLER_TYPE_INT_4BYTE ((uint32_t) 0x00000004)
 /*! \def NITF_DOWNSAMPLER_TYPE_INT_8BYTE - Integer, eight byte pixel */
-#   define NITF_DOWNSAMPLER_TYPE_INT_8BYTE ((nitf_Uint32) 0x00000008)
+#   define NITF_DOWNSAMPLER_TYPE_INT_8BYTE ((uint32_t) 0x00000008)
 
 /*! \def NITF_DOWNSAMPLER_TYPE_B_1BYTE - Binary, one byte pixel
          Note: The one bit type is presented to the user as one byte pixels
 */
-#   define NITF_DOWNSAMPLER_TYPE_B_1BYTE ((nitf_Uint32) 0x00000001)
+#   define NITF_DOWNSAMPLER_TYPE_B_1BYTE ((uint32_t) 0x00000001)
 
 /*! \def NITF_DOWNSAMPLER_TYPE_SI_1BYTE - Signed integer, one byte pixel */
-#   define NITF_DOWNSAMPLER_TYPE_SI_1BYTE ((nitf_Uint32) 0x00000010)
+#   define NITF_DOWNSAMPLER_TYPE_SI_1BYTE ((uint32_t) 0x00000010)
 /*! \def NITF_DOWNSAMPLER_TYPE_SI_2BYTE - Signed integer, two byte pixel */
-#   define NITF_DOWNSAMPLER_TYPE_SI_2BYTE ((nitf_Uint32) 0x00000020)
+#   define NITF_DOWNSAMPLER_TYPE_SI_2BYTE ((uint32_t) 0x00000020)
 /*! \def NITF_DOWNSAMPLER_TYPE_SI_4BYTE - Signed integer, four byte pixel */
-#   define NITF_DOWNSAMPLER_TYPE_SI_4BYTE ((nitf_Uint32) 0x00000040)
+#   define NITF_DOWNSAMPLER_TYPE_SI_4BYTE ((uint32_t) 0x00000040)
 /*! \def NITF_DOWNSAMPLER_TYPE_SI_8BYTE - Signed integer, eight byte pixel */
-#   define NITF_DOWNSAMPLER_TYPE_SI_8BYTE ((nitf_Uint32) 0x00000080)
+#   define NITF_DOWNSAMPLER_TYPE_SI_8BYTE ((uint32_t) 0x00000080)
 
 /*! \def NITF_DOWNSAMPLER_TYPE_R_4BYTE - Float, four byte pixel */
-#   define NITF_DOWNSAMPLER_TYPE_R_4BYTE ((nitf_Uint32) 0x00000100)
+#   define NITF_DOWNSAMPLER_TYPE_R_4BYTE ((uint32_t) 0x00000100)
 /*! \def NITF_DOWNSAMPLER_TYPE_R_8BYTE - Float, eight byte pixel */
-#   define NITF_DOWNSAMPLER_TYPE_R_8BYTE ((nitf_Uint32) 0x00000200)
+#   define NITF_DOWNSAMPLER_TYPE_R_8BYTE ((uint32_t) 0x00000200)
 
 /*! \def NITF_DOWNSAMPLER_TYPE_C_8BYTE - Complex, eight byte pixel */
-#   define NITF_DOWNSAMPLER_TYPE_C_8BYTE ((nitf_Uint32) 0x00001000)
+#   define NITF_DOWNSAMPLER_TYPE_C_8BYTE ((uint32_t) 0x00001000)
 /*! \def NITF_DOWNSAMPLER_TYPE_C_16BYTE - Complex, sixteen byte pixel */
-#   define NITF_DOWNSAMPLER_TYPE_C_16BYTE ((nitf_Uint32) 0x00002000)
+#   define NITF_DOWNSAMPLER_TYPE_C_16BYTE ((uint32_t) 0x00002000)
 
 /*! \def NITF_DOWNSAMPLER_TYPE_ALL - All types */
 #   define NITF_DOWNSAMPLER_TYPE_ALL \
@@ -247,8 +247,8 @@ nitf_DownSampler;
  *  \return This method returns an object on success, and NULL on
  *          failure.
  */
-NITFAPI(nitf_DownSampler *) nitf_PixelSkip_construct(nitf_Uint32 rowSkip,
-        nitf_Uint32 colSkip,
+NITFAPI(nitf_DownSampler *) nitf_PixelSkip_construct(uint32_t rowSkip,
+        uint32_t colSkip,
         nitf_Error * error);
 
 
@@ -270,9 +270,9 @@ NITFAPI(nitf_DownSampler *) nitf_PixelSkip_construct(nitf_Uint32 rowSkip,
  *  \return This method returns an object on success, and NULL on
  &          failure.
  */
-NITFAPI(nitf_DownSampler *) nitf_MaxDownSample_construct(nitf_Uint32
+NITFAPI(nitf_DownSampler *) nitf_MaxDownSample_construct(uint32_t
         rowSkip,
-        nitf_Uint32
+        uint32_t
         colSkip,
         nitf_Error *
         error);
@@ -294,9 +294,9 @@ NITFAPI(nitf_DownSampler *) nitf_MaxDownSample_construct(nitf_Uint32
 *  \return This method returns an object on success, and NULL on failure.
 */
 
-NITFAPI(nitf_DownSampler *) nitf_SumSq2DownSample_construct(nitf_Uint32
+NITFAPI(nitf_DownSampler *) nitf_SumSq2DownSample_construct(uint32_t
         rowSkip,
-        nitf_Uint32
+        uint32_t
         colSkip,
         nitf_Error *
         error);
@@ -318,9 +318,9 @@ NITFAPI(nitf_DownSampler *) nitf_SumSq2DownSample_construct(nitf_Uint32
 *  \return This method returns an object on success, and NULL on failure.
 */
 
-NITFAPI(nitf_DownSampler *) nitf_Select2DownSample_construct(nitf_Uint32
+NITFAPI(nitf_DownSampler *) nitf_Select2DownSample_construct(uint32_t
         rowSkip,
-        nitf_Uint32
+        uint32_t
         colSkip,
         nitf_Error *
         error);

--- a/modules/c/nitf/include/nitf/Extensions.h
+++ b/modules/c/nitf/include/nitf/Extensions.h
@@ -254,7 +254,7 @@ nitf_ExtensionsIterator_notEqualTo(nitf_ExtensionsIterator *it1,
  * \param error The error to populate on failure
  * \return the length
  */
-NITFAPI(nitf_Uint32)
+NITFAPI(uint32_t)
 nitf_Extensions_computeLength(nitf_Extensions * ext,
                               nitf_Version fver,
                               nitf_Error * error);

--- a/modules/c/nitf/include/nitf/Field.h
+++ b/modules/c/nitf/include/nitf/Field.h
@@ -135,7 +135,7 @@ NITFAPI(NITF_BOOL) nitf_Field_setRawData(nitf_Field * field,
  */
 
 NITFAPI(NITF_BOOL) nitf_Field_setUint32(nitf_Field * field,
-                                        nitf_Uint32 number,
+                                        uint32_t number,
                                         nitf_Error * error);
 
 /*!
@@ -160,7 +160,7 @@ NITFAPI(NITF_BOOL) nitf_Field_setUint32(nitf_Field * field,
  */
 
 NITFAPI(NITF_BOOL) nitf_Field_setUint64(nitf_Field * field,
-                                        nitf_Uint64 number,
+                                        uint64_t number,
                                         nitf_Error * error);
 
 /*!
@@ -184,7 +184,7 @@ NITFAPI(NITF_BOOL) nitf_Field_setUint64(nitf_Field * field,
  */
 
 NITFAPI(NITF_BOOL) nitf_Field_setInt32(nitf_Field * field,
-                                       nitf_Int32 number,
+                                       int32_t number,
                                        nitf_Error * error);
 
 /*!
@@ -207,7 +207,7 @@ NITFAPI(NITF_BOOL) nitf_Field_setInt32(nitf_Field * field,
  */
 
 NITFAPI(NITF_BOOL) nitf_Field_setInt64(nitf_Field * field,
-                                       nitf_Int64 number,
+                                       int64_t number,
                                        nitf_Error * error);
 
 /*!

--- a/modules/c/nitf/include/nitf/GraphicSegment.h
+++ b/modules/c/nitf/include/nitf/GraphicSegment.h
@@ -39,8 +39,8 @@ NITF_CXX_GUARD
 typedef struct _nitf_GraphicSegment
 {
     nitf_GraphicSubheader *subheader;
-    nitf_Uint64 offset;
-    nitf_Uint64 end;
+    uint64_t offset;
+    uint64_t end;
     char *graphic;
 }
 nitf_GraphicSegment;

--- a/modules/c/nitf/include/nitf/ImageIO.h
+++ b/modules/c/nitf/include/nitf/ImageIO.h
@@ -43,30 +43,30 @@
 
 /*! \def NITF_IMAGE_IO_NO_OFFSET - No block/mask offset */
 
-#define NITF_IMAGE_IO_NO_OFFSET      ((nitf_Uint32) 0xffffffff)
+#define NITF_IMAGE_IO_NO_OFFSET      ((uint32_t) 0xffffffff)
 
 /*! \def NITF_NBPP_TO_BYTES  - Compute bytes per pixel from NBPP field */
 
 #define NITF_NBPP_TO_BYTES(nbpp) ((((int) (nbpp)) - 1)/8 + 1)
 
 /*! \def NITF_IMAGE_IO_PIXEL_TYPE_INT - Integer */
-#define NITF_IMAGE_IO_PIXEL_TYPE_INT ((nitf_Uint32) 0x00080000)
+#define NITF_IMAGE_IO_PIXEL_TYPE_INT ((uint32_t) 0x00080000)
 
 /*! \def NITF_IMAGE_IO_PIXEL_TYPE_B - Bi-valued */
-#define NITF_IMAGE_IO_PIXEL_TYPE_B ((nitf_Uint32) 0x00100000)
+#define NITF_IMAGE_IO_PIXEL_TYPE_B ((uint32_t) 0x00100000)
 
 /*! \def NITF_IMAGE_IO_PIXEL_TYPE_SI - Two's complement signed integer */
-#define NITF_IMAGE_IO_PIXEL_TYPE_SI ((nitf_Uint32) 0x00200000)
+#define NITF_IMAGE_IO_PIXEL_TYPE_SI ((uint32_t) 0x00200000)
 
 /*! \def NITF_IMAGE_IO_PIXEL_TYPE_R - Floating point */
-#define NITF_IMAGE_IO_PIXEL_TYPE_R ((nitf_Uint32) 0x00400000)
+#define NITF_IMAGE_IO_PIXEL_TYPE_R ((uint32_t) 0x00400000)
 
 /*! \def NITF_IMAGE_IO_PIXEL_TYPE_C - Complex floating point */
-#define NITF_IMAGE_IO_PIXEL_TYPE_C ((nitf_Uint32) 0x00800000)
+#define NITF_IMAGE_IO_PIXEL_TYPE_C ((uint32_t) 0x00800000)
 
 /* Psuedo type for 12 bit integer (NBPP == 12 and ABPP = 12) */
 /*! \def NITF_IMAGE_IO_PIXEL_TYPE_12 - 12 bit integer signed or unsigned */
-#define NITF_IMAGE_IO_PIXEL_TYPE_12 ((nitf_Uint32) 0x01000000)
+#define NITF_IMAGE_IO_PIXEL_TYPE_12 ((uint32_t) 0x01000000)
 
 NITF_CXX_GUARD
 
@@ -92,10 +92,10 @@ typedef void nitf_ImageIO;
 
 typedef struct _nitf_BlockingInfo
 {
-    nitf_Uint32 numBlocksPerRow;        /*!< Number of blocks per row */
-    nitf_Uint32 numBlocksPerCol;        /*!< Number of blocks per column */
-    nitf_Uint32 numRowsPerBlock;        /*!< Number of rows per block */
-    nitf_Uint32 numColsPerBlock;        /*!< Number of columns per block */
+    uint32_t numBlocksPerRow;        /*!< Number of blocks per row */
+    uint32_t numBlocksPerCol;        /*!< Number of blocks per column */
+    uint32_t numRowsPerBlock;        /*!< Number of rows per block */
+    uint32_t numColsPerBlock;        /*!< Number of columns per block */
     size_t length;                      /*!< Total block length in bytes */
 }
 nitf_BlockingInfo;
@@ -227,8 +227,8 @@ NITFPROT(NITF_BOOL) nitf_ImageIO_writeDone(nitf_ImageIO * object,
 
 NITFPROT(NITF_BOOL) nitf_ImageIO_writeRows(nitf_ImageIO * object,
                                            nitf_IOInterface* io,
-                                           nitf_Uint32 numRows,
-                                           nitf_Uint8 ** data,
+                                           uint32_t numRows,
+                                           uint8_t ** data,
                                            nitf_Error * error
                                           );
 
@@ -277,8 +277,8 @@ NITFPROT(NITF_BOOL) nitf_ImageIO_flush(nitf_ImageIO * object,
 
 NITFPROT(NITF_BOOL)
 nitf_ImageIO_setPadPixel(nitf_ImageIO * object,
-                         nitf_Uint8 * value,
-                         nitf_Uint32 length,
+                         uint8_t * value,
+                         uint32_t length,
                          nitf_Error* error
     );
 
@@ -357,9 +357,9 @@ typedef nitf_CompressionControl *
 typedef NITF_BOOL
 (*NITF_COMPRESSION_INTERFACE_START_FUNCTION)
 (nitf_CompressionControl *object,
- nitf_Uint64 offset,nitf_Uint64 dataLength,
- nitf_Uint64 * blockMask,
- nitf_Uint64 * padMask, nitf_Error * error);
+ uint64_t offset,uint64_t dataLength,
+ uint64_t * blockMask,
+ uint64_t * padMask, nitf_Error * error);
 
 /*!
     \brief NITF_COMPRESSION_INTERFACE_WRITE_BLOCK_FUNCTION - Image
@@ -385,7 +385,7 @@ typedef NITF_BOOL
 */
 
 typedef NITF_BOOL (*NITF_COMPRESSION_INTERFACE_WRITE_BLOCK_FUNCTION)
-(nitf_CompressionControl * object, nitf_IOInterface* io,const nitf_Uint8 *data,
+(nitf_CompressionControl * object, nitf_IOInterface* io,const uint8_t *data,
     NITF_BOOL pad,NITF_BOOL noData,nitf_Error *error);
 
 /*!
@@ -482,10 +482,10 @@ typedef NITF_BOOL
 (*NITF_DECOMPRESSION_INTERFACE_START_FUNCTION)
 (nitf_DecompressionControl *object,
  nitf_IOInterface* io,
- nitf_Uint64 offset,
- nitf_Uint64 fileLength,
+ uint64_t offset,
+ uint64_t fileLength,
  nitf_BlockingInfo * blockingDefinition,
- nitf_Uint64 * blockMask, nitf_Error * error);
+ uint64_t * blockMask, nitf_Error * error);
 
  /*!
     \brief NITF_DECOMPRESSION_INTERFACE_READ_BLOCK_FUNCTION - Image
@@ -507,9 +507,9 @@ typedef NITF_BOOL
   On error, the error object is set
 */
 
-typedef nitf_Uint8 *(*NITF_DECOMPRESSION_INTERFACE_READ_BLOCK_FUNCTION)
+typedef uint8_t *(*NITF_DECOMPRESSION_INTERFACE_READ_BLOCK_FUNCTION)
 (nitf_DecompressionControl * object,
- nitf_Uint32 blockNumber, nitf_Uint64* blockSize, nitf_Error * error);
+ uint32_t blockNumber, uint64_t* blockSize, nitf_Error * error);
 
 /*!
     \brief NITF_DECOMPRESSION_INTERFACE_FREE_BLOCK_FUNCTION - Image
@@ -530,7 +530,7 @@ typedef nitf_Uint8 *(*NITF_DECOMPRESSION_INTERFACE_READ_BLOCK_FUNCTION)
 
 typedef NITF_BOOL(*NITF_DECOMPRESSION_INTERFACE_FREE_BLOCK_FUNCTION)
 (nitf_DecompressionControl * object,
- nitf_Uint8 * block, nitf_Error * error);
+ uint8_t * block, nitf_Error * error);
 
 /*!
     \brief NITF_DECOMPRESSION_CONTROL_DESTROY_FUNCTION - Image decompression
@@ -636,13 +636,13 @@ nitf_DecompressionInterface;
 typedef int (*NITF_DOWN_SAMPLE_FUNCTION) (void *input,
                                           void *output,
                                           void *parameters,
-                                          nitf_Uint32 numWindowRows,
-                                          nitf_Uint32 numWindowCols,
+                                          uint32_t numWindowRows,
+                                          uint32_t numWindowCols,
                                           nitf_SubWindow * subWindow,
-                                          nitf_Uint32 pixelType,
-                                          nitf_Uint32 pixelSize,
-                                          nitf_Uint32 rowsInLastWindow,
-                                          nitf_Uint32 colsInLastWindow,
+                                          uint32_t pixelType,
+                                          uint32_t pixelSize,
+                                          uint32_t rowsInLastWindow,
+                                          uint32_t colsInLastWindow,
                                           nitf_Error * error);
 /*!
   \brief Constructor for the nitf_ImageIO object
@@ -688,8 +688,8 @@ typedef int (*NITF_DOWN_SAMPLE_FUNCTION) (void *input,
 
 NITFPROT(nitf_ImageIO *)
 nitf_ImageIO_construct(nitf_ImageSubheader * subheader,
-                       nitf_Uint64 offset,
-                       nitf_Uint64 length,
+                       uint64_t offset,
+                       uint64_t length,
                        nitf_CompressionInterface * compressor,
                        nitf_DecompressionInterface * decompressor,
                        nrt_HashTable* options,
@@ -768,7 +768,7 @@ NITFPROT(void) nitf_ImageIO_destruct(nitf_ImageIO ** nitf);
 NITFPROT(NITF_BOOL) nitf_ImageIO_read(nitf_ImageIO * nitf,
                                       nitf_IOInterface* io,
                                       nitf_SubWindow * subWindow,
-                                      nitf_Uint8 ** user,
+                                      uint8_t ** user,
                                       int *padded,
                                       nitf_Error * error
                                      );
@@ -782,7 +782,7 @@ NITFPROT(NITF_BOOL) nitf_ImageIO_read(nitf_ImageIO * nitf,
   \return Returns pixel size in bytes
 */
 
-NITFPROT(nitf_Uint32) nitf_ImageIO_pixelSize(nitf_ImageIO * nitf);
+NITFPROT(uint32_t) nitf_ImageIO_pixelSize(nitf_ImageIO * nitf);
 
 /*!
   \brief  nitf_ImageIO_setFileOffset
@@ -803,7 +803,7 @@ NITFPROT(nitf_Uint32) nitf_ImageIO_pixelSize(nitf_ImageIO * nitf);
 */
 
 NITFPROT(NITF_BOOL) nitf_ImageIO_setFileOffset(nitf_ImageIO * nitf,
-                                               nitf_Uint64 offset,
+                                               uint64_t offset,
                                                nitf_Error * error
                                               );
 
@@ -888,7 +888,7 @@ NITFPROT(void) nitf_BlockingInfo_print(nitf_BlockingInfo * info,  /*!< The struc
  */
 NITFPROT(NITF_BOOL) nitf_ImageIO_setupDirectBlockRead(nitf_ImageIO *nitf,
                                                       nitf_IOInterface *io,
-                                                      nitf_Uint32 numBands,
+                                                      uint32_t numBands,
                                                       nitf_Error *error);
 
 /*!
@@ -903,10 +903,10 @@ NITFPROT(NITF_BOOL) nitf_ImageIO_setupDirectBlockRead(nitf_ImageIO *nitf,
   \param blockSize    The block size read
   \param error        Error object
  */
-NITFPROT(nitf_Uint8*) nitf_ImageIO_readBlockDirect(nitf_ImageIO* nitf,
+NITFPROT(uint8_t*) nitf_ImageIO_readBlockDirect(nitf_ImageIO* nitf,
                                                    nitf_IOInterface* io,
-                                                   nitf_Uint32 blockNumber,
-                                                   nitf_Uint64* blockSize,
+                                                   uint32_t blockNumber,
+                                                   uint64_t* blockSize,
                                                    nitf_Error * error);
 
 /*!
@@ -921,7 +921,7 @@ NITFPROT(nitf_Uint8*) nitf_ImageIO_readBlockDirect(nitf_ImageIO* nitf,
 NITFPROT(NRT_BOOL) nitf_ImageIO_writeBlockDirect(nitf_ImageIO* object,
                                                  nitf_IOInterface* io,
                                                  const void* buffer,
-                                                 nitf_Uint32 blockNumber,
+                                                 uint32_t blockNumber,
                                                  nitf_Error * error);
 
 NITF_CXX_ENDGUARD

--- a/modules/c/nitf/include/nitf/ImageReader.h
+++ b/modules/c/nitf/include/nitf/ImageReader.h
@@ -51,15 +51,15 @@ nitf_ImageReader_getBlockingInfo(nitf_ImageReader * imageReader,
  */
 NITFAPI(NITF_BOOL) nitf_ImageReader_read(nitf_ImageReader * imageReader,
         nitf_SubWindow * subWindow,
-        nitf_Uint8 ** user,
+        uint8_t ** user,
         int *padded, nitf_Error * error);
 
 /**
    Read a block directly from file
  */
-NITFAPI(nitf_Uint8*) nitf_ImageReader_readBlock(nitf_ImageReader * imageReader,
-                                                nitf_Uint32 blockNumber,
-                                                nitf_Uint64* blockSize,
+NITFAPI(uint8_t*) nitf_ImageReader_readBlock(nitf_ImageReader * imageReader,
+                                                uint32_t blockNumber,
+                                                uint64_t* blockSize,
                                                 nitf_Error * error);
 
 /*!

--- a/modules/c/nitf/include/nitf/ImageSegment.h
+++ b/modules/c/nitf/include/nitf/ImageSegment.h
@@ -41,8 +41,8 @@ NITF_CXX_GUARD
 typedef struct _nitf_ImageSegment
 {
     nitf_ImageSubheader *subheader;
-    nitf_Uint64 imageOffset;    /* Make these nitf_Off's */
-    nitf_Uint64 imageEnd;       /* Make these nitf_Off's */
+    uint64_t imageOffset;    /* Make these nitf_Off's */
+    uint64_t imageEnd;       /* Make these nitf_Off's */
     /*nitf_ImageSource *imageSource;*/
 }
 nitf_ImageSegment;

--- a/modules/c/nitf/include/nitf/ImageSubheader.h
+++ b/modules/c/nitf/include/nitf/ImageSubheader.h
@@ -115,7 +115,7 @@
 
 /*!< \def NITF_MAX_BAND_COUNT - Maximum band count */
 #define NITF_MAX_BAND_COUNT 99999
-#define NITF_INVALID_BAND_COUNT ((nitf_Uint32) -1)
+#define NITF_INVALID_BAND_COUNT ((uint32_t) -1)
 
 
 NITF_CXX_GUARD
@@ -258,12 +258,12 @@ NITFAPI(NITF_BOOL) nitf_ImageSubheader_setPixelInformation
 (
     nitf_ImageSubheader *subhdr,      /*!< Subheader object to set */
     const char *pvtype,               /*!< Pixel value type */
-    nitf_Uint32 nbpp,                 /*!< Number of bits/pixel */
-    nitf_Uint32 abpp,                 /*!< Actual number of bits/pixel */
+    uint32_t nbpp,                 /*!< Number of bits/pixel */
+    uint32_t abpp,                 /*!< Actual number of bits/pixel */
     const char *justification,        /*!< Pixel justification */
     const char *irep,                 /*!< Image representation */
     const char *icat,                 /*!< Image category */
-    nitf_Uint32 bandCount,            /*!< Number of bands */
+    uint32_t bandCount,            /*!< Number of bands */
     nitf_BandInfo **bands,            /*!< Band information object list */
     nitf_Error *error                 /*!< For error returns */
 );
@@ -282,7 +282,7 @@ NITFAPI(NITF_BOOL) nitf_ImageSubheader_setPixelInformation
   \return The number of bands or an error indicator
 
 */
-NITFAPI(nitf_Uint32) nitf_ImageSubheader_getBandCount
+NITFAPI(uint32_t) nitf_ImageSubheader_getBandCount
 (
     nitf_ImageSubheader* subhdr,     /*!< The associated subheader */
     nitf_Error *error                /*!< For error returns */
@@ -306,7 +306,7 @@ NITFAPI(nitf_Uint32) nitf_ImageSubheader_getBandCount
 NITFAPI(nitf_BandInfo *) nitf_ImageSubheader_getBandInfo
 (
     nitf_ImageSubheader* subhdr,    /*!< The associated subheader */
-    nitf_Uint32 band,               /*!< The band index */
+    uint32_t band,               /*!< The band index */
     nitf_Error *error               /*!< For error returns */
 );
 
@@ -324,7 +324,7 @@ NITFAPI(nitf_BandInfo *) nitf_ImageSubheader_getBandInfo
 */
 NITFAPI(NITF_BOOL) nitf_ImageSubheader_createBands(
     nitf_ImageSubheader * subhdr, /*!< The associated subheader */
-    nitf_Uint32 numBands,         /*!< The number of bands to create/add*/
+    uint32_t numBands,         /*!< The number of bands to create/add*/
     nitf_Error * error            /*!< For error returns */
 );
 
@@ -338,7 +338,7 @@ NITFAPI(NITF_BOOL) nitf_ImageSubheader_createBands(
 */
 NITFAPI(NITF_BOOL) nitf_ImageSubheader_removeBand(
     nitf_ImageSubheader * subhdr, /*!< The associated subheader */
-    nitf_Uint32 index,            /*!< The index of the band to remove */
+    uint32_t index,            /*!< The index of the band to remove */
     nitf_Error * error            /*!< For error returns */
 );
 
@@ -357,8 +357,8 @@ NITFAPI(NITF_BOOL) nitf_ImageSubheader_removeBand(
 NITFAPI(NITF_BOOL) nitf_ImageSubheader_getDimensions
 (
     nitf_ImageSubheader* subhdr,  /*!< Associated image subheader object */
-    nitf_Uint32 *numRows,         /*!< Returns the number of rows */
-    nitf_Uint32 *numCols,         /*!< Returns the number of columns */
+    uint32_t *numRows,         /*!< Returns the number of rows */
+    uint32_t *numCols,         /*!< Returns the number of columns */
     nitf_Error *error             /*!< Object for error messages */
 );
 
@@ -379,12 +379,12 @@ NITFAPI(NITF_BOOL) nitf_ImageSubheader_getDimensions
 NITFAPI(NITF_BOOL) nitf_ImageSubheader_getBlocking
 (
     nitf_ImageSubheader* subhdr,  /*!< Associated image subheader object */
-    nitf_Uint32 *numRows,         /*!< Returns the number of rows */
-    nitf_Uint32 *numCols,         /*!< Returns the number of columns */
-    nitf_Uint32 *numRowsPerBlock, /*!< Returns the number of rows/block */
-    nitf_Uint32 *numColsPerBlock, /*!< Returns the number of columns/block */
-    nitf_Uint32 *numBlocksPerRow, /*!< Returns the number of blocks/row */
-    nitf_Uint32 *numBlocksPerCol, /*!< Returns the number of blocks/column */
+    uint32_t *numRows,         /*!< Returns the number of rows */
+    uint32_t *numCols,         /*!< Returns the number of columns */
+    uint32_t *numRowsPerBlock, /*!< Returns the number of rows/block */
+    uint32_t *numColsPerBlock, /*!< Returns the number of columns/block */
+    uint32_t *numBlocksPerRow, /*!< Returns the number of blocks/row */
+    uint32_t *numBlocksPerCol, /*!< Returns the number of blocks/column */
     char *imode,                  /*!< Returns the image mode string */
     nitf_Error *error             /*!< Object for error messages */
 );
@@ -433,8 +433,8 @@ NITFAPI(NITF_BOOL) nitf_ImageSubheader_getCompression
 NITFAPI(NITF_BOOL) nitf_ImageSubheader_setDimensions
 (
     nitf_ImageSubheader* subhdr,  /*!< Associated image subheader object */
-    nitf_Uint32 numRows,          /*!< The number of rows */
-    nitf_Uint32 numCols,          /*!< The number of columns */
+    uint32_t numRows,          /*!< The number of rows */
+    uint32_t numCols,          /*!< The number of columns */
     nitf_Error *error             /*!< Object for error messages */
 );
 
@@ -509,12 +509,12 @@ nitf_ImageSubheader_getCornersAsLatLons(nitf_ImageSubheader* subheader,
 NITFAPI(void)
 nitf_ImageSubheader_computeBlocking
 (
-    nitf_Uint32 numRows,           /*!< The number of rows */
-    nitf_Uint32 numCols,           /*!< The number of columns */
-    nitf_Uint32* numRowsPerBlock,  /*!< The number of rows/block */
-    nitf_Uint32* numColsPerBlock,  /*!< The number of columns/block */
-    nitf_Uint32* numBlocksPerCol,  /*!< The number of blocks per column */
-    nitf_Uint32* numBlocksPerRow   /*!< The number of blocks per row */
+    uint32_t numRows,           /*!< The number of rows */
+    uint32_t numCols,           /*!< The number of columns */
+    uint32_t* numRowsPerBlock,  /*!< The number of rows/block */
+    uint32_t* numColsPerBlock,  /*!< The number of columns/block */
+    uint32_t* numBlocksPerCol,  /*!< The number of blocks per column */
+    uint32_t* numBlocksPerRow   /*!< The number of blocks per row */
 );
 
 /*!
@@ -533,10 +533,10 @@ nitf_ImageSubheader_computeBlocking
 NITFAPI(NITF_BOOL) nitf_ImageSubheader_setBlocking
 (
     nitf_ImageSubheader* subhdr,  /*!< Associated image subheader object */
-    nitf_Uint32 numRows,          /*!< The number of rows */
-    nitf_Uint32 numCols,          /*!< The number of columns */
-    nitf_Uint32 numRowsPerBlock,  /*!< The number of rows/block */
-    nitf_Uint32 numColsPerBlock,  /*!< The number of columns/block */
+    uint32_t numRows,          /*!< The number of rows */
+    uint32_t numCols,          /*!< The number of columns */
+    uint32_t numRowsPerBlock,  /*!< The number of rows/block */
+    uint32_t numColsPerBlock,  /*!< The number of columns/block */
     const char *imode,            /*!< Image mode */
     nitf_Error *error             /*!< Object for error messages */
 );

--- a/modules/c/nitf/include/nitf/ImageWriter.h
+++ b/modules/c/nitf/include/nitf/ImageWriter.h
@@ -109,8 +109,8 @@ NITFAPI(NITF_BOOL) nitf_ImageWriter_setDirectBlockWrite
  *  failed
  */
 NITFAPI(NITF_BOOL) nitf_ImageWriter_setPadPixel(nitf_ImageWriter* imageWriter,
-                                                nitf_Uint8* value,
-                                                nitf_Uint32 length,
+                                                uint8_t* value,
+                                                uint32_t length,
                                                 nitf_Error* error);
 
 NITF_CXX_ENDGUARD

--- a/modules/c/nitf/include/nitf/LabelSegment.h
+++ b/modules/c/nitf/include/nitf/LabelSegment.h
@@ -39,8 +39,8 @@ NITF_CXX_GUARD
 typedef struct _nitf_LabelSegment
 {
     nitf_LabelSubheader *subheader;
-    nitf_Uint64 offset;
-    nitf_Uint64 end;
+    uint64_t offset;
+    uint64_t end;
     char *label;
 }
 nitf_LabelSegment;

--- a/modules/c/nitf/include/nitf/LookupTable.h
+++ b/modules/c/nitf/include/nitf/LookupTable.h
@@ -39,9 +39,9 @@ NITF_CXX_GUARD
 */
 typedef struct _nitf_LookupTable
 {
-    nitf_Uint32 tables;         /*!< Number of tables */
-    nitf_Uint32 entries;        /*!< Number of entries per table */
-    nitf_Uint8 *table;          /*!< The tables */
+    uint32_t tables;         /*!< Number of tables */
+    uint32_t entries;        /*!< Number of entries per table */
+    uint8_t *table;          /*!< The tables */
 }
 nitf_LookupTable;
 
@@ -57,8 +57,8 @@ nitf_LookupTable;
  */
 NITFAPI(nitf_LookupTable *) nitf_LookupTable_construct
 (
-    nitf_Uint32 numTables,
-    nitf_Uint32 numEntries,
+    uint32_t numTables,
+    uint32_t numEntries,
     nitf_Error * error
 );
 
@@ -98,8 +98,8 @@ NITFAPI(void) nitf_LookupTable_destruct(nitf_LookupTable ** lut);
 */
 NITFAPI(NITF_BOOL) nitf_LookupTable_init(
     nitf_LookupTable * lut,      /*!< The lookup table to initialize */
-    nitf_Uint32 numTables,       /*!< Number of tables */
-    nitf_Uint32 numEntries,      /*!< Number of entries in the tablt */
+    uint32_t numTables,       /*!< Number of tables */
+    uint32_t numEntries,      /*!< Number of entries in the tablt */
     const NITF_DATA * tables,    /*!< The tables */
     nitf_Error * error           /*!< Error object for error returns */
 );

--- a/modules/c/nitf/include/nitf/PluginIdentifier.h
+++ b/modules/c/nitf/include/nitf/PluginIdentifier.h
@@ -87,10 +87,10 @@ typedef nitf_TREHandler* (*NITF_PLUGIN_TRE_HANDLER_FUNCTION)(nitf_Error * error)
 
 typedef int (*NITF_PLUGIN_COMPRESSION_HANDLER_FUNCTION)
 (
-    nitf_Uint8 *input,
-    nitf_Uint32 inputLen,
-    nitf_Uint8 **output,
-    nitf_Uint32 *outputLen,
+    uint8_t *input,
+    uint32_t inputLen,
+    uint8_t **output,
+    uint32_t *outputLen,
     nitf_Error *error
 );
 

--- a/modules/c/nitf/include/nitf/RESegment.h
+++ b/modules/c/nitf/include/nitf/RESegment.h
@@ -39,8 +39,8 @@ NITF_CXX_GUARD
 typedef struct _nitf_RESegment
 {
     nitf_RESubheader *subheader;
-    nitf_Uint64 offset;
-    nitf_Uint64 end;
+    uint64_t offset;
+    uint64_t end;
     char *data;
 }
 nitf_RESegment;

--- a/modules/c/nitf/include/nitf/RESubheader.h
+++ b/modules/c/nitf/include/nitf/RESubheader.h
@@ -55,7 +55,7 @@ typedef struct _nitf_RESubheader
     nitf_FileSecurity *securityGroup;
     nitf_Field *subheaderFieldsLength;
     char *subheaderFields;
-    nitf_Uint64 dataLength;
+    uint64_t dataLength;
 }
 nitf_RESubheader;
 

--- a/modules/c/nitf/include/nitf/Record.h
+++ b/modules/c/nitf/include/nitf/Record.h
@@ -122,7 +122,7 @@ NITFAPI(nitf_Version) nitf_Record_getVersion(const nitf_Record * record);
 /*!
  *  Utility function gets the number of images out of the record.
  *  Just goes into the FHDR and gets out NUMI and converts the
- *  field to a Uint32
+ *  field to a uint32_t
  *
  *  \param record The record
  *  \param error An error to populate on failure
@@ -148,7 +148,7 @@ NITFAPI(nitf_ImageSegment*) nitf_Record_newImageSegment(nitf_Record * record,
 /*!
  *  Utility function gets the number of graphics out of the record.
  *  Just goes into the FHDR and gets out NUMS and converts the
- *  field to a Uint32
+ *  field to a uint32_t
  *
  *  \param record The record
  *  \param error An error to populate on failure
@@ -176,7 +176,7 @@ nitf_Record_newGraphicSegment(nitf_Record * record,
 /*!
  *  Utility function gets the number of texts out of the record.
  *  Just goes into the FHDR and gets out NUMT and converts the
- *  field to a Uint32
+ *  field to a uint32_t
  *
  *  \param record The record
  *  \param error An error to populate on failure
@@ -204,7 +204,7 @@ NITFAPI(nitf_TextSegment*) nitf_Record_newTextSegment(nitf_Record * record,
 /*!
  *  Utility function gets the number of DES out of the record.
  *  Just goes into the FHDR and gets out NUMDES and converts the
- *  field to a Uint32
+ *  field to a uint32_t
  *
  *  \param record The record
  *  \param error An error to populate on failure
@@ -267,7 +267,7 @@ NITFAPI(NITF_BOOL) nitf_Record_removeGraphicSegment
 /*!
  *  Utility function gets the number of labels out of the record.
  *  Just goes into the FHDR and gets out NUMX and converts the
- *  field to a Uint32
+ *  field to a uint32_t
  *
  *  \param record The record
  *  \param error An error to populate on failure
@@ -333,7 +333,7 @@ NITFAPI(NITF_BOOL) nitf_Record_removeDataExtensionSegment
 /*!
  *  Utility function gets the number of RES out of the record.
  *  Just goes into the FHDR and gets out NUMRES and converts the
- *  field to a Uint32
+ *  field to a uint32_t
  *
  *  \param record The record
  *  \param error An error to populate on failure

--- a/modules/c/nitf/include/nitf/Record.h
+++ b/modules/c/nitf/include/nitf/Record.h
@@ -129,7 +129,7 @@ NITFAPI(nitf_Version) nitf_Record_getVersion(const nitf_Record * record);
  *  \return We will return a value that can be tested using
  *      NITF_INVALID_NUM_SEGMENTS(rv)
  */
-NITFAPI(nitf_Uint32) nitf_Record_getNumImages(const nitf_Record* record,
+NITFAPI(uint32_t) nitf_Record_getNumImages(const nitf_Record* record,
                                               nitf_Error* error);
 
 /*!
@@ -155,7 +155,7 @@ NITFAPI(nitf_ImageSegment*) nitf_Record_newImageSegment(nitf_Record * record,
  *  \return We will return a value that can be tested using
  *      NITF_INVALID_NUM_SEGMENTS(rv)
  */
-NITFAPI(nitf_Uint32) nitf_Record_getNumGraphics(const nitf_Record* record,
+NITFAPI(uint32_t) nitf_Record_getNumGraphics(const nitf_Record* record,
                                                 nitf_Error* error);
 
 /*!
@@ -183,7 +183,7 @@ nitf_Record_newGraphicSegment(nitf_Record * record,
  *  \return We will return a value that can be tested using
  *      NITF_INVALID_NUM_SEGMENTS(rv)
  */
-NITFAPI(nitf_Uint32) nitf_Record_getNumTexts(const nitf_Record* record,
+NITFAPI(uint32_t) nitf_Record_getNumTexts(const nitf_Record* record,
                                              nitf_Error* error);
 
 /*!
@@ -211,7 +211,7 @@ NITFAPI(nitf_TextSegment*) nitf_Record_newTextSegment(nitf_Record * record,
  *  \return We will return a value that can be tested using
  *      NITF_INVALID_NUM_SEGMENTS(rv)
  */
-NITFAPI(nitf_Uint32) nitf_Record_getNumDataExtensions(const nitf_Record* record,
+NITFAPI(uint32_t) nitf_Record_getNumDataExtensions(const nitf_Record* record,
                                                       nitf_Error* error);
 
 /*!
@@ -242,7 +242,7 @@ nitf_Record_newDataExtensionSegment(nitf_Record * record,
 NITFAPI(NITF_BOOL) nitf_Record_removeImageSegment
 (
     nitf_Record * record,
-    nitf_Uint32 segmentNumber,
+    uint32_t segmentNumber,
     nitf_Error * error
 );
 
@@ -259,7 +259,7 @@ NITFAPI(NITF_BOOL) nitf_Record_removeImageSegment
 NITFAPI(NITF_BOOL) nitf_Record_removeGraphicSegment
 (
     nitf_Record * record,
-    nitf_Uint32 segmentNumber,
+    uint32_t segmentNumber,
     nitf_Error * error
 );
 
@@ -274,7 +274,7 @@ NITFAPI(NITF_BOOL) nitf_Record_removeGraphicSegment
  *  \return We will return a value that can be tested using
  *      NITF_INVALID_NUM_SEGMENTS(rv)
  */
-NITFAPI(nitf_Uint32) nitf_Record_getNumLabels(const nitf_Record* record,
+NITFAPI(uint32_t) nitf_Record_getNumLabels(const nitf_Record* record,
                                               nitf_Error* error);
 
 
@@ -291,7 +291,7 @@ NITFAPI(nitf_Uint32) nitf_Record_getNumLabels(const nitf_Record* record,
 NITFAPI(NITF_BOOL) nitf_Record_removeLabelSegment
 (
     nitf_Record * record,
-    nitf_Uint32 segmentNumber,
+    uint32_t segmentNumber,
     nitf_Error * error
 );
 
@@ -308,7 +308,7 @@ NITFAPI(NITF_BOOL) nitf_Record_removeLabelSegment
 NITFAPI(NITF_BOOL) nitf_Record_removeTextSegment
 (
     nitf_Record * record,
-    nitf_Uint32 segmentNumber,
+    uint32_t segmentNumber,
     nitf_Error * error
 );
 
@@ -325,7 +325,7 @@ NITFAPI(NITF_BOOL) nitf_Record_removeTextSegment
 NITFAPI(NITF_BOOL) nitf_Record_removeDataExtensionSegment
 (
     nitf_Record * record,
-    nitf_Uint32 segmentNumber,
+    uint32_t segmentNumber,
     nitf_Error * error
 );
 
@@ -340,7 +340,7 @@ NITFAPI(NITF_BOOL) nitf_Record_removeDataExtensionSegment
  *  \return We will return a value that can be tested using
  *      NITF_INVALID_NUM_SEGMENTS(rv)
  */
-NITFAPI(nitf_Uint32) nitf_Record_getNumReservedExtensions(const nitf_Record* record,
+NITFAPI(uint32_t) nitf_Record_getNumReservedExtensions(const nitf_Record* record,
                                                           nitf_Error* error);
 
 /*!
@@ -356,7 +356,7 @@ NITFAPI(nitf_Uint32) nitf_Record_getNumReservedExtensions(const nitf_Record* rec
 NITFAPI(NITF_BOOL) nitf_Record_removeReservedExtensionSegment
 (
     nitf_Record * record,
-    nitf_Uint32 segmentNumber,
+    uint32_t segmentNumber,
     nitf_Error * error
 );
 
@@ -372,8 +372,8 @@ NITFAPI(NITF_BOOL) nitf_Record_removeReservedExtensionSegment
 NITFAPI(NITF_BOOL) nitf_Record_moveImageSegment
 (
     nitf_Record * record,
-    nitf_Uint32 oldIndex,
-    nitf_Uint32 newIndex,
+    uint32_t oldIndex,
+    uint32_t newIndex,
     nitf_Error * error
 );
 
@@ -389,8 +389,8 @@ NITFAPI(NITF_BOOL) nitf_Record_moveImageSegment
 NITFAPI(NITF_BOOL) nitf_Record_moveGraphicSegment
 (
     nitf_Record * record,
-    nitf_Uint32 oldIndex,
-    nitf_Uint32 newIndex,
+    uint32_t oldIndex,
+    uint32_t newIndex,
     nitf_Error * error
 );
 
@@ -406,8 +406,8 @@ NITFAPI(NITF_BOOL) nitf_Record_moveGraphicSegment
 NITFAPI(NITF_BOOL) nitf_Record_moveLabelSegment
 (
     nitf_Record * record,
-    nitf_Uint32 oldIndex,
-    nitf_Uint32 newIndex,
+    uint32_t oldIndex,
+    uint32_t newIndex,
     nitf_Error * error
 );
 
@@ -423,8 +423,8 @@ NITFAPI(NITF_BOOL) nitf_Record_moveLabelSegment
 NITFAPI(NITF_BOOL) nitf_Record_moveTextSegment
 (
     nitf_Record * record,
-    nitf_Uint32 oldIndex,
-    nitf_Uint32 newIndex,
+    uint32_t oldIndex,
+    uint32_t newIndex,
     nitf_Error * error
 );
 
@@ -440,8 +440,8 @@ NITFAPI(NITF_BOOL) nitf_Record_moveTextSegment
 NITFAPI(NITF_BOOL) nitf_Record_moveDataExtensionSegment
 (
     nitf_Record * record,
-    nitf_Uint32 oldIndex,
-    nitf_Uint32 newIndex,
+    uint32_t oldIndex,
+    uint32_t newIndex,
     nitf_Error * error
 );
 
@@ -457,8 +457,8 @@ NITFAPI(NITF_BOOL) nitf_Record_moveDataExtensionSegment
 NITFAPI(NITF_BOOL) nitf_Record_moveReservedExtensionSegment
 (
     nitf_Record * record,
-    nitf_Uint32 oldIndex,
-    nitf_Uint32 newIndex,
+    uint32_t oldIndex,
+    uint32_t newIndex,
     nitf_Error * error
 );
 

--- a/modules/c/nitf/include/nitf/RowSource.h
+++ b/modules/c/nitf/include/nitf/RowSource.h
@@ -67,7 +67,7 @@ NITF_CXX_GUARD
   \return Returns true on success. On failure the error object is set
 */
 typedef NITF_BOOL(*NITF_ROW_SOURCE_NEXT_ROW) (void *algorithm,
-        nitf_Uint32 band,
+        uint32_t band,
         NITF_DATA * buffer,
         nitf_Error * error);
 
@@ -84,9 +84,9 @@ NITFAPI(nitf_BandSource *) nitf_RowSource_construct
 (
     void *algorithm,                    /*!< The algorithm object */
     NITF_ROW_SOURCE_NEXT_ROW nextRow,   /*!< Pointer to the next row function */
-    nitf_Uint32 band,                   /*!< Associate output band */
-    nitf_Uint32 numRows,                /*!< Number of rows */
-    nitf_Uint32 rowLength,              /*!< Length of each row in bytes (single band) */
+    uint32_t band,                   /*!< Associate output band */
+    uint32_t numRows,                /*!< Number of rows */
+    uint32_t rowLength,              /*!< Length of each row in bytes (single band) */
     nitf_Error * error                  /*!< For error returns */
 );
 

--- a/modules/c/nitf/include/nitf/SegmentReader.h
+++ b/modules/c/nitf/include/nitf/SegmentReader.h
@@ -57,9 +57,9 @@ NITF_CXX_GUARD
 typedef struct _nitf_SegmentReader
 {
     nitf_IOInterface* input;
-    nitf_Uint32 dataLength;
-    nitf_Uint64 baseOffset;
-    nitf_Uint64 virtualOffset;
+    uint32_t dataLength;
+    uint64_t baseOffset;
+    uint64_t virtualOffset;
 }
 nitf_SegmentReader;
 

--- a/modules/c/nitf/include/nitf/StreamIOWriteHandler.h
+++ b/modules/c/nitf/include/nitf/StreamIOWriteHandler.h
@@ -42,8 +42,8 @@ NITF_CXX_GUARD
  */
 NITFAPI(nitf_WriteHandler*) nitf_StreamIOWriteHandler_construct(
     nitf_IOInterface *io,
-    nitf_Uint64 offset,
-    nitf_Uint64 bytes,
+    uint64_t offset,
+    uint64_t bytes,
     nitf_Error *error);
 
 

--- a/modules/c/nitf/include/nitf/SubWindow.h
+++ b/modules/c/nitf/include/nitf/SubWindow.h
@@ -48,14 +48,14 @@ NITF_CXX_GUARD
  */
 typedef struct _nitf_SubWindow
 {
-    nitf_Uint32 startRow;       /*!< Start row */
-    nitf_Uint32 startCol;       /*!< Start column */
+    uint32_t startRow;       /*!< Start row */
+    uint32_t startCol;       /*!< Start column */
 
-    nitf_Uint32 numRows;        /*!< Number of rows to read */
-    nitf_Uint32 numCols;        /*!< Number of columns to read */
+    uint32_t numRows;        /*!< Number of rows to read */
+    uint32_t numCols;        /*!< Number of columns to read */
 
-    nitf_Uint32 *bandList;      /*!< List of bands to read */
-    nitf_Uint32 numBands;       /*!< Number of bands to read */
+    uint32_t *bandList;      /*!< List of bands to read */
+    uint32_t numBands;       /*!< Number of bands to read */
 
     nitf_DownSampler *downsampler;      /* A downsampler, if any  */
 

--- a/modules/c/nitf/include/nitf/System.h
+++ b/modules/c/nitf/include/nitf/System.h
@@ -22,6 +22,9 @@
 
 #ifndef __NITF_SYSTEM_H__
 #define __NITF_SYSTEM_H__
+#pragma once
+
+#include <stdint.h>
 
 #ifdef WIN32
 #      if defined(NITF_MODULE_EXPORTS)
@@ -87,6 +90,16 @@
 /* TYPES                                                                      */
 /******************************************************************************/
 #include "nrt/Types.h"
+ // Keeping these here so that code using "nitf_Uint8" still compiles;
+ // we can't make others change to "uint8_t".
+typedef uint8_t                   nitf_Uint8;
+typedef uint16_t                  nitf_Uint16;
+typedef uint32_t                  nitf_Uint32;
+typedef uint64_t                  nitf_Uint64;
+typedef int8_t                    nitf_Int8;
+typedef int16_t                   nitf_Int16;
+typedef int32_t                   nitf_Int32;
+typedef int64_t                   nitf_Int64;
 typedef nrt_IOHandle                nitf_IOHandle;
 typedef NRT_NATIVE_DLL              NITF_NATIVE_DLL;
 typedef NRT_DLL_FUNCTION_PTR        NITF_DLL_FUNCTION_PTR;

--- a/modules/c/nitf/include/nitf/System.h
+++ b/modules/c/nitf/include/nitf/System.h
@@ -87,14 +87,6 @@
 /* TYPES                                                                      */
 /******************************************************************************/
 #include "nrt/Types.h"
-typedef uint8_t                   nitf_Uint8;
-typedef uint16_t                  nitf_Uint16;
-typedef uint32_t                  nitf_Uint32;
-typedef uint64_t                  nitf_Uint64;
-typedef int8_t                    nitf_Int8;
-typedef int16_t                   nitf_Int16;
-typedef int32_t                   nitf_Int32;
-typedef int64_t                   nitf_Int64;
 typedef nrt_IOHandle                nitf_IOHandle;
 typedef NRT_NATIVE_DLL              NITF_NATIVE_DLL;
 typedef NRT_DLL_FUNCTION_PTR        NITF_DLL_FUNCTION_PTR;

--- a/modules/c/nitf/include/nitf/System.h
+++ b/modules/c/nitf/include/nitf/System.h
@@ -87,14 +87,14 @@
 /* TYPES                                                                      */
 /******************************************************************************/
 #include "nrt/Types.h"
-typedef nrt_Uint8                   nitf_Uint8;
-typedef nrt_Uint16                  nitf_Uint16;
-typedef nrt_Uint32                  nitf_Uint32;
-typedef nrt_Uint64                  nitf_Uint64;
-typedef nrt_Int8                    nitf_Int8;
-typedef nrt_Int16                   nitf_Int16;
-typedef nrt_Int32                   nitf_Int32;
-typedef nrt_Int64                   nitf_Int64;
+typedef uint8_t                   nitf_Uint8;
+typedef uint16_t                  nitf_Uint16;
+typedef uint32_t                  nitf_Uint32;
+typedef uint64_t                  nitf_Uint64;
+typedef int8_t                    nitf_Int8;
+typedef int16_t                   nitf_Int16;
+typedef int32_t                   nitf_Int32;
+typedef int64_t                   nitf_Int64;
 typedef nrt_IOHandle                nitf_IOHandle;
 typedef NRT_NATIVE_DLL              NITF_NATIVE_DLL;
 typedef NRT_DLL_FUNCTION_PTR        NITF_DLL_FUNCTION_PTR;

--- a/modules/c/nitf/include/nitf/TRE.h
+++ b/modules/c/nitf/include/nitf/TRE.h
@@ -154,7 +154,7 @@ typedef const char* (*NITF_TRE_ID_GET) (nitf_TRE* tre);
  * \return          NITF_FAILURE if an error occurred, otherwise NITF_SUCCESS
  */
 typedef NITF_BOOL (*NITF_TRE_READER)(nitf_IOInterface* io,
-                                     nitf_Uint32 length,
+                                     uint32_t length,
                                      nitf_TRE *tre,
                                      struct _nitf_Record *record,
                                      nitf_Error *error);

--- a/modules/c/nitf/include/nitf/TREPrivateData.h
+++ b/modules/c/nitf/include/nitf/TREPrivateData.h
@@ -35,7 +35,7 @@ NITF_CXX_GUARD
  */
 typedef struct _nitf_TREPrivateData
 {
-    nitf_Uint32 length;
+    uint32_t length;
     char* descriptionName;   /* the name/ID of the TREDescription */
     nitf_TREDescription* description;
     nitf_HashTable *hash;

--- a/modules/c/nitf/include/nitf/TREUtils.h
+++ b/modules/c/nitf/include/nitf/TREUtils.h
@@ -34,7 +34,7 @@ NITF_CXX_GUARD
 NITFAPI(int) nitf_TREUtils_computeLength(nitf_TRE * tre);
 
 NITFAPI(NITF_BOOL) nitf_TREUtils_setDescription(nitf_TRE* tre,
-                                                nitf_Uint32 length,
+                                                uint32_t length,
                                                 nitf_Error* error);
 
 NITFAPI(NITF_BOOL) nitf_TREUtils_fillData(nitf_TRE * tre,
@@ -52,7 +52,7 @@ NITFAPI(NITF_BOOL) nitf_TREUtils_readField(nitf_IOInterface* io,
                                            nitf_Error * error);
 
 NITFAPI(char *) nitf_TREUtils_getRawData(nitf_TRE * tre,
-                                         nitf_Uint32* treLength,
+                                         uint32_t* treLength,
                                          nitf_Error * error);
 
 NITFAPI(NITF_BOOL) nitf_TREUtils_isSane(nitf_TRE * tre);
@@ -88,7 +88,7 @@ NITFAPI(NITF_BOOL) nitf_TREUtils_basicInit(nitf_TRE * tre,
 NITFAPI(const char*) nitf_TREUtils_basicGetID(nitf_TRE *tre);
 
 NITFAPI(NITF_BOOL) nitf_TREUtils_basicRead(nitf_IOInterface* io,
-                                           nitf_Uint32 length,
+                                           uint32_t length,
                                            nitf_TRE* tre,
                                            struct _nitf_Record* record,
                                            nitf_Error* error);

--- a/modules/c/nitf/include/nitf/TextSegment.h
+++ b/modules/c/nitf/include/nitf/TextSegment.h
@@ -39,8 +39,8 @@ NITF_CXX_GUARD
 typedef struct _nitf_TextSegment
 {
     nitf_TextSubheader *subheader;
-    nitf_Uint64 offset;
-    nitf_Uint64 end;
+    uint64_t offset;
+    uint64_t end;
 }
 nitf_TextSegment;
 

--- a/modules/c/nitf/include/nitf/Writer.h
+++ b/modules/c/nitf/include/nitf/Writer.h
@@ -199,7 +199,7 @@ NITFAPI(NITF_BOOL) nitf_Writer_write(nitf_Writer * writer, nitf_Error * error);
  */
 NITFPROT(NITF_BOOL) nitf_Writer_writeHeader(nitf_Writer* writer,
                                             nitf_Off* fileLenOff,
-                                            nitf_Uint32* hdrLen,
+                                            uint32_t* hdrLen,
                                             nitf_Error* error);
 
 /*!
@@ -238,7 +238,7 @@ nitf_Writer_writeImageSubheader(nitf_Writer* writer,
  */
 NITFPROT(NITF_BOOL) nitf_Writer_writeDESubheader(nitf_Writer* writer,
                                                  const nitf_DESubheader* subhdr,
-                                                 nitf_Uint32* userSublen,
+                                                 uint32_t* userSublen,
                                                  nitf_Version fver,
                                                  nitf_Error* error);
 
@@ -256,10 +256,10 @@ NITFPROT(NITF_BOOL) nitf_Writer_writeDESubheader(nitf_Writer* writer,
  * \return NITF_SUCCESS on success, NITF_FAILURE otherwise
  */
 NITFPROT(NITF_BOOL) nitf_Writer_writeInt64Field(nitf_Writer* writer,
-                                                nitf_Uint64 field,
-                                                nitf_Uint32 length,
+                                                uint64_t field,
+                                                uint32_t length,
                                                 char fill,
-                                                nitf_Uint32 fillDir,
+                                                uint32_t fillDir,
                                                 nitf_Error* error);
 
 NITF_CXX_ENDGUARD

--- a/modules/c/nitf/shared/ENGRDA.c
+++ b/modules/c/nitf/shared/ENGRDA.c
@@ -132,15 +132,15 @@ NITFPRIV(int) ENGRDA_parse(nitf_TRE * tre,
             {
                 if (length == NITF_INT16_SZ)
                 {
-                    nitf_Int16 int16 =
-                        (nitf_Int16)NITF_NTOHS(*((nitf_Int16 *) (bufptr + offset)));
+                    int16_t int16 =
+                        (int16_t)NITF_NTOHS(*((int16_t *) (bufptr + offset)));
                     status = nitf_Field_setRawData(field,
                             (NITF_DATA *) & int16, length, error);
                 }
                 else if (length == NITF_INT32_SZ)
                 {
-                    nitf_Int32 int32 =
-                        (nitf_Int32)NITF_NTOHL(*((nitf_Int32 *) (bufptr + offset)));
+                    int32_t int32 =
+                        (int32_t)NITF_NTOHL(*((int32_t *) (bufptr + offset)));
                     status = nitf_Field_setRawData(field,
                             (NITF_DATA *) & int32, length, error);
                 }
@@ -210,7 +210,7 @@ NITFPRIV(int) ENGRDA_parse(nitf_TRE * tre,
  *       original read function?
  */
 NITFPRIV(NITF_BOOL) ENGRDA_read(nitf_IOInterface* io,
-                                nitf_Uint32 length,
+                                uint32_t length,
                                 nitf_TRE* tre,
                                 struct _nitf_Record* record,
                                 nitf_Error* error)

--- a/modules/c/nitf/source/BandInfo.c
+++ b/modules/c/nitf/source/BandInfo.c
@@ -133,8 +133,8 @@ NITFAPI(NITF_BOOL) nitf_BandInfo_init(nitf_BandInfo * bandInfo,
                                       const char *subcategory,
                                       const char *imageFilterCondition,
                                       const char *imageFilterCode,
-                                      nitf_Uint32 numLUTs,
-                                      nitf_Uint32 bandEntriesPerLUT,
+                                      uint32_t numLUTs,
+                                      uint32_t bandEntriesPerLUT,
                                       nitf_LookupTable * lut,
                                       nitf_Error * error)
 {

--- a/modules/c/nitf/source/BandSource.c
+++ b/modules/c/nitf/source/BandSource.c
@@ -59,7 +59,7 @@ NITFPRIV(NITF_BOOL) MemorySource_contigRead(
 {
     (void) error; /* Suppresses a warning. Param seems to exist for consistency purposes. Not used. */
     memcpy(buf,
-           (const nitf_Uint8*)memorySource->data + memorySource->mark,
+           (const uint8_t*)memorySource->data + memorySource->mark,
            (size_t)size);
     memorySource->mark += size;
     return NITF_SUCCESS;
@@ -73,8 +73,8 @@ NITFPRIV(NITF_BOOL) MemorySource_offsetRead(
         nitf_Error* error)
 {
     size_t destOffset = 0;
-    const nitf_Uint8* const src = (const nitf_Uint8*)memorySource->data;
-    nitf_Uint8* const dest = (nitf_Uint8*)buf;
+    const uint8_t* const src = (const uint8_t*)memorySource->data;
+    uint8_t* const dest = (uint8_t*)buf;
     (void) error;
 
     while (destOffset < (size_t)size)
@@ -300,15 +300,15 @@ NITFPRIV(NITF_BOOL) IOSource_offsetRead(IOSourceImpl * source,
     /* TODO - this *could* be smaller, but this should be ok for now */
     nitf_Off tsize = size * (source->pixelSkip + 1);
 
-    nitf_Uint8* tbuf;
-    nitf_Uint8* bufPtr = (nitf_Uint8*)buf;
+    uint8_t* tbuf;
+    uint8_t* bufPtr = (uint8_t*)buf;
     nitf_Off lmark = 0;
     int i = 0;
     int j = 0;
     if (tsize + source->mark > source->size)
         tsize = source->size - source->mark;
 
-    tbuf = (nitf_Uint8 *) NITF_MALLOC((size_t)tsize);
+    tbuf = (uint8_t *) NITF_MALLOC((size_t)tsize);
     if (!tbuf)
     {
         nitf_Error_init(error,

--- a/modules/c/nitf/source/ComplexityLevel.c
+++ b/modules/c/nitf/source/ComplexityLevel.c
@@ -109,7 +109,7 @@ NITFPRIV(NITF_CLEVEL) checkCCSExtent(nitf_Record* record,
 NITFPRIV(NITF_CLEVEL) checkFileSize(nitf_Record* record,
                                     nitf_Error* error)
 {
-    nitf_Int64 fl;
+    int64_t fl;
     if (!nitf_Field_get(record->header->NITF_FL, &fl, NITF_CONV_INT, 8, error))
         return NITF_CLEVEL_CHECK_FAILED;
 
@@ -244,7 +244,7 @@ NITFPRIV(NITF_CLEVEL) checkBlockSize(nitf_Record* record, nitf_Error* error)
 
 NITFPRIV(NITF_CLEVEL) checkNumImages(nitf_Record* record, nitf_Error* error)
 {
-    nitf_Uint32 numi = nitf_Record_getNumImages(record, error);
+    uint32_t numi = nitf_Record_getNumImages(record, error);
     return (numi > 20) ? NITF_CLEVEL_05 : NITF_CLEVEL_03;
 }
 
@@ -252,7 +252,7 @@ NITFPRIV(NITF_CLEVEL) checkNumDES(nitf_Record* record, nitf_Error* error)
 {
 
     int clevel = NITF_CLEVEL_03;
-    nitf_Uint32 numdes = nitf_Record_getNumDataExtensions(record, error);
+    uint32_t numdes = nitf_Record_getNumDataExtensions(record, error);
 
 
     if (numdes > 10)

--- a/modules/c/nitf/source/ComponentInfo.c
+++ b/modules/c/nitf/source/ComponentInfo.c
@@ -26,9 +26,9 @@
     if (OWNER->ID) nitf_Field_destruct(OWNER->ID);
 
 /*  Create the image info structure */
-NITFAPI(nitf_ComponentInfo *) nitf_ComponentInfo_construct(nitf_Uint32
+NITFAPI(nitf_ComponentInfo *) nitf_ComponentInfo_construct(uint32_t
         subheaderFieldWidth,
-        nitf_Uint32
+        uint32_t
         dataFieldWidth,
         nitf_Error *
         error)

--- a/modules/c/nitf/source/DESubheader.c
+++ b/modules/c/nitf/source/DESubheader.c
@@ -86,7 +86,7 @@ CATCH_ERROR:
 NITFAPI(nitf_DESubheader *)
 nitf_DESubheader_clone(nitf_DESubheader * source, nitf_Error * error)
 {
-    nitf_Uint32 subLen;
+    uint32_t subLen;
     nitf_DESubheader *subhdr = NULL;
     NITF_BOOL success;
     if (source)

--- a/modules/c/nitf/source/DefaultTRE.c
+++ b/modules/c/nitf/source/DefaultTRE.c
@@ -68,7 +68,7 @@ NITFPRIV(const char*) defaultGetID(nitf_TRE *tre)
 
 
 NITFPRIV(NITF_BOOL) defaultRead(nitf_IOInterface *io,
-                                nitf_Uint32 length,
+                                uint32_t length,
                                 nitf_TRE * tre,
                                 struct _nitf_Record* record,
                                 nitf_Error * error)

--- a/modules/c/nitf/source/DirectBlockSource.c
+++ b/modules/c/nitf/source/DirectBlockSource.c
@@ -35,7 +35,7 @@ typedef struct _DirectBlockSourceImpl
     /* Pointer to the next row function */
     NITF_DIRECT_BLOCK_SOURCE_NEXT_BLOCK nextBlock;
     nitf_ImageReader* imageReader;
-    nitf_Uint32 blockNumber;
+    uint32_t blockNumber;
     size_t numBlocks;
 }
 DirectBlockSourceImpl;
@@ -60,7 +60,7 @@ NITFPRIV(NITF_BOOL) DirectBlockSource_read(NITF_DATA * data, void *buf,
 {
     DirectBlockSourceImpl *directBlockSource = toDirectBlockSource(data, error);
     const void* block;
-    nitf_Uint64 blockSize;
+    uint64_t blockSize;
 
     if (!directBlockSource)
         return NITF_FAILURE;
@@ -131,7 +131,7 @@ NITFAPI(nitf_BandSource *) nitf_DirectBlockSource_construct(void * algorithm,
                                                             NITF_DIRECT_BLOCK_SOURCE_NEXT_BLOCK
                                                             nextBlock,
                                                             nitf_ImageReader* imageReader,
-                                                            nitf_Uint32 numBands,
+                                                            uint32_t numBands,
                                                             nitf_Error * error)
 {
     static nitf_IDataSource iDirectBlockSource =

--- a/modules/c/nitf/source/DownSampler.c
+++ b/modules/c/nitf/source/DownSampler.c
@@ -37,23 +37,23 @@ NITFAPI(void) nitf_DownSampler_destruct(nitf_DownSampler ** downsampler)
 NITFPRIV(NITF_BOOL) PixelSkip_apply(nitf_DownSampler * object,
                                     NITF_DATA ** inputWindows,
                                     NITF_DATA ** outputWindows,
-                                    nitf_Uint32 numBands,
-                                    nitf_Uint32 numWindowRows,
-                                    nitf_Uint32 numWindowCols,
-                                    nitf_Uint32 numInputCols,
-                                    nitf_Uint32 numCols,
-                                    nitf_Uint32 pixelType,
-                                    nitf_Uint32 pixelSize,
-                                    nitf_Uint32 rowsInLastWindow,
-                                    nitf_Uint32 colsInLastWindow,
+                                    uint32_t numBands,
+                                    uint32_t numWindowRows,
+                                    uint32_t numWindowCols,
+                                    uint32_t numInputCols,
+                                    uint32_t numCols,
+                                    uint32_t pixelType,
+                                    uint32_t pixelSize,
+                                    uint32_t rowsInLastWindow,
+                                    uint32_t colsInLastWindow,
                                     nitf_Error * error)
 {
-    nitf_Uint32 row;            /* Current row */
-    nitf_Uint32 column;         /* Current column */
-    nitf_Uint32 colInc;         /* Column increment */
-    nitf_Uint32 rowInc;         /* Pointer increment for end of row */
-    nitf_Uint32 outRowInc;      /* Output pointer increment for end of row */
-    nitf_Uint32 band;           /* Current band */
+    uint32_t row;            /* Current row */
+    uint32_t column;         /* Current column */
+    uint32_t colInc;         /* Column increment */
+    uint32_t rowInc;         /* Pointer increment for end of row */
+    uint32_t outRowInc;      /* Output pointer increment for end of row */
+    uint32_t band;           /* Current band */
 
     /*
      *  Note: The output buffer is at down-sampled resolution and the
@@ -72,13 +72,13 @@ NITFPRIV(NITF_BOOL) PixelSkip_apply(nitf_DownSampler * object,
     {
         case 1:
         {
-            nitf_Uint8 *inp;    /* Pointer into input */
-            nitf_Uint8 *outp;   /* Pointer into output */
+            uint8_t *inp;    /* Pointer into input */
+            uint8_t *outp;   /* Pointer into output */
 
             for (band = 0; band < numBands; band++)
             {
-                inp = (nitf_Uint8 *) inputWindows[band];
-                outp = (nitf_Uint8 *) outputWindows[band];
+                inp = (uint8_t *) inputWindows[band];
+                outp = (uint8_t *) outputWindows[band];
 
                 for (row = 0; row < numWindowRows; row++)
                 {
@@ -95,13 +95,13 @@ NITFPRIV(NITF_BOOL) PixelSkip_apply(nitf_DownSampler * object,
         break;
         case 2:
         {
-            nitf_Uint16 *inp;   /* Pointer into input */
-            nitf_Uint16 *outp;  /* Pointer into output */
+            uint16_t *inp;   /* Pointer into input */
+            uint16_t *outp;  /* Pointer into output */
 
             for (band = 0; band < numBands; band++)
             {
-                inp = (nitf_Uint16 *) inputWindows[band];
-                outp = (nitf_Uint16 *) outputWindows[band];
+                inp = (uint16_t *) inputWindows[band];
+                outp = (uint16_t *) outputWindows[band];
 
                 for (row = 0; row < numWindowRows; row++)
                 {
@@ -118,13 +118,13 @@ NITFPRIV(NITF_BOOL) PixelSkip_apply(nitf_DownSampler * object,
         break;
         case 4:
         {
-            nitf_Uint32 *inp;   /* Pointer into input */
-            nitf_Uint32 *outp;  /* Pointer into output */
+            uint32_t *inp;   /* Pointer into input */
+            uint32_t *outp;  /* Pointer into output */
 
             for (band = 0; band < numBands; band++)
             {
-                inp = (nitf_Uint32 *) inputWindows[band];
-                outp = (nitf_Uint32 *) outputWindows[band];
+                inp = (uint32_t *) inputWindows[band];
+                outp = (uint32_t *) outputWindows[band];
                 for (row = 0; row < numWindowRows; row++)
                 {
                     for (column = 0; column < numWindowCols; column++)
@@ -140,13 +140,13 @@ NITFPRIV(NITF_BOOL) PixelSkip_apply(nitf_DownSampler * object,
         break;
         case 8:
         {
-            nitf_Uint64 *inp;   /* Pointer into input */
-            nitf_Uint64 *outp;  /* Pointer into output */
+            uint64_t *inp;   /* Pointer into input */
+            uint64_t *outp;  /* Pointer into output */
 
             for (band = 0; band < numBands; band++)
             {
-                inp = (nitf_Uint64 *) inputWindows[band];
-                outp = (nitf_Uint64 *) outputWindows[band];
+                inp = (uint64_t *) inputWindows[band];
+                outp = (uint64_t *) outputWindows[band];
 
                 for (row = 0; row < numWindowRows; row++)
                 {
@@ -163,8 +163,8 @@ NITFPRIV(NITF_BOOL) PixelSkip_apply(nitf_DownSampler * object,
         break;
         case 16:                   /* It's not clear if this case is actually possible */
         {
-            nitf_Uint64 *inp;   /* Pointer into input */
-            nitf_Uint64 *outp;  /* Pointer into output */
+            uint64_t *inp;   /* Pointer into input */
+            uint64_t *outp;  /* Pointer into output */
 
             colInc *= 2;
             rowInc *= 2;
@@ -172,8 +172,8 @@ NITFPRIV(NITF_BOOL) PixelSkip_apply(nitf_DownSampler * object,
 
             for (band = 0; band < numBands; band++)
             {
-                inp = (nitf_Uint64 *) inputWindows[band];
-                outp = (nitf_Uint64 *) outputWindows[band];
+                inp = (uint64_t *) inputWindows[band];
+                outp = (uint64_t *) outputWindows[band];
 
                 for (row = 0; row < numWindowRows; row++)
                 {
@@ -202,8 +202,8 @@ NITFPRIV(void) PixelSkip_destruct(NITF_DATA * data)
     return;                     /* There is no implementation data */
 }
 
-NITFAPI(nitf_DownSampler *) nitf_PixelSkip_construct(nitf_Uint32 rowSkip,
-        nitf_Uint32 colSkip,
+NITFAPI(nitf_DownSampler *) nitf_PixelSkip_construct(uint32_t rowSkip,
+        uint32_t colSkip,
         nitf_Error * error)
 {
 
@@ -248,17 +248,17 @@ NITFAPI(nitf_DownSampler *) nitf_PixelSkip_construct(nitf_Uint32 rowSkip,
 
 #define MAX_DOWN_SAMPLE(type) \
     { \
-        nitf_Uint32 colSkip;     /* Column skip */ \
-        nitf_Uint32 rowSkip;     /* Row skip */ \
-        nitf_Uint32 colInc;      /* Column increment */ \
-        nitf_Uint32 rowInc;      /* Pointer increment for end of row */ \
-        nitf_Uint32 outRowInc;   /* Output pointer increment for end of row */ \
-        nitf_Uint32 winRowInc;   /* Row increment, current window */ \
-        nitf_Uint32 row;         /* Current row */ \
-        nitf_Uint32 column;      /* Current column */ \
-        nitf_Uint32 winRow;      /* Current row in current window */ \
-        nitf_Uint32 winCol;      /* Current column current window */ \
-        nitf_Uint32 rowWinLimit; /* Number of rows in current window */ \
+        uint32_t colSkip;     /* Column skip */ \
+        uint32_t rowSkip;     /* Row skip */ \
+        uint32_t colInc;      /* Column increment */ \
+        uint32_t rowInc;      /* Pointer increment for end of row */ \
+        uint32_t outRowInc;   /* Output pointer increment for end of row */ \
+        uint32_t winRowInc;   /* Row increment, current window */ \
+        uint32_t row;         /* Current row */ \
+        uint32_t column;      /* Current column */ \
+        uint32_t winRow;      /* Current row in current window */ \
+        uint32_t winCol;      /* Current column current window */ \
+        uint32_t rowWinLimit; /* Number of rows in current window */ \
         type *currentRowPtr;     /* Pointer to the current window row */ \
         type *currentPtr;        /* Pointer to the current window UL corner */ \
         type *pixel;             /* Pointer to the current pixel */ \
@@ -328,17 +328,17 @@ NITFAPI(nitf_DownSampler *) nitf_PixelSkip_construct(nitf_Uint32 rowSkip,
 
 #define MAX_DOWN_SAMPLE_CMPX(type) \
     { \
-        nitf_Uint32 colSkip;     /* Column skip */ \
-        nitf_Uint32 rowSkip;     /* Row skip */ \
-        nitf_Uint32 colInc;      /* Column increment */ \
-        nitf_Uint32 rowInc;      /* Pointer increment for end of row */ \
-        nitf_Uint32 outRowInc;   /* Output pointer increment for end of row */ \
-        nitf_Uint32 winRowInc;   /* Row increment, current window */ \
-        nitf_Uint32 row;         /* Current row */ \
-        nitf_Uint32 column;      /* Current column */ \
-        nitf_Uint32 winRow;      /* Current row in current window */ \
-        nitf_Uint32 winCol;      /* Current column current window */ \
-        nitf_Uint32 rowWinLimit; /* Number of rows in current window */ \
+        uint32_t colSkip;     /* Column skip */ \
+        uint32_t rowSkip;     /* Row skip */ \
+        uint32_t colInc;      /* Column increment */ \
+        uint32_t rowInc;      /* Pointer increment for end of row */ \
+        uint32_t outRowInc;   /* Output pointer increment for end of row */ \
+        uint32_t winRowInc;   /* Row increment, current window */ \
+        uint32_t row;         /* Current row */ \
+        uint32_t column;      /* Current column */ \
+        uint32_t winRow;      /* Current row in current window */ \
+        uint32_t winCol;      /* Current column current window */ \
+        uint32_t rowWinLimit; /* Number of rows in current window */ \
         type *currentRowPtr;     /* Pointer to the current window row */ \
         type *currentPtr;        /* Pointer to the current window UL corner */ \
         type *pixelReal;         /* Pointer to the current pixel */ \
@@ -430,31 +430,31 @@ NITFAPI(nitf_DownSampler *) nitf_PixelSkip_construct(nitf_Uint32 rowSkip,
 NITFPRIV(NITF_BOOL) MaxDownSample_apply(nitf_DownSampler * object,
                                         NITF_DATA ** inputWindows,
                                         NITF_DATA ** outputWindows,
-                                        nitf_Uint32 numBands,
-                                        nitf_Uint32 numWindowRows,
-                                        nitf_Uint32 numWindowCols,
-                                        nitf_Uint32 numInputCols,
-                                        nitf_Uint32 numCols,
-                                        nitf_Uint32 pixelType,
-                                        nitf_Uint32 pixelSize,
-                                        nitf_Uint32 rowsInLastWindow,
-                                        nitf_Uint32 colsInLastWindow,
+                                        uint32_t numBands,
+                                        uint32_t numWindowRows,
+                                        uint32_t numWindowCols,
+                                        uint32_t numInputCols,
+                                        uint32_t numCols,
+                                        uint32_t pixelType,
+                                        uint32_t pixelSize,
+                                        uint32_t rowsInLastWindow,
+                                        uint32_t colsInLastWindow,
                                         nitf_Error * error)
 {
-    nitf_Uint32 band;           /* Current band */
+    uint32_t band;           /* Current band */
 
     if (pixelType == NITF_PIXEL_TYPE_INT)
     {
         switch (pixelSize)
         {
             case 1:
-		MAX_DOWN_SAMPLE(nitf_Uint8)
+		MAX_DOWN_SAMPLE(uint8_t)
             case 2:
-                MAX_DOWN_SAMPLE(nitf_Uint16)
+                MAX_DOWN_SAMPLE(uint16_t)
             case 4:
-                MAX_DOWN_SAMPLE(nitf_Uint32)
+                MAX_DOWN_SAMPLE(uint32_t)
             case 8:
-                MAX_DOWN_SAMPLE(nitf_Uint64)
+                MAX_DOWN_SAMPLE(uint64_t)
             default:
                 nitf_Error_init(error, "Invalid pixel type",
                                 NITF_CTXT, NITF_ERR_INVALID_PARAMETER);
@@ -463,20 +463,20 @@ NITFPRIV(NITF_BOOL) MaxDownSample_apply(nitf_DownSampler * object,
     }
     else if (pixelType == NITF_PIXEL_TYPE_B)
     {
-        MAX_DOWN_SAMPLE(nitf_Uint8)
+        MAX_DOWN_SAMPLE(uint8_t)
     }
     else if (pixelType == NITF_PIXEL_TYPE_SI)
     {
         switch (pixelSize)
         {
             case 1:
-                MAX_DOWN_SAMPLE(nitf_Int8)
+                MAX_DOWN_SAMPLE(int8_t)
             case 2:
-                MAX_DOWN_SAMPLE(nitf_Int16)
+                MAX_DOWN_SAMPLE(int16_t)
             case 4:
-                MAX_DOWN_SAMPLE(nitf_Int32)
+                MAX_DOWN_SAMPLE(int32_t)
             case 8:
-                MAX_DOWN_SAMPLE(nitf_Int64)
+                MAX_DOWN_SAMPLE(int64_t)
 
             default:
                 nitf_Error_init(error, "Invalid pixel type",
@@ -525,9 +525,9 @@ NITFPRIV(void) MaxDownSample_destruct(NITF_DATA * data)
     return;                     /* There is no instance data */
 }
 
-NITFAPI(nitf_DownSampler *) nitf_MaxDownSample_construct(nitf_Uint32
+NITFAPI(nitf_DownSampler *) nitf_MaxDownSample_construct(uint32_t
         rowSkip,
-        nitf_Uint32
+        uint32_t
         colSkip,
         nitf_Error *
         error)
@@ -579,17 +579,17 @@ NITFAPI(nitf_DownSampler *) nitf_MaxDownSample_construct(nitf_Uint32
 
 #define SUM_SQ_2_DOWN_SAMPLE(type) \
     { \
-        nitf_Uint32 colSkip;     /* Column skip */ \
-        nitf_Uint32 rowSkip;     /* Row skip */ \
-        nitf_Uint32 colInc;      /* Column increment */ \
-        nitf_Uint32 rowInc;      /* Pointer increment for end of row */ \
-        nitf_Uint32 outRowInc;   /* Output pointer increment for end of row */ \
-        nitf_Uint32 winRowInc;   /* Row increment, current window */ \
-        nitf_Uint32 row;         /* Current row */ \
-        nitf_Uint32 column;      /* Current column */ \
-        nitf_Uint32 winRow;      /* Current row in current window */ \
-        nitf_Uint32 winCol;      /* Current column current window */ \
-        nitf_Uint32 rowWinLimit; /* Number of rows in current window */ \
+        uint32_t colSkip;     /* Column skip */ \
+        uint32_t rowSkip;     /* Row skip */ \
+        uint32_t colInc;      /* Column increment */ \
+        uint32_t rowInc;      /* Pointer increment for end of row */ \
+        uint32_t outRowInc;   /* Output pointer increment for end of row */ \
+        uint32_t winRowInc;   /* Row increment, current window */ \
+        uint32_t row;         /* Current row */ \
+        uint32_t column;      /* Current column */ \
+        uint32_t winRow;      /* Current row in current window */ \
+        uint32_t winCol;      /* Current column current window */ \
+        uint32_t rowWinLimit; /* Number of rows in current window */ \
         type *outp0;             /* Pointer into output, band 0 */ \
         type *outp1;             /* Pointer into output, band 0 */ \
         type *currentRowPtr0;    /* Pointer to the current window row, band 0 */ \
@@ -683,15 +683,15 @@ NITFAPI(nitf_DownSampler *) nitf_MaxDownSample_construct(nitf_Uint32
     NITFPRIV(NITF_BOOL) SumSq2DownSample_apply(nitf_DownSampler * object,
 NITF_DATA ** inputWindows,
 NITF_DATA ** outputWindows,
-nitf_Uint32 numBands,
-nitf_Uint32 numWindowRows,
-nitf_Uint32 numWindowCols,
-nitf_Uint32 numInputCols,
-nitf_Uint32 numCols,
-nitf_Uint32 pixelType,
-nitf_Uint32 pixelSize,
-nitf_Uint32 rowsInLastWindow,
-nitf_Uint32 colsInLastWindow,
+uint32_t numBands,
+uint32_t numWindowRows,
+uint32_t numWindowCols,
+uint32_t numInputCols,
+uint32_t numCols,
+uint32_t pixelType,
+uint32_t pixelSize,
+uint32_t rowsInLastWindow,
+uint32_t colsInLastWindow,
 nitf_Error * error)
 {
 
@@ -707,13 +707,13 @@ nitf_Error * error)
         switch (pixelSize)
         {
             case 1:
-                SUM_SQ_2_DOWN_SAMPLE(nitf_Uint8)
+                SUM_SQ_2_DOWN_SAMPLE(uint8_t)
             case 2:
-                SUM_SQ_2_DOWN_SAMPLE(nitf_Uint16)
+                SUM_SQ_2_DOWN_SAMPLE(uint16_t)
             case 4:
-                SUM_SQ_2_DOWN_SAMPLE(nitf_Uint32)
+                SUM_SQ_2_DOWN_SAMPLE(uint32_t)
             case 8:
-                SUM_SQ_2_DOWN_SAMPLE(nitf_Uint64)
+                SUM_SQ_2_DOWN_SAMPLE(uint64_t)
             default:
                 nitf_Error_init(error, "Invalid pixel type",
                                 NITF_CTXT, NITF_ERR_INVALID_PARAMETER);
@@ -722,20 +722,20 @@ nitf_Error * error)
     }
     else if (pixelType == NITF_PIXEL_TYPE_B)
     {
-        SUM_SQ_2_DOWN_SAMPLE(nitf_Uint8)
+        SUM_SQ_2_DOWN_SAMPLE(uint8_t)
     }
     else if (pixelType == NITF_PIXEL_TYPE_SI)
     {
         switch (pixelSize)
         {
             case 1:
-                SUM_SQ_2_DOWN_SAMPLE(nitf_Int8)
+                SUM_SQ_2_DOWN_SAMPLE(int8_t)
             case 2:
-                SUM_SQ_2_DOWN_SAMPLE(nitf_Int16)
+                SUM_SQ_2_DOWN_SAMPLE(int16_t)
             case 4:
-                SUM_SQ_2_DOWN_SAMPLE(nitf_Int32)
+                SUM_SQ_2_DOWN_SAMPLE(int32_t)
             case 8:
-                SUM_SQ_2_DOWN_SAMPLE(nitf_Int64)
+                SUM_SQ_2_DOWN_SAMPLE(int64_t)
             default:
                 nitf_Error_init(error, "Invalid pixel type",
                                 NITF_CTXT, NITF_ERR_INVALID_PARAMETER);
@@ -775,9 +775,9 @@ NITFPRIV(void) SumSq2DownSample_destruct(NITF_DATA * data)
     return;                     /* There is no instance data */
 }
 
-NITFAPI(nitf_DownSampler *) nitf_SumSq2DownSample_construct(nitf_Uint32
+NITFAPI(nitf_DownSampler *) nitf_SumSq2DownSample_construct(uint32_t
         rowSkip,
-        nitf_Uint32
+        uint32_t
         colSkip,
         nitf_Error *
         error)
@@ -830,17 +830,17 @@ NITFAPI(nitf_DownSampler *) nitf_SumSq2DownSample_construct(nitf_Uint32
 
 #define SELECT_2_DOWN_SAMPLE(type) \
     { \
-        nitf_Uint32 colSkip;     /* Column skip */ \
-        nitf_Uint32 rowSkip;     /* Row skip */ \
-        nitf_Uint32 colInc;      /* Column increment */ \
-        nitf_Uint32 rowInc;      /* Pointer increment for end of row */ \
-        nitf_Uint32 outRowInc;   /* Output pointer increment for end of row */ \
-        nitf_Uint32 winRowInc;   /* Row increment, current window */ \
-        nitf_Uint32 row;         /* Current row */ \
-        nitf_Uint32 column;      /* Current column */ \
-        nitf_Uint32 winRow;      /* Current row in current window */ \
-        nitf_Uint32 winCol;      /* Current column current window */ \
-        nitf_Uint32 rowWinLimit; /* Number of rows in current window */ \
+        uint32_t colSkip;     /* Column skip */ \
+        uint32_t rowSkip;     /* Row skip */ \
+        uint32_t colInc;      /* Column increment */ \
+        uint32_t rowInc;      /* Pointer increment for end of row */ \
+        uint32_t outRowInc;   /* Output pointer increment for end of row */ \
+        uint32_t winRowInc;   /* Row increment, current window */ \
+        uint32_t row;         /* Current row */ \
+        uint32_t column;      /* Current column */ \
+        uint32_t winRow;      /* Current row in current window */ \
+        uint32_t winCol;      /* Current column current window */ \
+        uint32_t rowWinLimit; /* Number of rows in current window */ \
         type *outp0;             /* Pointer into output, band 0 */ \
         type *outp1;             /* Pointer into output, band 0 */ \
         type *currentRowPtr0;    /* Pointer to the current window row, band 0 */ \
@@ -942,15 +942,15 @@ NITFAPI(nitf_DownSampler *) nitf_SumSq2DownSample_construct(nitf_Uint32
     NITFPRIV(NITF_BOOL) Select2DownSample_apply(nitf_DownSampler * object,
 NITF_DATA ** inputWindows,
 NITF_DATA ** outputWindows,
-nitf_Uint32 numBands,
-nitf_Uint32 numWindowRows,
-nitf_Uint32 numWindowCols,
-nitf_Uint32 numInputCols,
-nitf_Uint32 numCols,
-nitf_Uint32 pixelType,
-nitf_Uint32 pixelSize,
-nitf_Uint32 rowsInLastWindow,
-nitf_Uint32 colsInLastWindow,
+uint32_t numBands,
+uint32_t numWindowRows,
+uint32_t numWindowCols,
+uint32_t numInputCols,
+uint32_t numCols,
+uint32_t pixelType,
+uint32_t pixelSize,
+uint32_t rowsInLastWindow,
+uint32_t colsInLastWindow,
 nitf_Error * error)
 {
 
@@ -966,13 +966,13 @@ nitf_Error * error)
         switch (pixelSize)
         {
             case 1:
-                SELECT_2_DOWN_SAMPLE(nitf_Uint8)
+                SELECT_2_DOWN_SAMPLE(uint8_t)
             case 2:
-                SELECT_2_DOWN_SAMPLE(nitf_Uint16)
+                SELECT_2_DOWN_SAMPLE(uint16_t)
             case 4:
-                SELECT_2_DOWN_SAMPLE(nitf_Uint32)
+                SELECT_2_DOWN_SAMPLE(uint32_t)
             case 8:
-                SELECT_2_DOWN_SAMPLE(nitf_Uint64)
+                SELECT_2_DOWN_SAMPLE(uint64_t)
             default:
                 nitf_Error_init(error, "Invalid pixel type",
                                 NITF_CTXT, NITF_ERR_INVALID_PARAMETER);
@@ -981,20 +981,20 @@ nitf_Error * error)
     }
     else if (pixelType == NITF_PIXEL_TYPE_B)
     {
-        SELECT_2_DOWN_SAMPLE(nitf_Uint8)
+        SELECT_2_DOWN_SAMPLE(uint8_t)
     }
     else if (pixelType == NITF_PIXEL_TYPE_SI)
     {
         switch (pixelSize)
         {
             case 1:
-                SELECT_2_DOWN_SAMPLE(nitf_Int8)
+                SELECT_2_DOWN_SAMPLE(int8_t)
             case 2:
-                SELECT_2_DOWN_SAMPLE(nitf_Int16)
+                SELECT_2_DOWN_SAMPLE(int16_t)
             case 4:
-                SELECT_2_DOWN_SAMPLE(nitf_Int32)
+                SELECT_2_DOWN_SAMPLE(int32_t)
             case 8:
-                SELECT_2_DOWN_SAMPLE(nitf_Int64)
+                SELECT_2_DOWN_SAMPLE(int64_t)
             default:
                 nitf_Error_init(error, "Invalid pixel type",
                                 NITF_CTXT, NITF_ERR_INVALID_PARAMETER);
@@ -1034,9 +1034,9 @@ NITFPRIV(void) Select2DownSample_destruct(NITF_DATA * data)
     return;                     /* There is no instance data */
 }
 
-NITFAPI(nitf_DownSampler *) nitf_Select2DownSample_construct(nitf_Uint32
+NITFAPI(nitf_DownSampler *) nitf_Select2DownSample_construct(uint32_t
         rowSkip,
-        nitf_Uint32
+        uint32_t
         colSkip,
         nitf_Error *
         error)

--- a/modules/c/nitf/source/Extensions.c
+++ b/modules/c/nitf/source/Extensions.c
@@ -376,10 +376,10 @@ nitf_ExtensionsIterator_notEqualTo(nitf_ExtensionsIterator * it1,
 }
 
 
-NITFAPI(nitf_Uint32) nitf_Extensions_computeLength
+NITFAPI(uint32_t) nitf_Extensions_computeLength
 (nitf_Extensions * ext, nitf_Version fver, nitf_Error * error)
 {
-    nitf_Uint32 dataLength = 0;
+    uint32_t dataLength = 0;
     nitf_ExtensionsIterator iter, end;
     nitf_TRE *tre;
 
@@ -395,7 +395,7 @@ NITFAPI(nitf_Uint32) nitf_Extensions_computeLength
             tre = (nitf_TRE *) nitf_ExtensionsIterator_get(&iter);
 
             /* if unknown length, we need to compute it */
-            dataLength += (nitf_Uint32)tre->handler->getCurrentSize(tre, error);
+            dataLength += (uint32_t)tre->handler->getCurrentSize(tre, error);
             dataLength += NITF_ETAG_SZ + NITF_EL_SZ;
 
             /* increment */

--- a/modules/c/nitf/source/Field.c
+++ b/modules/c/nitf/source/Field.c
@@ -154,11 +154,11 @@ NITFAPI(void) nitf_Field_trimString(char *str)
 /*  Set a number field from a uint32 */
 
 NITFAPI(NITF_BOOL) nitf_Field_setUint32(nitf_Field * field,
-                                        nitf_Uint32 number,
+                                        uint32_t number,
                                         nitf_Error * error)
 {
     char numberBuffer[20];      /* Holds converted number */
-    nitf_Uint32 numberLen;      /* Length of converted number string */
+    uint32_t numberLen;      /* Length of converted number string */
 
     /*  Check the field type */
 
@@ -202,11 +202,11 @@ NITFAPI(NITF_BOOL) nitf_Field_setUint32(nitf_Field * field,
 /*  Set a number field from a uint64 */
 
 NITFAPI(NITF_BOOL) nitf_Field_setUint64(nitf_Field * field,
-                                        nitf_Uint64 number,
+                                        uint64_t number,
                                         nitf_Error * error)
 {
     char numberBuffer[20];      /* Holds converted number */
-    nitf_Uint32 numberLen;      /* Length of converted number string */
+    uint32_t numberLen;      /* Length of converted number string */
 
     /*  Check the field type */
 
@@ -249,11 +249,11 @@ NITFAPI(NITF_BOOL) nitf_Field_setUint64(nitf_Field * field,
 /*  Set a number field from a int32 */
 
 NITFAPI(NITF_BOOL) nitf_Field_setInt32(nitf_Field * field,
-                                       nitf_Int32 number,
+                                       int32_t number,
                                        nitf_Error * error)
 {
     char numberBuffer[20];      /* Holds converted number */
-    nitf_Uint32 numberLen;      /* Length of converted number string */
+    uint32_t numberLen;      /* Length of converted number string */
 
     /*  Check the field type */
 
@@ -296,11 +296,11 @@ NITFAPI(NITF_BOOL) nitf_Field_setInt32(nitf_Field * field,
 /*  Set a number field from a int64 */
 
 NITFAPI(NITF_BOOL) nitf_Field_setInt64(nitf_Field * field,
-                                       nitf_Int64 number,
+                                       int64_t number,
                                        nitf_Error * error)
 {
     char numberBuffer[20];      /* Holds converted number */
-    nitf_Uint32 numberLen;      /* Length of converted number string */
+    uint32_t numberLen;      /* Length of converted number string */
 
     /*  Check the field type */
 
@@ -348,7 +348,7 @@ NITFPRIV(NITF_BOOL) isBCSA(const char *str, size_t len, nitf_Error * error);
 NITFAPI(NITF_BOOL) nitf_Field_setString(nitf_Field * field,
                                         const char *str, nitf_Error * error)
 {
-    nitf_Uint32 strLen;         /* Length of input string */
+    uint32_t strLen;         /* Length of input string */
 
     /*  Check the field type */
 
@@ -438,8 +438,8 @@ NITFAPI(NITF_BOOL) nitf_Field_setReal(nitf_Field * field,
                                       const char *type, NITF_BOOL plus,
                                       double value, nitf_Error *error)
 {
-    nitf_Uint32 precision;     /* Format precision */
-    nitf_Uint32 bufferLen;     /* Length of buffer */
+    uint32_t precision;     /* Format precision */
+    uint32_t bufferLen;     /* Length of buffer */
     char *buffer;              /* Holds intermediate and final results */
     char fmt[64];              /* Format used */
 
@@ -589,17 +589,17 @@ NITFPRIV(NITF_BOOL) fromStringToString(nitf_Field * field, char *outValue,
 }
 
 
-NITFPRIV(NITF_BOOL) toInt16(nitf_Field * field, nitf_Int16 * int16,
+NITFPRIV(NITF_BOOL) toInt16(nitf_Field * field, int16_t * int16,
                             nitf_Error * error);
-NITFPRIV(NITF_BOOL) toInt32(nitf_Field * field, nitf_Int32 * int32,
+NITFPRIV(NITF_BOOL) toInt32(nitf_Field * field, int32_t * int32,
                             nitf_Error * error);
-NITFPRIV(NITF_BOOL) toInt64(nitf_Field * field, nitf_Int64 * int64,
+NITFPRIV(NITF_BOOL) toInt64(nitf_Field * field, int64_t * int64,
                             nitf_Error * error);
-NITFPRIV(NITF_BOOL) toUint16(nitf_Field * field, nitf_Uint16 * int16,
+NITFPRIV(NITF_BOOL) toUint16(nitf_Field * field, uint16_t * int16,
                              nitf_Error * error);
-NITFPRIV(NITF_BOOL) toUint32(nitf_Field * field, nitf_Uint32 * int32,
+NITFPRIV(NITF_BOOL) toUint32(nitf_Field * field, uint32_t * int32,
                              nitf_Error * error);
-NITFPRIV(NITF_BOOL) toUint64(nitf_Field * field, nitf_Uint64 * int64,
+NITFPRIV(NITF_BOOL) toUint64(nitf_Field * field, uint64_t * int64,
                              nitf_Error * error);
 
 /* We may want to rethink this function a bit.
@@ -618,7 +618,7 @@ NITFPRIV(NITF_BOOL) fromIntToString(nitf_Field * field, char *outValue,
     {
         case 2:
         {
-            nitf_Int16 int16;
+            int16_t int16;
             if (!toInt16(field, &int16, error))
                 goto CATCH_ERROR;
             actualLength = NITF_SNPRINTF(buffer, 256, "%d", int16);
@@ -626,7 +626,7 @@ NITFPRIV(NITF_BOOL) fromIntToString(nitf_Field * field, char *outValue,
         break;
         case 4:
         {
-            nitf_Int32 int32;
+            int32_t int32;
             if (!toInt32(field, &int32, error))
                 goto CATCH_ERROR;
             actualLength = NITF_SNPRINTF(buffer, 256, "%ld", (long) int32);
@@ -634,7 +634,7 @@ NITFPRIV(NITF_BOOL) fromIntToString(nitf_Field * field, char *outValue,
         break;
         case 8:
         {
-            nitf_Int64 int64;
+            int64_t int64;
             if (!toInt64(field, &int64, error))
                 goto CATCH_ERROR;
             actualLength = NITF_SNPRINTF(buffer, 256, "%lld", (long long)int64);
@@ -748,50 +748,50 @@ NITFPRIV(NITF_BOOL) toReal(nitf_Field * field, NITF_DATA * outData,
 }
 
 
-NITFPRIV(NITF_BOOL) toInt16(nitf_Field * field, nitf_Int16 * int16,
+NITFPRIV(NITF_BOOL) toInt16(nitf_Field * field, int16_t * int16,
                             nitf_Error * error)
 {
-    *int16 = *((nitf_Int16 *) field->raw);
+    *int16 = *((int16_t *) field->raw);
     return NITF_SUCCESS;
 }
 
 
-NITFPRIV(NITF_BOOL) toInt32(nitf_Field * field, nitf_Int32 * int32,
+NITFPRIV(NITF_BOOL) toInt32(nitf_Field * field, int32_t * int32,
                             nitf_Error * error)
 {
-    *int32 = *((nitf_Int32 *) field->raw);
+    *int32 = *((int32_t *) field->raw);
     return NITF_SUCCESS;
 }
 
 
-NITFPRIV(NITF_BOOL) toInt64(nitf_Field * field, nitf_Int64 * int64,
+NITFPRIV(NITF_BOOL) toInt64(nitf_Field * field, int64_t * int64,
                             nitf_Error * error)
 {
-    *int64 = *((nitf_Int64 *) field->raw);
+    *int64 = *((int64_t *) field->raw);
     return NITF_SUCCESS;
 }
 
 
-NITFPRIV(NITF_BOOL) toUint16(nitf_Field * field, nitf_Uint16 * int16,
+NITFPRIV(NITF_BOOL) toUint16(nitf_Field * field, uint16_t * int16,
                              nitf_Error * error)
 {
-    *int16 = *((nitf_Uint16 *) field->raw);
+    *int16 = *((uint16_t *) field->raw);
     return NITF_SUCCESS;
 }
 
 
-NITFPRIV(NITF_BOOL) toUint32(nitf_Field * field, nitf_Uint32 * int32,
+NITFPRIV(NITF_BOOL) toUint32(nitf_Field * field, uint32_t * int32,
                              nitf_Error * error)
 {
-    *int32 = *((nitf_Uint32 *) field->raw);
+    *int32 = *((uint32_t *) field->raw);
     return NITF_SUCCESS;
 }
 
 
-NITFPRIV(NITF_BOOL) toUint64(nitf_Field * field, nitf_Uint64 * int64,
+NITFPRIV(NITF_BOOL) toUint64(nitf_Field * field, uint64_t * int64,
                              nitf_Error * error)
 {
-    *int64 = *((nitf_Uint64 *) field->raw);
+    *int64 = *((uint64_t *) field->raw);
     return NITF_SUCCESS;
 }
 
@@ -814,25 +814,25 @@ NITFPRIV(NITF_BOOL) fromStringToInt(nitf_Field * field,
     {
         case 1:
         {
-            nitf_Int8 *int8 = (nitf_Int8 *) outData;
-            *int8 = (nitf_Int8) NITF_ATO32(buffer);
+            int8_t *int8 = (int8_t *) outData;
+            *int8 = (int8_t) NITF_ATO32(buffer);
         }
         break;
         case 2:
         {
-            nitf_Int16 *int16 = (nitf_Int16 *) outData;
-            *int16 = (nitf_Int16) NITF_ATO32(buffer);
+            int16_t *int16 = (int16_t *) outData;
+            *int16 = (int16_t) NITF_ATO32(buffer);
         }
         break;
         case 4:
         {
-            nitf_Int32 *int32 = (nitf_Int32 *) outData;
+            int32_t *int32 = (int32_t *) outData;
             *int32 = NITF_ATO32(buffer);
         }
         break;
         case 8:
         {
-            nitf_Int64 *int64 = (nitf_Int64 *) outData;
+            int64_t *int64 = (int64_t *) outData;
 #if defined(__aix__)
             sscanf(buffer, "%lld", int64);
 #else
@@ -867,29 +867,29 @@ NITFPRIV(NITF_BOOL) fromStringToUint(nitf_Field * field,
     {
         case 1:
         {
-            nitf_Uint8 *int8 = (nitf_Uint8 *) outData;
-            *int8 = (nitf_Uint8) NITF_ATO32(buffer);
+            uint8_t *int8 = (uint8_t *) outData;
+            *int8 = (uint8_t) NITF_ATO32(buffer);
         }
         break;
         case 2:
         {
-            nitf_Uint16 *int16 = (nitf_Uint16 *) outData;
-            *int16 = (nitf_Uint16) NITF_ATO32(buffer);
+            uint16_t *int16 = (uint16_t *) outData;
+            *int16 = (uint16_t) NITF_ATO32(buffer);
         }
         break;
         case 4:
         {
-            nitf_Uint32 *int32 = (nitf_Uint32 *) outData;
-            *int32 = (nitf_Uint32) NITF_ATOU32(buffer);
+            uint32_t *int32 = (uint32_t *) outData;
+            *int32 = (uint32_t) NITF_ATOU32(buffer);
         }
         break;
         case 8:
         {
-            nitf_Uint64 *int64 = (nitf_Uint64 *) outData;
+            uint64_t *int64 = (uint64_t *) outData;
 #if defined(__aix__)
             sscanf(buffer, "%lld", int64);
 #else
-            *int64 = (nitf_Uint64) NITF_ATO64(buffer);
+            *int64 = (uint64_t) NITF_ATO64(buffer);
 #endif
         }
         break;
@@ -915,13 +915,13 @@ NITFPRIV(NITF_BOOL) toInt(nitf_Field * field,
         switch (field->length)
         {
             case 2:
-                status = toInt16(field, (nitf_Int16 *) outData, error);
+                status = toInt16(field, (int16_t *) outData, error);
                 break;
             case 4:
-                status = toInt32(field, (nitf_Int32 *) outData, error);
+                status = toInt32(field, (int32_t *) outData, error);
                 break;
             case 8:
-                status = toInt64(field, (nitf_Int64 *) outData, error);
+                status = toInt64(field, (int64_t *) outData, error);
                 break;
             default:
                 nitf_Error_initf(error, NITF_CTXT,
@@ -951,13 +951,13 @@ NITFPRIV(NITF_BOOL) toUint(nitf_Field * field,
         switch (field->length)
         {
             case 2:
-                status = toUint16(field, (nitf_Uint16 *) outData, error);
+                status = toUint16(field, (uint16_t *) outData, error);
                 break;
             case 4:
-                status = toUint32(field, (nitf_Uint32 *) outData, error);
+                status = toUint32(field, (uint32_t *) outData, error);
                 break;
             case 8:
-                status = toUint64(field, (nitf_Uint64 *) outData, error);
+                status = toUint64(field, (uint64_t *) outData, error);
                 break;
             default:
                 nitf_Error_initf(error, NITF_CTXT,
@@ -1221,7 +1221,7 @@ NITFPRIV(NITF_BOOL) isBCSA(const char *str, size_t len, nitf_Error * error)
 
     for (ii = 0; ii < len; ++ii)
     {
-        const nitf_Uint8 ch = (nitf_Uint8)str[ii];
+        const uint8_t ch = (uint8_t)str[ii];
 
         if (ch < 0x20 || ch > 0x7e)
         {

--- a/modules/c/nitf/source/FileHeader.c
+++ b/modules/c/nitf/source/FileHeader.c
@@ -116,9 +116,9 @@ CATCH_ERROR:
 NITFAPI(nitf_FileHeader *) nitf_FileHeader_clone(nitf_FileHeader * source,
         nitf_Error * error)
 {
-    nitf_Uint32 numImages, numGraphics, numLabels;
-    nitf_Uint32 numTexts, numDES, numRES;
-    nitf_Uint32 i;
+    uint32_t numImages, numGraphics, numLabels;
+    uint32_t numTexts, numDES, numRES;
+    uint32_t i;
 
     /*  Start with a NULL pointer  */
     nitf_FileHeader *header = NULL;
@@ -362,9 +362,9 @@ CATCH_ERROR:
  */
 NITFAPI(void) nitf_FileHeader_destruct(nitf_FileHeader ** fh)
 {
-    nitf_Uint32 numImages, numGraphics=0, numLabels=0;
-    nitf_Uint32 numTexts=0, numDES=0, numRES=0;
-    nitf_Uint32 i;
+    uint32_t numImages, numGraphics=0, numLabels=0;
+    uint32_t numTexts=0, numDES=0, numRES=0;
+    uint32_t i;
 
     nitf_Error error;
 

--- a/modules/c/nitf/source/ImageIO.c
+++ b/modules/c/nitf/source/ImageIO.c
@@ -54,70 +54,70 @@ compression of a one byte unsigned image.\n
                         NITF_INT64_SZ, error)) goto CATCH_ERROR
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_NC - No compression, no blocking */
-#define NITF_IMAGE_IO_COMPRESSION_NC            ((nitf_Uint32) 0x00000001)
+#define NITF_IMAGE_IO_COMPRESSION_NC            ((uint32_t) 0x00000001)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_NM - No compression, blocking */
-#define NITF_IMAGE_IO_COMPRESSION_NM            ((nitf_Uint32) 0x00000002)
+#define NITF_IMAGE_IO_COMPRESSION_NM            ((uint32_t) 0x00000002)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_C1 - Bi-level compression, no blocking */
-#define NITF_IMAGE_IO_COMPRESSION_C1            ((nitf_Uint32) 0x00000004)
+#define NITF_IMAGE_IO_COMPRESSION_C1            ((uint32_t) 0x00000004)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_C3 - JPEG compression, no blocking */
-#define NITF_IMAGE_IO_COMPRESSION_C3            ((nitf_Uint32) 0x00000008)
+#define NITF_IMAGE_IO_COMPRESSION_C3            ((uint32_t) 0x00000008)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_C4- Vector quantization  compression,
    no blocking */
-#define NITF_IMAGE_IO_COMPRESSION_C4            ((nitf_Uint32) 0x00000010)
+#define NITF_IMAGE_IO_COMPRESSION_C4            ((uint32_t) 0x00000010)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_C5 - Lossless JPEG compression,
    no blocking */
-#define NITF_IMAGE_IO_COMPRESSION_C5            ((nitf_Uint32) 0x00000020)
+#define NITF_IMAGE_IO_COMPRESSION_C5            ((uint32_t) 0x00000020)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_C6 - Reserved, no blocking */
-#define NITF_IMAGE_IO_COMPRESSION_C6            ((nitf_Uint32) 0x00000040)
+#define NITF_IMAGE_IO_COMPRESSION_C6            ((uint32_t) 0x00000040)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_C7 - Reserved, Complex SAR compression */
-#define NITF_IMAGE_IO_COMPRESSION_C7            ((nitf_Uint32) 0x00000060)
+#define NITF_IMAGE_IO_COMPRESSION_C7            ((uint32_t) 0x00000060)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_C8 - JPEG 2000 */
-#define NITF_IMAGE_IO_COMPRESSION_C8            ((nitf_Uint32) 0x00000080)
+#define NITF_IMAGE_IO_COMPRESSION_C8            ((uint32_t) 0x00000080)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_I1 - Downsampled JPEG, no blocking */
-#define NITF_IMAGE_IO_COMPRESSION_I1            ((nitf_Uint32) 0x00000100)
+#define NITF_IMAGE_IO_COMPRESSION_I1            ((uint32_t) 0x00000100)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_M1 - Bi-level compression, blocking */
-#define NITF_IMAGE_IO_COMPRESSION_M1            ((nitf_Uint32) 0x00000200)
+#define NITF_IMAGE_IO_COMPRESSION_M1            ((uint32_t) 0x00000200)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_M3 - JPEG compression, blocking */
-#define NITF_IMAGE_IO_COMPRESSION_M3 ((nitf_Uint32) 0x00000400)
+#define NITF_IMAGE_IO_COMPRESSION_M3 ((uint32_t) 0x00000400)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_M4 - Vector quantization  compression,
    blocking */
-#define NITF_IMAGE_IO_COMPRESSION_M4 ((nitf_Uint32) 0x00000800)
+#define NITF_IMAGE_IO_COMPRESSION_M4 ((uint32_t) 0x00000800)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_M5 - Lossless JPEG compression, blocking */
-#define NITF_IMAGE_IO_COMPRESSION_M5 ((nitf_Uint32) 0x00001000)
+#define NITF_IMAGE_IO_COMPRESSION_M5 ((uint32_t) 0x00001000)
 
 /*! \def NITF_IMAGE_IO_COMPRESSION_M8 - JPEG 2000 */
-#define NITF_IMAGE_IO_COMPRESSION_M8 ((nitf_Uint32) 0x00004000)
+#define NITF_IMAGE_IO_COMPRESSION_M8 ((uint32_t) 0x00004000)
 
 /*! \def NITF_IMAGE_IO_BLOCKING_MODE_B - Band interleaved by block */
-#define NITF_IMAGE_IO_BLOCKING_MODE_B ((nitf_Uint32) 0x00008000)
+#define NITF_IMAGE_IO_BLOCKING_MODE_B ((uint32_t) 0x00008000)
 
 /*! \def NITF_IMAGE_IO_BLOCKING_MODE_P - Band interleaved by pixel */
-#define NITF_IMAGE_IO_BLOCKING_MODE_P ((nitf_Uint32) 0x00010000)
+#define NITF_IMAGE_IO_BLOCKING_MODE_P ((uint32_t) 0x00010000)
 
 /*! \def NITF_IMAGE_IO_BLOCKING_MODE_R - Band interleaved by row */
-#define NITF_IMAGE_IO_BLOCKING_MODE_R ((nitf_Uint32) 0x00020000)
+#define NITF_IMAGE_IO_BLOCKING_MODE_R ((uint32_t) 0x00020000)
 
 /*! \def NITF_IMAGE_IO_BLOCKING_MODE_S - Band sequential */
-#define NITF_IMAGE_IO_BLOCKING_MODE_S ((nitf_Uint32) 0x00040000)
+#define NITF_IMAGE_IO_BLOCKING_MODE_S ((uint32_t) 0x00040000)
 
 /*! \def NITF_IMAGE_IO_BLOCKING_MODE_RGB24 - Special case RGB 24-bit BIP */
-#define NITF_IMAGE_IO_BLOCKING_MODE_RGB24 ((nitf_Uint32) 0x00050000)
+#define NITF_IMAGE_IO_BLOCKING_MODE_RGB24 ((uint32_t) 0x00050000)
 
 /*! \def NITF_IMAGE_IO_BLOCKING_MODE_IQ - Special case IQ 2-band BIP */
-#define NITF_IMAGE_IO_BLOCKING_MODE_IQ ((nitf_Uint32) 0x00060000)
+#define NITF_IMAGE_IO_BLOCKING_MODE_IQ ((uint32_t) 0x00060000)
 
 /*! \def NITF_IMAGE_IO_NO_COMPRESSION - No compression combined mask */
 #define NITF_IMAGE_IO_NO_COMPRESSION \
@@ -129,7 +129,7 @@ compression of a one byte unsigned image.\n
 
 /*! \def NITF_IMAGE_IO_NO_BLOCK - Code used for block number when there is
    no block in the corresponding block cache buffer */
-#define NITF_IMAGE_IO_NO_BLOCK             ((nitf_Uint32) 0xffffffff)
+#define NITF_IMAGE_IO_NO_BLOCK             ((uint32_t) 0xffffffff)
 
 /*! \def NITF_IMAGE_IO_PAD_MAX_LENGTH - Maximum lenght of a pad pixel
    in bytes */
@@ -158,11 +158,11 @@ compression of a one byte unsigned image.\n
     { \
         type *pixels = (type *) (blockIO->blockControl.block); \
         type padValue = *((type *) (blockIO->cntl->nitf->pixel.pad)); \
-        nitf_Uint32 row; \
-        nitf_Uint32 col; \
-        nitf_Uint32 rowEndIncr; \
-        nitf_Uint32 colLimit; \
-        nitf_Uint32 rowLimit; \
+        uint32_t row; \
+        uint32_t col; \
+        uint32_t rowEndIncr; \
+        uint32_t colLimit; \
+        uint32_t rowLimit; \
         _nitf_ImageIO *nitf = blockIO->cntl->nitf; \
         NITF_BOOL pFound = 0; \
         NITF_BOOL dFound = 0; \
@@ -241,7 +241,7 @@ typedef void (*_NITF_IMAGE_IO_PACK_FUNC)
 */
 
 typedef void (*_NITF_IMAGE_IO_UNFORMAT_FUNC)
-(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount);
+(uint8_t * buffer, size_t count, uint32_t shiftCount);
 
 /*!
   \brief _NITF_IMAGE_IO_FORMAT_FUNC - Pixel format function pointer
@@ -254,7 +254,7 @@ typedef void (*_NITF_IMAGE_IO_UNFORMAT_FUNC)
 */
 
 typedef void (*_NITF_IMAGE_IO_FORMAT_FUNC)
-(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount);
+(uint8_t * buffer, size_t count, uint32_t shiftCount);
 
 /*!
   \brief Pad pixel scan function pointer
@@ -349,11 +349,11 @@ which can be written to assume that the masks are always present.
 typedef struct
 {
     int ready;                  /*!< Structure is setup if TRUE */
-    nitf_Uint32 imageDataOffset;        /*!< Offset to actual image data past masks */
-    nitf_Uint16 blockRecordLength;      /*!< Block mask record length */
-    nitf_Uint16 padRecordLength;        /*!< Pad pixel mask record length */
+    uint32_t imageDataOffset;        /*!< Offset to actual image data past masks */
+    uint16_t blockRecordLength;      /*!< Block mask record length */
+    uint16_t padRecordLength;        /*!< Pad pixel mask record length */
     /*!< Pad pixel value length in bytes */
-    nitf_Uint16 padPixelValueLength;
+    uint16_t padPixelValueLength;
 }
 _nitf_ImageIO_MaskHeader;
 
@@ -370,12 +370,12 @@ _nitf_ImageIO_MaskHeader;
 
 typedef struct
 {
-    nitf_Uint32 type;           /*!< Pixel type code */
-    nitf_Uint32 bytes;          /*!< Pixel (unpacked) size in bytes */
+    uint32_t type;           /*!< Pixel type code */
+    uint32_t bytes;          /*!< Pixel (unpacked) size in bytes */
     /*!< Pad value */
-    nitf_Uint8 pad[NITF_IMAGE_IO_PAD_MAX_LENGTH];
+    uint8_t pad[NITF_IMAGE_IO_PAD_MAX_LENGTH];
     int swap;                   /*!< Byte swap if TRUE */
-    nitf_Uint32 shift;          /*!< Shift count (in bits) for left justified pixels */
+    uint32_t shift;          /*!< Shift count (in bits) for left justified pixels */
 }
 _nitf_ImageIOPixelDef;
 
@@ -389,8 +389,8 @@ _nitf_ImageIOPixelDef;
 
 typedef struct
 {
-    nitf_Uint64 mark;  /*!< The current offset */
-    nitf_Uint64 orig;  /*!< The original (base) offset */
+    uint64_t mark;  /*!< The current offset */
+    uint64_t orig;  /*!< The original (base) offset */
 } _nitf_Offsets64;
 
 /*!
@@ -404,7 +404,7 @@ typedef struct
 
 typedef struct
 {
-    nitf_Uint8* buffer;
+    uint8_t* buffer;
     _nitf_Offsets64 offset;
 } _nitf_DataBuffer64;
 
@@ -419,7 +419,7 @@ typedef struct
 typedef struct
 {
     double noCacheThreshold;/*!< Request/Block size threshold for no caching */
-    nitf_Uint32 clearCache; /*!< Clear cache after I/O operation */
+    uint32_t clearCache; /*!< Clear cache after I/O operation */
 }
 _nitf_ImageIOParameters;
 
@@ -443,9 +443,9 @@ The current implementation supports a cache of one block
 
 typedef struct
 {
-    nitf_Uint32 number;         /*!< Current block number */
+    uint32_t number;         /*!< Current block number */
     NITF_BOOL freeFlag;         /*!< Free buffer if TRUE */
-    nitf_Uint8 *block;          /*!< Current block buffer */
+    uint8_t *block;          /*!< Current block buffer */
 }
 _nitf_ImageIOBlockCacheControl;
 
@@ -477,26 +477,26 @@ calculation is used to read compressed blocks.
 
 typedef struct
 {
-    nitf_Uint32 numRows;          /*!< Number of rows */
-    nitf_Uint32 numColumns;       /*!< Number of columns */
-    nitf_Uint32 numBands;         /*!< Number of bands */
+    uint32_t numRows;          /*!< Number of rows */
+    uint32_t numColumns;       /*!< Number of columns */
+    uint32_t numBands;         /*!< Number of bands */
     _nitf_ImageIOPixelDef pixel;        /*!< Pixel definition */
-    nitf_Uint32 nBlocksPerRow;  /*!< Number of blocks per row */
-    nitf_Uint32 nBlocksPerColumn; /*!< Number of blocks per column */
-    nitf_Uint32 numRowsPerBlock;    /*!< Number of rows per block */
-    nitf_Uint32 numColumnsPerBlock; /*!< Number of columns per block */
+    uint32_t nBlocksPerRow;  /*!< Number of blocks per row */
+    uint32_t nBlocksPerColumn; /*!< Number of blocks per column */
+    uint32_t numRowsPerBlock;    /*!< Number of rows per block */
+    uint32_t numColumnsPerBlock; /*!< Number of columns per block */
     size_t blockSize;               /*!< Block size in bytes */
-    nitf_Uint32 nBlocksTotal;     /*!< Total number of blocks */
-    nitf_Uint32 numRowsActual;    /*!< Actual number of rows */
-    nitf_Uint32 numColumnsActual; /*!< Actual number of columns */
-    nitf_Uint32 compression;    /*!< Compression type code */
+    uint32_t nBlocksTotal;     /*!< Total number of blocks */
+    uint32_t numRowsActual;    /*!< Actual number of rows */
+    uint32_t numColumnsActual; /*!< Actual number of columns */
+    uint32_t compression;    /*!< Compression type code */
     double compressionRate;     /*!< Compression type code */
-    nitf_Uint32 blockingMode;   /*!< Blocking mode code */
+    uint32_t blockingMode;   /*!< Blocking mode code */
     int blockInfoFlag;          /*!< Blocking information set if TRUE */
     nitf_BlockingInfo blockInfo;/*!< "Official" blocking information */
-    nitf_Uint64 imageBase;      /*!< File offset to image data section */
-    nitf_Uint64 pixelBase;      /*!< File offset to actual pixel data */
-    nitf_Uint64 dataLength;     /*!< Length of the data including masks */
+    uint64_t imageBase;      /*!< File offset to image data section */
+    uint64_t pixelBase;      /*!< File offset to actual pixel data */
+    uint64_t dataLength;     /*!< Length of the data including masks */
     /*!< Configuration parameters */
     _nitf_ImageIOParameters parameters;
     /*!< Block control */
@@ -512,8 +512,8 @@ typedef struct
     int cachedWriteFlag;        /*!< Using caching writes if TRUE */
     /*!< Block and pad mask header */
     _nitf_ImageIO_MaskHeader maskHeader;
-    nitf_Uint64 *blockMask;     /*!< Block mask */
-    nitf_Uint64 *padMask;       /*!< Pad pixel mask */
+    uint64_t *blockMask;     /*!< Block mask */
+    uint64_t *padMask;       /*!< Pad pixel mask */
     _nitf_ImageIOVtbl vtbl;     /*!< Function vector table */
     int oneBand;                /*!< Read/write one band at a time if TRUE */
     /*!< Control structure for current write */
@@ -522,7 +522,7 @@ typedef struct
     struct _nitf_ImageIOReadControl_s *readControl;
     _NITF_IMAGE_IO_PAD_SCAN_FUNC padScanner; /*! Scans for pad pixels in write */
     /*! Total blocks written to disk */
-    nitf_Int64 totalBlocksWritten;
+    int64_t totalBlocksWritten;
 } _nitf_ImageIO;
 
 /*!
@@ -565,31 +565,31 @@ typedef struct _nitf_ImageIOControl_s
     _nitf_ImageIO *nitf;
 
     /*! Number of row in the sub-window */
-    nitf_Uint32 numRows;
+    uint32_t numRows;
 
     /*! Start row in the main image */
-    nitf_Uint32 row;
+    uint32_t row;
 
     /*! Row skip factor */
-    nitf_Uint32 rowSkip;
+    uint32_t rowSkip;
 
     /*! Number of columns in the sub-window */
-    nitf_Uint32 numColumns;
+    uint32_t numColumns;
 
     /*! Start column in the main image */
-    nitf_Uint32 column;
+    uint32_t column;
 
     /*! Column skip factor */
-    nitf_Uint32 columnSkip;
+    uint32_t columnSkip;
 
     /*! Array of bands to read/write */
-    nitf_Uint32 *bandSubset;
+    uint32_t *bandSubset;
 
     /*! Number of bands to read/write */
-    nitf_Uint32 numBandSubset;
+    uint32_t numBandSubset;
 
     /*! Base user buffer, one pointer per band */
-    nitf_Uint8 **userBase;
+    uint8_t **userBase;
 
     /*! Operation is read if TRUE */
     int reading;
@@ -604,31 +604,31 @@ typedef struct _nitf_ImageIOControl_s
     NITF_DATA **downSampleOut;
 
     /*! Number of _nitf_ImageIOBlock structures */
-    nitf_Uint32 nBlockIO;
+    uint32_t nBlockIO;
 
     /*! Array of _nitf_ImageIOBlock structures */
     struct _nitf_ImageIOBlock_s **blockIO;
 
     /*! Block number next row increment  */
-    nitf_Uint32 numberInc;
+    uint32_t numberInc;
 
     /*! Data's offset in block next row byte increment */
-    nitf_Uint64 blockOffsetInc;
+    uint64_t blockOffsetInc;
 
     /*! Read/write buffer next row byte increment */
-    nitf_Uint32 bufferInc;
+    uint32_t bufferInc;
 
     /*! Unpacked data buffer next row byte increment */
-    nitf_Uint32 unpackedInc;
+    uint32_t unpackedInc;
 
     /*! User data buffer next row byte increment */
-    nitf_Uint32 userInc;
+    uint32_t userInc;
 
     /*! Pad pixel buffer */
-    nitf_Uint8 *padBuffer;
+    uint8_t *padBuffer;
 
     /*! Pad pixel buffer size in bytes */
-    nitf_Uint32 padBufferSize;
+    uint32_t padBufferSize;
 
     /*! Operation involved pad pixels */
     int padded;
@@ -640,7 +640,7 @@ typedef struct _nitf_ImageIOControl_s
     size_t ioCountDown;
 
     /*! Save buffer for partial down-sample windows */
-    nitf_Uint8 *columnSave;
+    uint8_t *columnSave;
 }
 _nitf_ImageIOControl;
 
@@ -768,25 +768,25 @@ typedef struct _nitf_ImageIOBlock_s
     _nitf_ImageIOControl *cntl;
 
     /*! Band associated with this I/O */
-    nitf_Uint32 band;
+    uint32_t band;
 
     /*! Do the read/write if TRUE */
     int doIO;
 
     /*! Block number */
-    nitf_Uint32 number;
+    uint32_t number;
 
     /*! Rows until next block */
-    nitf_Uint32 rowsUntil;
+    uint32_t rowsUntil;
 
     /*! Block mask to use */
-    nitf_Uint64 *blockMask;
+    uint64_t *blockMask;
 
     /*! Pad pixel mask to use */
-    nitf_Uint64 *padMask;
+    uint64_t *padMask;
 
     /*! Block's offset from image base */
-    nitf_Uint64 imageDataOffset;
+    uint64_t imageDataOffset;
 
     /*! Current and base offset into the block */
     _nitf_Offsets64 blockOffset;
@@ -798,13 +798,13 @@ typedef struct _nitf_ImageIOBlock_s
     _nitf_DataBuffer64 unpacked;
 
     /*! Free unpacked data buffer if TRUE */
-    nitf_Uint32 unpackedNoFree;
+    uint32_t unpackedNoFree;
 
     /*! User buffer plus offsets */
     _nitf_DataBuffer64 user;
 
     /*! Read/write buffer is user buffer if TRUE */
-    nitf_Uint32 userEqBuffer;
+    uint32_t userEqBuffer;
 
     /*! Read count in bytes */
     size_t readCount;
@@ -819,22 +819,22 @@ typedef struct _nitf_ImageIOBlock_s
     size_t formatCount;
 
     /*! Byte count of pad pixel columns to write */
-    nitf_Uint32 padColumnCount;
+    uint32_t padColumnCount;
 
     /*! Row count of pad pixel rows to write */
-    nitf_Uint32 padRowCount;
+    uint32_t padRowCount;
 
     /*! Start column of the first sample window */
-    nitf_Uint32 sampleStartColumn;
+    uint32_t sampleStartColumn;
 
     /*! Partial sample columns previous block */
-    nitf_Uint32 residual;
+    uint32_t residual;
 
     /*! Partial sample columns current block */
-    nitf_Uint32 myResidual;
+    uint32_t myResidual;
 
     /*! Current row in the image */
-    nitf_Uint32 currentRow;
+    uint32_t currentRow;
 
     /*! Block control for cached write */
     _nitf_ImageIOBlockCacheControl blockControl;
@@ -862,7 +862,7 @@ typedef struct _nitf_ImageIOWriteControl_s
     /*!< Writing method code */
     _nitf_ImageIO_writeMethod method;
     _nitf_ImageIOControl *cntl; /*!< Associated control structure */
-    nitf_Uint32 nextRow;        /*!< Next row to write (sequential) */
+    uint32_t nextRow;        /*!< Next row to write (sequential) */
 }
 _nitf_ImageIOWriteControl;
 
@@ -901,19 +901,19 @@ typedef struct _nitf_ImageIO_BPixelControl
     nitf_IOInterface* io;
 
     /*! Saved open argument */
-    nitf_Uint64 offset;
+    uint64_t offset;
 
     /*! Saved open argument */
     nitf_BlockingInfo *blockInfo;
 
     /*! Saved open argument */
-    nitf_Uint64 *blockMask;
+    uint64_t *blockMask;
 
     /*! Size of compressed block in bytes */
     size_t blockSizeCompressed;
 
     /*! Buffer for compressed block */
-    nitf_Uint8 *buffer;
+    uint8_t *buffer;
 }
 nitf_ImageIO_BPixelControl;
 
@@ -929,16 +929,16 @@ typedef struct _nitf_ImageIO_12PixelControl
     nitf_IOInterface* io;
 
     /*! Saved open argument */
-    nitf_Uint64 offset;
+    uint64_t offset;
 
     /*! Saved open argument */
     nitf_BlockingInfo *blockInfo;
 
     /*! Saved open argument */
-    nitf_Uint64 *blockMask;
+    uint64_t *blockMask;
 
     /*! Odd number of pixels in block flag 0 or 1, one means odd */
-    nitf_Uint32 odd;
+    uint32_t odd;
 
     /*! Number of pixels in block */
     size_t blockPixelCount;
@@ -947,7 +947,7 @@ typedef struct _nitf_ImageIO_12PixelControl
     size_t blockSizeCompressed;
 
     /*! Buffer for compressed block */
-    nitf_Uint8 *buffer;
+    uint8_t *buffer;
 }
 nitf_ImageIO_12PixelControl;
 
@@ -963,19 +963,19 @@ typedef struct _nitf_ImageIO_12PixelComControl
     nitf_IOInterface* io;
 
     /*! Saved start argument */
-    nitf_Uint64 offset;
+    uint64_t offset;
 
     /*! Saved start argument */
-    nitf_Uint64 dataLength;
+    uint64_t dataLength;
 
     /*! Saved start argument */
-    nitf_Uint64 *blockMask;
+    uint64_t *blockMask;
 
     /*! Saved start argument */
-    nitf_Uint64 *padMask;
+    uint64_t *padMask;
 
     /*! Odd number of pixels in block flag 0 or 1, one means odd */
-    nitf_Uint32 odd;
+    uint32_t odd;
 
     /*! Number of pixels in block */
     size_t blockPixelCount;
@@ -987,10 +987,10 @@ typedef struct _nitf_ImageIO_12PixelComControl
     size_t blockSizeCompressed;
 
     /*! Amount of data written so far */
-    nitf_Uint64 written;
+    uint64_t written;
 
     /*! Buffer for compressed block */
-    nitf_Uint8 *buffer;
+    uint8_t *buffer;
 }
 nitf_ImageIO_12PixelComControl;
 
@@ -1102,8 +1102,8 @@ NITFPRIV(void) nitf_ImageIO_setIO(_nitf_ImageIO * nitf);
 
 NITFPRIV(int) nitf_ImageIO_setPixelDef(_nitf_ImageIO * nitf,
                                        char *pixelType,
-                                       nitf_Uint32 nBits,
-                                       nitf_Uint32 nBitsActual,
+                                       uint32_t nBits,
+                                       uint32_t nBitsActual,
                                        char *justify,
                                        nitf_Error * error);
 
@@ -1152,8 +1152,8 @@ Memory allocation error
 /*!< Number of block columns */
 /*!< Number of bands */
 NITFPRIV(_nitf_ImageIOBlock **) nitf_ImageIO_allocBlockArray(
-        nitf_Uint32 numColumns,
-        nitf_Uint32 numBands,
+        uint32_t numColumns,
+        uint32_t numBands,
         nitf_Error * error       /*! Error object */
                                                             );
 
@@ -1186,7 +1186,7 @@ directly by the user.
 */
 
 /*!< nitf_ImageIO I/O control object */
-NITFPRIV(nitf_Uint32)
+NITFPRIV(uint32_t)
 nitf_ImageIO_getPadBufferSizeCommon(_nitf_ImageIOControl *cntl);
 
 /*!
@@ -1218,16 +1218,16 @@ directly by the user.
 NITFPRIV(void) nitf_ImageIO_commonBlockInit(
     _nitf_ImageIOControl * cntl,
     _nitf_ImageIOBlock *blockIO,
-    nitf_Uint32 band,
-    nitf_Uint32 blockNumber,
-    nitf_Uint32 columnCountFR,
-    nitf_Uint32 residual,
-    nitf_Uint32 myResidual,
-    nitf_Uint32 blockColIdx,
-    nitf_Uint32 bandIdx,
-    nitf_Uint32 nBlockCols,
-    nitf_Uint32 startColumn,
-    nitf_Uint32 userOff);
+    uint32_t band,
+    uint32_t blockNumber,
+    uint32_t columnCountFR,
+    uint32_t residual,
+    uint32_t myResidual,
+    uint32_t blockColIdx,
+    uint32_t bandIdx,
+    uint32_t nBlockCols,
+    uint32_t startColumn,
+    uint32_t userOff);
 
 /*!
   \brief nitf_ImageIO_updateMyResidual - update how much is left for next read
@@ -1249,13 +1249,13 @@ directly by the user.
 /*!< Current blockCol index */
 /*!< Number of blockCols */
 /*!< Partial sample columns this block */
-NITFPRIV(nitf_Uint32) nitf_ImageIO_updateMyResidual(
+NITFPRIV(uint32_t) nitf_ImageIO_updateMyResidual(
     _nitf_ImageIOControl *cntl,
     _nitf_ImageIOBlock *blockIO,
-    nitf_Uint32 bandIdx,
-    nitf_Uint32 blockColIdx,
-    nitf_Uint32 nBlockCols,
-    nitf_Uint32 myResidual);
+    uint32_t bandIdx,
+    uint32_t blockColIdx,
+    uint32_t nBlockCols,
+    uint32_t myResidual);
 
 /*!
   \brief nitf_ImageIO_setPadColumnCount - Set padColumnCount for blockIOs
@@ -1275,7 +1275,7 @@ directly by the user.
 /*!< Number of columns per block */
 /*!< Flag indicating whether padColumnCount needs to account for bands */
 NITFPRIV(void) nitf_ImageIO_setPadColumnCount(_nitf_ImageIOControl* cntl,
-    nitf_Uint32 nBlockCols,
+    uint32_t nBlockCols,
     int scaleByBandCount);
 
 /*!
@@ -1319,7 +1319,7 @@ Memory allocation error
 /*!< Number of columns for each block */
 /*!< Error object */
 NITFPRIV(int) nitf_ImageIO_setup_common(_nitf_ImageIOControl *cntl,
-        nitf_Uint32 nBlockCols,
+        uint32_t nBlockCols,
         nitf_Error *error);
 
 
@@ -1480,7 +1480,7 @@ Memory allocation error
 
 /*!< nitf_ImageIO object */
 /*!< IO handle for read */
-NITFPRIV(_nitf_ImageIOControl *) nitf_ImageIOControl_construct(_nitf_ImageIO * nitf, nitf_IOInterface* io, nitf_Uint8 ** user,  /*!< User data buffer pointers */
+NITFPRIV(_nitf_ImageIOControl *) nitf_ImageIOControl_construct(_nitf_ImageIO * nitf, nitf_IOInterface* io, uint8_t ** user,  /*!< User data buffer pointers */
         nitf_SubWindow * subWindow,      /*!< Sub-window to process */
         int reading,     /*!< Reading if TRUE, else writing */
         nitf_Error * error       /*!< Error object */
@@ -1735,7 +1735,7 @@ I/O Error
 
 /*!< The ImageIO object */
 /*!< IO handle for reads */
-NITFPRIV(int) nitf_ImageIO_initMaskHeader(_nitf_ImageIO * nitf, nitf_IOInterface *io, nitf_Uint32 blockCount,   /*!< Total number of blocks in the file */
+NITFPRIV(int) nitf_ImageIO_initMaskHeader(_nitf_ImageIO * nitf, nitf_IOInterface *io, uint32_t blockCount,   /*!< Total number of blocks in the file */
         int reading,  /*!< Read operation if TRUE */
         nitf_Error * error    /*!< Used for error handling */
                                          );
@@ -1934,7 +1934,7 @@ I/O error
 
 /*!< IO handle for read */
 /*!< File offset for read */
-NITFPRIV(int) nitf_ImageIO_readFromFile(nitf_IOInterface* io, nitf_Uint64 fileOffset, nitf_Uint8 * buffer,      /*!< Data buffer to read into */
+NITFPRIV(int) nitf_ImageIO_readFromFile(nitf_IOInterface* io, uint64_t fileOffset, uint8_t * buffer,      /*!< Data buffer to read into */
                                         size_t count,      /*!< Number of bytes to read */
                                         nitf_Error * errorBuffer        /*!< Error object */
                                        );
@@ -1960,7 +1960,7 @@ I/O error
 /*!< IO handle for write */
 /*!< File offset for write */
 NITFPRIV(int) nitf_ImageIO_writeToFile(nitf_IOInterface* io,
-                                       nitf_Uint64 fileOffset, const nitf_Uint8 * buffer, /*!< Data buffer to write from */
+                                       uint64_t fileOffset, const uint8_t * buffer, /*!< Data buffer to write from */
                                        size_t count,       /*!< Number of bytes to write */
                                        nitf_Error * errorBuffer /*!< Error object */
                                       );
@@ -2007,7 +2007,7 @@ NITFPRIV(int) nitf_ImageIO_writeToBlock
     _nitf_ImageIOBlock * blockIO, /*!< Associated block control */
     nitf_IOInterface* io,         /*!< IO handle for write */
     size_t blockOffset,      /*!< Offset into block buffer for write */
-    const nitf_Uint8 * buffer,    /*!< Data buffer to write from */
+    const uint8_t * buffer,    /*!< Data buffer to write from */
     size_t count,            /*!< Number of bytes to write */
     nitf_Error * error            /*!< Error object */
 );
@@ -2273,22 +2273,22 @@ directly by the user.
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatExtend_1(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount       /*!< Number of bits to shift */
+void nitf_ImageIO_unformatExtend_1(uint8_t * buffer, size_t count, uint32_t shiftCount       /*!< Number of bits to shift */
                                   );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatExtend_2(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount       /*!< Number of bits to shift */
+void nitf_ImageIO_unformatExtend_2(uint8_t * buffer, size_t count, uint32_t shiftCount       /*!< Number of bits to shift */
                                   );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatExtend_4(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount       /*!< Number of bits to shift */
+void nitf_ImageIO_unformatExtend_4(uint8_t * buffer, size_t count, uint32_t shiftCount       /*!< Number of bits to shift */
                                   );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatExtend_8(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount       /*!< Number of bits to shift */
+void nitf_ImageIO_unformatExtend_8(uint8_t * buffer, size_t count, uint32_t shiftCount       /*!< Number of bits to shift */
                                   );
 
 /*!
@@ -2319,22 +2319,22 @@ directly by the user.
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatShift_1(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount        /*!< Number of bits to shift */
+void nitf_ImageIO_unformatShift_1(uint8_t * buffer, size_t count, uint32_t shiftCount        /*!< Number of bits to shift */
                                  );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatShift_2(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount        /*!< Number of bits to shift */
+void nitf_ImageIO_unformatShift_2(uint8_t * buffer, size_t count, uint32_t shiftCount        /*!< Number of bits to shift */
                                  );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatShift_4(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount        /*!< Number of bits to shift */
+void nitf_ImageIO_unformatShift_4(uint8_t * buffer, size_t count, uint32_t shiftCount        /*!< Number of bits to shift */
                                  );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatShift_8(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount        /*!< Number of bits to shift */
+void nitf_ImageIO_unformatShift_8(uint8_t * buffer, size_t count, uint32_t shiftCount        /*!< Number of bits to shift */
                                  );
 
 /*!
@@ -2365,22 +2365,22 @@ directly by the user.
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatUShift_1(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount       /*!< Number of bits to shift */
+void nitf_ImageIO_unformatUShift_1(uint8_t * buffer, size_t count, uint32_t shiftCount       /*!< Number of bits to shift */
                                   );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatUShift_2(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount       /*!< Number of bits to shift */
+void nitf_ImageIO_unformatUShift_2(uint8_t * buffer, size_t count, uint32_t shiftCount       /*!< Number of bits to shift */
                                   );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatUShift_4(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount       /*!< Number of bits to shift */
+void nitf_ImageIO_unformatUShift_4(uint8_t * buffer, size_t count, uint32_t shiftCount       /*!< Number of bits to shift */
                                   );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatUShift_8(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount       /*!< Number of bits to shift */
+void nitf_ImageIO_unformatUShift_8(uint8_t * buffer, size_t count, uint32_t shiftCount       /*!< Number of bits to shift */
                                   );
 
 /*!
@@ -2417,37 +2417,37 @@ directly by the user.
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_swapOnly_2(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount     /*!< Number of bits to shift (unused) */
+void nitf_ImageIO_swapOnly_2(uint8_t * buffer, size_t count, uint32_t shiftCount     /*!< Number of bits to shift (unused) */
                             );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_swapOnly_4(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount     /*!< Number of bits to shift (unused) */
+void nitf_ImageIO_swapOnly_4(uint8_t * buffer, size_t count, uint32_t shiftCount     /*!< Number of bits to shift (unused) */
                             );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_swapOnly_4c(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount    /*!< Number of bits to shift (unused) */
+void nitf_ImageIO_swapOnly_4c(uint8_t * buffer, size_t count, uint32_t shiftCount    /*!< Number of bits to shift (unused) */
                              );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_swapOnly_4c(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount    /*!< Number of bits to shift (unused) */
+void nitf_ImageIO_swapOnly_4c(uint8_t * buffer, size_t count, uint32_t shiftCount    /*!< Number of bits to shift (unused) */
                              );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_swapOnly_8(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount     /*!< Number of bits to shift (unused) */
+void nitf_ImageIO_swapOnly_8(uint8_t * buffer, size_t count, uint32_t shiftCount     /*!< Number of bits to shift (unused) */
                             );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_swapOnly_8c(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount    /*!< Number of bits to shift (unused) */
+void nitf_ImageIO_swapOnly_8c(uint8_t * buffer, size_t count, uint32_t shiftCount    /*!< Number of bits to shift (unused) */
                              );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_swapOnly_16c(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount   /*!< Number of bits to shift (unused) */
+void nitf_ImageIO_swapOnly_16c(uint8_t * buffer, size_t count, uint32_t shiftCount   /*!< Number of bits to shift (unused) */
                               );
 
 /*!
@@ -2477,17 +2477,17 @@ directly by the user.
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatSwapExtend_2(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount   /*!< Number of bits to shift (unused) */
+void nitf_ImageIO_unformatSwapExtend_2(uint8_t * buffer, size_t count, uint32_t shiftCount   /*!< Number of bits to shift (unused) */
                                       );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatSwapExtend_4(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount   /*!< Number of bits to shift (unused) */
+void nitf_ImageIO_unformatSwapExtend_4(uint8_t * buffer, size_t count, uint32_t shiftCount   /*!< Number of bits to shift (unused) */
                                       );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatSwapExtend_8(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount   /*!< Number of bits to shift (unused) */
+void nitf_ImageIO_unformatSwapExtend_8(uint8_t * buffer, size_t count, uint32_t shiftCount   /*!< Number of bits to shift (unused) */
                                       );
 
 /*!
@@ -2517,17 +2517,17 @@ directly by the user.
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatSwapShift_2(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount    /*!< Number of bits to shift */
+void nitf_ImageIO_unformatSwapShift_2(uint8_t * buffer, size_t count, uint32_t shiftCount    /*!< Number of bits to shift */
                                      );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatSwapShift_4(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount    /*!< Number of bits to shift */
+void nitf_ImageIO_unformatSwapShift_4(uint8_t * buffer, size_t count, uint32_t shiftCount    /*!< Number of bits to shift */
                                      );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatSwapShift_8(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount    /*!< Number of bits to shift */
+void nitf_ImageIO_unformatSwapShift_8(uint8_t * buffer, size_t count, uint32_t shiftCount    /*!< Number of bits to shift */
                                      );
 
 /*!
@@ -2557,17 +2557,17 @@ directly by the user.
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatSwapUShift_2(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount   /*!< Number of bits to shift */
+void nitf_ImageIO_unformatSwapUShift_2(uint8_t * buffer, size_t count, uint32_t shiftCount   /*!< Number of bits to shift */
                                       );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatSwapUShift_4(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount   /*!< Number of bits to shift */
+void nitf_ImageIO_unformatSwapUShift_4(uint8_t * buffer, size_t count, uint32_t shiftCount   /*!< Number of bits to shift */
                                       );
 
 /*!< Buffer holding the data to unformat */
 /*!< Number of values to unformat */
-void nitf_ImageIO_unformatSwapUShift_8(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount   /*!< Number of bits to shift */
+void nitf_ImageIO_unformatSwapUShift_8(uint8_t * buffer, size_t count, uint32_t shiftCount   /*!< Number of bits to shift */
                                       );
 
 /*!
@@ -2598,22 +2598,22 @@ the user.
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatShift_1(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount  /*!< Number of bits to shift */
+void nitf_ImageIO_formatShift_1(uint8_t * buffer, size_t count, uint32_t shiftCount  /*!< Number of bits to shift */
                                );
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatShift_2(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount  /*!< Number of bits to shift */
+void nitf_ImageIO_formatShift_2(uint8_t * buffer, size_t count, uint32_t shiftCount  /*!< Number of bits to shift */
                                );
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatShift_4(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount  /*!< Number of bits to shift */
+void nitf_ImageIO_formatShift_4(uint8_t * buffer, size_t count, uint32_t shiftCount  /*!< Number of bits to shift */
                                );
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatShift_8(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount  /*!< Number of bits to shift */
+void nitf_ImageIO_formatShift_8(uint8_t * buffer, size_t count, uint32_t shiftCount  /*!< Number of bits to shift */
                                );
 
 /*!
@@ -2643,22 +2643,22 @@ the user.
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatMask_1(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount   /*!< Number of bits to shift */
+void nitf_ImageIO_formatMask_1(uint8_t * buffer, size_t count, uint32_t shiftCount   /*!< Number of bits to shift */
                               );
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatMask_2(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount   /*!< Number of bits to shift */
+void nitf_ImageIO_formatMask_2(uint8_t * buffer, size_t count, uint32_t shiftCount   /*!< Number of bits to shift */
                               );
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatMask_4(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount   /*!< Number of bits to shift */
+void nitf_ImageIO_formatMask_4(uint8_t * buffer, size_t count, uint32_t shiftCount   /*!< Number of bits to shift */
                               );
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatMask_8(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount   /*!< Number of bits to shift */
+void nitf_ImageIO_formatMask_8(uint8_t * buffer, size_t count, uint32_t shiftCount   /*!< Number of bits to shift */
                               );
 
 /*!
@@ -2688,17 +2688,17 @@ the user.
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatShiftSwap_2(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount      /*!< Number of bits to shift */
+void nitf_ImageIO_formatShiftSwap_2(uint8_t * buffer, size_t count, uint32_t shiftCount      /*!< Number of bits to shift */
                                    );
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatShiftSwap_4(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount      /*!< Number of bits to shift */
+void nitf_ImageIO_formatShiftSwap_4(uint8_t * buffer, size_t count, uint32_t shiftCount      /*!< Number of bits to shift */
                                    );
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatShiftSwap_8(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount      /*!< Number of bits to shift */
+void nitf_ImageIO_formatShiftSwap_8(uint8_t * buffer, size_t count, uint32_t shiftCount      /*!< Number of bits to shift */
                                    );
 
 /*!
@@ -2729,17 +2729,17 @@ the user.
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatMaskSwap_2(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount       /*!< Number of bits to shift */
+void nitf_ImageIO_formatMaskSwap_2(uint8_t * buffer, size_t count, uint32_t shiftCount       /*!< Number of bits to shift */
                                   );
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatMaskSwap_4(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount       /*!< Number of bits to shift */
+void nitf_ImageIO_formatMaskSwap_4(uint8_t * buffer, size_t count, uint32_t shiftCount       /*!< Number of bits to shift */
                                   );
 
 /*!< Buffer holding the data to format */
 /*!< Number of values to format */
-void nitf_ImageIO_formatMaskSwap_8(nitf_Uint8 * buffer, size_t count, nitf_Uint32 shiftCount       /*!< Number of bits to shift */
+void nitf_ImageIO_formatMaskSwap_8(uint8_t * buffer, size_t count, uint32_t shiftCount       /*!< Number of bits to shift */
                                   );
 
 /*!
@@ -2835,13 +2835,13 @@ NITFPRIV(void) nitf_ImageIOBlock_print
 NITFAPI(NITF_BOOL) nitf_ImageIO_getMaskInfo
 (
     nitf_ImageIO *nitf,            /*!< The ImageIO to access */
-    nitf_Uint32 *imageDataOffset,  /*!< Offset to actual image data past masks */
-    nitf_Uint32 *blockRecordLength, /*!< Block mask record length */
-    nitf_Uint32 *padRecordLength,   /*!< Pad mask record length */
-    nitf_Uint32 *padPixelValueLength, /*!< Pad pixel value length in bytes */
-    nitf_Uint8 **padValue,          /*!< Pad value */
-    nitf_Uint64 **blockMask,        /*!< Block mask array */
-    nitf_Uint64 **padMask           /*!< Pad mask array */
+    uint32_t *imageDataOffset,  /*!< Offset to actual image data past masks */
+    uint32_t *blockRecordLength, /*!< Block mask record length */
+    uint32_t *padRecordLength,   /*!< Pad mask record length */
+    uint32_t *padPixelValueLength, /*!< Pad pixel value length in bytes */
+    uint8_t **padValue,          /*!< Pad value */
+    uint64_t **blockMask,        /*!< Block mask array */
+    uint64_t **padMask           /*!< Pad mask array */
 );
 
 /*!
@@ -2871,10 +2871,10 @@ NITFPRIV(nitf_DecompressionControl*) nitf_ImageIO_bPixelOpen
 NITFPRIV(NITF_BOOL) nitf_ImageIO_bPixelStart(
         nitf_DecompressionControl * control,
         nitf_IOInterface* io,
-        nitf_Uint64 offset,
-        nitf_Uint64 fileLength,     /*!< Total file length (not used) */
+        uint64_t offset,
+        uint64_t fileLength,     /*!< Total file length (not used) */
         nitf_BlockingInfo * blockInfo,    /*!< Associated blocking information */
-        nitf_Uint64 * blockMask,  /*!< Associated block mask */
+        uint64_t * blockMask,  /*!< Associated block mask */
         nitf_Error * error        /*!< For error returns */
                                                              );
 
@@ -2889,7 +2889,7 @@ NITFPRIV(NITF_BOOL) nitf_ImageIO_bPixelStart(
 /*!< Block to free */
 NITFPRIV(NITF_BOOL) nitf_ImageIO_bPixelFreeBlock(
         nitf_DecompressionControl * control,
-        nitf_Uint8 * block,
+        uint8_t * block,
         nitf_Error * error    /*!< For error returns */
                                                 );
 
@@ -2914,9 +2914,9 @@ NITFPRIV(void) nitf_ImageIO_bPixelClose(nitf_DecompressionControl **
 
 /*!< Associated control structure */
 /*!< Block number to read */
-NITFPRIV(nitf_Uint8 *) nitf_ImageIO_bPixelReadBlock(nitf_DecompressionControl * control,
-                                                    nitf_Uint32 blockNumber,
-                                                    nitf_Uint64* blockSize,
+NITFPRIV(uint8_t *) nitf_ImageIO_bPixelReadBlock(nitf_DecompressionControl * control,
+                                                    uint32_t blockNumber,
+                                                    uint64_t* blockSize,
                                                     nitf_Error * error    /*!< For error returns */
     );
 
@@ -2945,7 +2945,7 @@ static nitf_DecompressionInterface nitf_ImageIO_bPixelInterface =
 /*!< Associated control structure */
 /*!< Block to free */
 NITFPRIV(NITF_BOOL) nitf_ImageIO_12PixelFreeBlock(
-  nitf_DecompressionControl * control, nitf_Uint8 * block,
+  nitf_DecompressionControl * control, uint8_t * block,
   nitf_Error * error);    /*!< For error returns */
 
 
@@ -2973,10 +2973,10 @@ NITFPRIV(nitf_DecompressionControl*) nitf_ImageIO_12PixelOpen
 NITFPRIV(NITF_BOOL) nitf_ImageIO_12PixelStart(
    nitf_DecompressionControl* oontrol,
    nitf_IOInterface* io,            /*!< IO handle for reads */
-   nitf_Uint64 offset,              /*!< Offset to start of blocks */
-   nitf_Uint64 fileLength,          /*!< Total file length (not used) */
+   uint64_t offset,              /*!< Offset to start of blocks */
+   uint64_t fileLength,          /*!< Total file length (not used) */
    nitf_BlockingInfo * blockInfo,   /*!< Associated blocking information */
-   nitf_Uint64 * blockMask,         /*!< Associated block mask */
+   uint64_t * blockMask,         /*!< Associated block mask */
    nitf_Error * error);             /*!< For error returns */
 
 /*!
@@ -2997,10 +2997,10 @@ NITFPRIV(void) nitf_ImageIO_12PixelClose(nitf_DecompressionControl **control);
   the error object is set
 */
 
-NITFPRIV(nitf_Uint8 *) nitf_ImageIO_12PixelReadBlock(
+NITFPRIV(uint8_t *) nitf_ImageIO_12PixelReadBlock(
   nitf_DecompressionControl * control, /*!< Associated control structure */
-  nitf_Uint32 blockNumber, /*!< Block number to read */
-  nitf_Uint64* blockSize, /*!< Size of block that was read */
+  uint32_t blockNumber, /*!< Block number to read */
+  uint64_t* blockSize, /*!< Size of block that was read */
   nitf_Error * error);    /*!< For error returns */
 
 /*!
@@ -3038,8 +3038,8 @@ nitf_CompressionControl  *nitf_ImageIO_12PixelComOpen
 */
 
 NITF_BOOL nitf_ImageIO_12PixelComStart
-  (nitf_CompressionControl *object,nitf_Uint64 offset,nitf_Uint64 dataLength,
-   nitf_Uint64 * blockMask,nitf_Uint64 * padMask, nitf_Error * error);
+  (nitf_CompressionControl *object,uint64_t offset,uint64_t dataLength,
+   uint64_t * blockMask,uint64_t * padMask, nitf_Error * error);
 
 /*!
     \brief nitf_ImageIO_12PixelComWriteBlock - Write block function for 12 bit
@@ -3051,7 +3051,7 @@ NITF_BOOL nitf_ImageIO_12PixelComStart
 
 NITF_BOOL nitf_ImageIO_12PixelComWriteBlock(nitf_CompressionControl* object,
                                             nitf_IOInterface* io,
-                                            const nitf_Uint8 *data,
+                                            const uint8_t *data,
                                             NITF_BOOL pad,
                                             NITF_BOOL noData,
                                             nitf_Error *error);
@@ -3102,8 +3102,8 @@ static nitf_CompressionInterface nitf_ImageIO_12PixelComInterface =
 
 NITFPROT(nitf_ImageIO *) nitf_ImageIO_construct(
         nitf_ImageSubheader* subheader,
-        nitf_Uint64 offset,
-        nitf_Uint64 length,
+        uint64_t offset,
+        uint64_t length,
         nitf_CompressionInterface* compressor,
         nitf_DecompressionInterface* decompressor,
         nrt_HashTable* options,
@@ -3114,17 +3114,17 @@ NITFPROT(nitf_ImageIO *) nitf_ImageIO_construct(
 
     /*     Values from the segment */
 
-    nitf_Uint32 numRows;          /* Number of rows in the image */
-    nitf_Uint32 numColumns;       /* Number of columns in the image */
-    nitf_Uint32 numBands, xBands; /* Number of bands */
+    uint32_t numRows;          /* Number of rows in the image */
+    uint32_t numColumns;       /* Number of columns in the image */
+    uint32_t numBands, xBands; /* Number of bands */
     char *pixelType;            /* Pixel type */
-    nitf_Uint32 nBits;          /* Number of bits per pixel */
-    nitf_Uint32 nBitsActual;    /* Actual number of bits per pixel */
+    uint32_t nBits;          /* Number of bits per pixel */
+    uint32_t nBitsActual;    /* Actual number of bits per pixel */
     char *justification;        /* Pixels justification */
-    nitf_Uint32 nBlocksPerRow;    /* Number of blocks per row */
-    nitf_Uint32 nBlocksPerColumn; /* Number of blocks per Column */
-    nitf_Uint32 numRowsPerBlock;    /* Number of rows per block */
-    nitf_Uint32 numColumnsPerBlock; /* Number of columns per block */
+    uint32_t nBlocksPerRow;    /* Number of blocks per row */
+    uint32_t nBlocksPerColumn; /* Number of blocks per Column */
+    uint32_t numRowsPerBlock;    /* Number of rows per block */
+    uint32_t numColumnsPerBlock; /* Number of columns per block */
 
     /*      Load values from calling segment */
 
@@ -3352,7 +3352,7 @@ NITFPROT(void) nitf_ImageIO_destruct(nitf_ImageIO ** nitf)
 NITFPROT(NITF_BOOL) nitf_ImageIO_read(nitf_ImageIO * nitf,
                                       nitf_IOInterface* io,
                                       nitf_SubWindow * subWindow,
-                                      nitf_Uint8 ** user,
+                                      uint8_t ** user,
                                       int *padded, nitf_Error * error)
 {
     _nitf_ImageIO *nitfI;       /* Internal version of nitf */
@@ -3363,7 +3363,7 @@ NITFPROT(NITF_BOOL) nitf_ImageIO_read(nitf_ImageIO * nitf,
     _nitf_ImageIOControl *cntl; /* IO control structure */
     _nitf_ImageIOReadControl *readCntl; /* Read control structure */
     nitf_SubWindow tmpSub;      /* Temp sub-window structure for one band loop */
-    nitf_Uint32 band;           /* Current band */
+    uint32_t band;           /* Current band */
     int ret;                    /* Return value */
 
     ret = 1;                    /* To avoid warning */
@@ -3620,19 +3620,19 @@ NITFPROT(NITF_BOOL) nitf_ImageIO_writeSequential(nitf_ImageIO * nitf,
 
 NITFPROT(NITF_BOOL) nitf_ImageIO_writeRows(nitf_ImageIO * object,
                                            nitf_IOInterface* io,
-                                           nitf_Uint32 numRows,
-                                           nitf_Uint8 ** data,
+                                           uint32_t numRows,
+                                           uint8_t ** data,
                                            nitf_Error * error)
 {
     _nitf_ImageIO *nitf;        /* Parent _nitf_ImageIO object */
     _nitf_ImageIOWriteControl *cntl; /* Internal representation */
     _nitf_ImageIOControl *ioCntl; /* Associated IO control object */
-    nitf_Uint32 idxIO;          /* Current block IO index (linear array) */
-    nitf_Uint32 nBlockCols;       /* Number of block columns */
-    nitf_Uint32 numBands;         /* Number of bands */
-    nitf_Uint32 col;            /* Block column index */
-    nitf_Uint32 row;            /* Current row in sub-window */
-    nitf_Uint32 band;           /* Current band in sub-window */
+    uint32_t idxIO;          /* Current block IO index (linear array) */
+    uint32_t nBlockCols;       /* Number of block columns */
+    uint32_t numBands;         /* Number of bands */
+    uint32_t col;            /* Block column index */
+    uint32_t row;            /* Current row in sub-window */
+    uint32_t band;           /* Current band in sub-window */
     _nitf_ImageIOBlock *blockIO; /* The current  block IO structure */
 
     cntl = ((_nitf_ImageIO *) object)->writeControl;
@@ -3663,7 +3663,7 @@ NITFPROT(NITF_BOOL) nitf_ImageIO_writeRows(nitf_ImageIO * object,
     for (idxIO = 0; idxIO < ioCntl->nBlockIO; idxIO++)
     {
         /* Current user data pointer from "data" argument */
-        nitf_Uint8 *user;
+        uint8_t *user;
 
         user = data[ioCntl->bandSubset[blockIO->band]];
 
@@ -3739,8 +3739,8 @@ NITFPROT(NITF_BOOL) nitf_ImageIO_writeRows(nitf_ImageIO * object,
 
 
 NITFPROT(NITF_BOOL) nitf_ImageIO_setPadPixel(nitf_ImageIO * object,
-                                             nitf_Uint8 * value,
-                                             nitf_Uint32 length,
+                                             uint8_t * value,
+                                             uint32_t length,
                                              nitf_Error* error)
 {
     _nitf_ImageIO* nio = (_nitf_ImageIO*)object;
@@ -3756,23 +3756,23 @@ NITFPROT(NITF_BOOL) nitf_ImageIO_setPadPixel(nitf_ImageIO * object,
     {
     case 2:
     {
-        nitf_Uint16* int16 =
-            (nitf_Uint16*)&(nio->pixel.pad);
+        uint16_t* int16 =
+            (uint16_t*)&(nio->pixel.pad);
         *int16 = NITF_HTONS(*int16);
         break;
 
     }
     case 4:
     {
-        nitf_Uint32* int32 =
-            (nitf_Uint32*)&(nio->pixel.pad);
+        uint32_t* int32 =
+            (uint32_t*)&(nio->pixel.pad);
         *int32 = NITF_HTONL(*int32);
         break;
     }
     case 8:
     {
-        nitf_Uint64* int64 =
-            (nitf_Uint64*)&(nio->pixel.pad);
+        uint64_t* int64 =
+            (uint64_t*)&(nio->pixel.pad);
 
         if (nio->pixel.type == NITF_IMAGE_IO_PIXEL_TYPE_C)
         {
@@ -3799,7 +3799,7 @@ NITFPROT(NITF_BOOL) nitf_ImageIO_setPadPixel(nitf_ImageIO * object,
 
 /*=================== nitf_ImageIO_pixelSize =================================*/
 
-NITFPROT(nitf_Uint32) nitf_ImageIO_pixelSize(nitf_ImageIO * nitf)
+NITFPROT(uint32_t) nitf_ImageIO_pixelSize(nitf_ImageIO * nitf)
 {
     return (((_nitf_ImageIO *) nitf)->pixel.bytes);
 }
@@ -3808,7 +3808,7 @@ NITFPROT(nitf_Uint32) nitf_ImageIO_pixelSize(nitf_ImageIO * nitf)
 /*=================== nitf_ImageIO_pixelSize =================================*/
 
 NITFPROT(NITF_BOOL) nitf_ImageIO_setFileOffset(nitf_ImageIO * nitf,
-        nitf_Uint64 offset,
+        uint64_t offset,
         nitf_Error * error)
 {
     _nitf_ImageIO *nitfI;       /* Internal version of the handle */
@@ -4303,19 +4303,19 @@ NITFPRIV(void) nitf_ImageIO_setIO(_nitf_ImageIO * nitf)
 typedef struct
 {
     /* Pixel types mask */
-    nitf_Uint32 types;
+    uint32_t types;
 
     /* Pixel size in byte flas */
-    nitf_Uint32 bytes;
+    uint32_t bytes;
 
     /* Characteristics flag. swap */
-    nitf_Uint32 swap;
+    uint32_t swap;
 
     /* Characteristics flag. sign */
-    nitf_Uint32 sign;
+    uint32_t sign;
 
     /* Characteristics flag, just */
-    nitf_Uint32 just;
+    uint32_t just;
 
     /* The function to use for unformat */
     _NITF_IMAGE_IO_UNFORMAT_FUNC unfmt;
@@ -4501,17 +4501,17 @@ static unformatTable UNFORMAT_TABLE[NENTRIES] =
 
 NITFPRIV(int) nitf_ImageIO_setPixelDef(_nitf_ImageIO * nitf,
                                        char *pixelType,
-                                       nitf_Uint32 nBits,
-                                       nitf_Uint32 nBitsActual,
+                                       uint32_t nBits,
+                                       uint32_t nBitsActual,
                                        char *justify,
                                        nitf_Error * error)
 {
     char pixelTypeBuf[4];  /* Buffer for justified pixel type string */
     char *pixelTypePtr;    /* Pointer into justified pixel type string */
     char *pixelTypeBufPtr; /* Pointer into justified pixel type buffer */
-    nitf_Uint32 swap;      /* Pixel characteristics flag, swap */
-    nitf_Uint32 sign;      /* Pixel characteristics flag, sign */
-    nitf_Uint32 just;      /* Pixel characteristics flag, just */
+    uint32_t swap;      /* Pixel characteristics flag, swap */
+    uint32_t sign;      /* Pixel characteristics flag, sign */
+    uint32_t just;      /* Pixel characteristics flag, just */
     int found;             /* Found a valid unformat/format function */
     int i;
 
@@ -4682,11 +4682,11 @@ NITFPRIV(void) nitf_ImageIO_setUnpack(_nitf_ImageIO * nitf)
 }
 
 NITFPRIV(_nitf_ImageIOBlock **) nitf_ImageIO_allocBlockArray
-(nitf_Uint32 numColumns, nitf_Uint32 numBands, nitf_Error * error)
+(uint32_t numColumns, uint32_t numBands, nitf_Error * error)
 {
     _nitf_ImageIOBlock **blockIOs;        /*!< The result */
     _nitf_ImageIOBlock *blockIOPtr;       /*!< The linear array of structures */
-    nitf_Uint32 i;
+    uint32_t i;
 
     blockIOs =
         (_nitf_ImageIOBlock **) NITF_MALLOC(sizeof(_nitf_ImageIOBlock *) *
@@ -4741,11 +4741,11 @@ NITFPRIV(void) nitf_ImageIO_freeBlockArray(_nitf_ImageIOBlock *** blockIOs)
     return;
 }
 
-NITFPRIV(nitf_Uint32)
+NITFPRIV(uint32_t)
 nitf_ImageIO_getPadBufferSizeCommon(_nitf_ImageIOControl *cntl)
 {
     _nitf_ImageIO* nitf;
-    nitf_Uint32 padBufferSize;
+    uint32_t padBufferSize;
 
     nitf = cntl->nitf;
 
@@ -4760,24 +4760,24 @@ nitf_ImageIO_getPadBufferSizeCommon(_nitf_ImageIOControl *cntl)
 
 NITFPRIV(void) nitf_ImageIO_commonBlockInit(_nitf_ImageIOControl * cntl,
     _nitf_ImageIOBlock *blockIO,  /* BlockIO to initialize */
-    nitf_Uint32 band,             /* Current band */
-    nitf_Uint32 blockNumber,      /* Current block number */
-    nitf_Uint32 columnCountFR,    /* Remaining column transfer count (bytes) */
-    nitf_Uint32 residual,         /* Partial sample columns previous block */
-    nitf_Uint32 myResidual,       /* Partial sample columns this block */
-    nitf_Uint32 blockColIdx,      /* Current block column index */
-    nitf_Uint32 bandIdx,          /* Current band index */
-    nitf_Uint32 nBlockCols,       /* Number of blockCols */
-    nitf_Uint32 startColumn,      /* First column of this block */
-    nitf_Uint32 userOff)          /* Offset for user buffer */
+    uint32_t band,             /* Current band */
+    uint32_t blockNumber,      /* Current block number */
+    uint32_t columnCountFR,    /* Remaining column transfer count (bytes) */
+    uint32_t residual,         /* Partial sample columns previous block */
+    uint32_t myResidual,       /* Partial sample columns this block */
+    uint32_t blockColIdx,      /* Current block column index */
+    uint32_t bandIdx,          /* Current band index */
+    uint32_t nBlockCols,       /* Number of blockCols */
+    uint32_t startColumn,      /* First column of this block */
+    uint32_t userOff)          /* Offset for user buffer */
 {
     _nitf_ImageIO *nitf;             /* Parent _nitf_ImageIO object */
-    nitf_Uint32 bytes;               /* Bytes per pixel */
-    nitf_Uint64 modeBlockBaseOffset; /* Block pixel offset based on mode*/
-    nitf_Uint64 maskOffset;          /* Mask offset based on mode */
-    nitf_Uint64 markOffset;          /* Mark offset based on mode */
-    nitf_Uint32 numColsFR;           /* Number of columns at full resolution */
-    nitf_Uint32 startRowThisBlock;   /* Row of this block to start at */
+    uint32_t bytes;               /* Bytes per pixel */
+    uint64_t modeBlockBaseOffset; /* Block pixel offset based on mode*/
+    uint64_t maskOffset;          /* Mask offset based on mode */
+    uint64_t markOffset;          /* Mark offset based on mode */
+    uint32_t numColsFR;           /* Number of columns at full resolution */
+    uint32_t startRowThisBlock;   /* Row of this block to start at */
 
     nitf = cntl->nitf;
     bytes = nitf->pixel.bytes;
@@ -4821,7 +4821,7 @@ NITFPRIV(void) nitf_ImageIO_commonBlockInit(_nitf_ImageIOControl * cntl,
          *  In diagram, all rows between vertical lines are stored contiguously
          *  So the goal is to jump between entire sections
          */
-        modeBlockBaseOffset = (nitf_Uint64)band *
+        modeBlockBaseOffset = (uint64_t)band *
                 nitf->numColumnsPerBlock * nitf->numRowsPerBlock;
     }
     else if (nitf->blockingMode == NITF_IMAGE_IO_BLOCKING_MODE_R)
@@ -4832,7 +4832,7 @@ NITFPRIV(void) nitf_ImageIO_commonBlockInit(_nitf_ImageIOControl * cntl,
          * 00000 11111 22222
          * For band 1, jump to pixel 1 * 5 = 5
          */
-        modeBlockBaseOffset = (nitf_Uint64)band * nitf->numColumnsPerBlock;
+        modeBlockBaseOffset = (uint64_t)band * nitf->numColumnsPerBlock;
     }
 
     blockIO->blockOffset.orig = (modeBlockBaseOffset + startColumn) * bytes;
@@ -4844,7 +4844,7 @@ NITFPRIV(void) nitf_ImageIO_commonBlockInit(_nitf_ImageIOControl * cntl,
     }
 
     /* Advance to starting row*/
-    markOffset = (nitf_Uint64)startRowThisBlock * nitf->numColumnsPerBlock * bytes;
+    markOffset = (uint64_t)startRowThisBlock * nitf->numColumnsPerBlock * bytes;
     if (nitf->blockingMode == NITF_IMAGE_IO_BLOCKING_MODE_R ||
         nitf->blockingMode == NITF_IMAGE_IO_BLOCKING_MODE_P)
     {
@@ -4856,7 +4856,7 @@ NITFPRIV(void) nitf_ImageIO_commonBlockInit(_nitf_ImageIOControl * cntl,
     maskOffset = 0;
     if (nitf->blockingMode == NITF_IMAGE_IO_BLOCKING_MODE_S)
     {
-        maskOffset = (nitf_Uint64)band *
+        maskOffset = (uint64_t)band *
                 nitf->nBlocksPerRow * nitf->nBlocksPerColumn;
     }
 
@@ -4924,16 +4924,16 @@ NITFPRIV(void) nitf_ImageIO_commonBlockInit(_nitf_ImageIOControl * cntl,
     blockIO->user.offset.orig = userOff;
 }
 
-nitf_Uint32 nitf_ImageIO_updateMyResidual(
+uint32_t nitf_ImageIO_updateMyResidual(
         _nitf_ImageIOControl * cntl, /* nitf_ImageIO control object */
         _nitf_ImageIOBlock *blockIO, /* Current BlockIO */
-        nitf_Uint32 bandIdx,         /* Current band index */
-        nitf_Uint32 blockColIdx,     /* Current blockCol index */
-        nitf_Uint32 nBlockCols,      /* Number of blockCols */
-        nitf_Uint32 myResidual) /* We return this if it doesn't need updating */
+        uint32_t bandIdx,         /* Current band index */
+        uint32_t blockColIdx,     /* Current blockCol index */
+        uint32_t nBlockCols,      /* Number of blockCols */
+        uint32_t myResidual) /* We return this if it doesn't need updating */
 {
     _nitf_ImageIO *nitf;   /* Parent _nitf_ImageIO object */
-    nitf_Uint32 numColsFR; /* Number of columns at full resolution */
+    uint32_t numColsFR; /* Number of columns at full resolution */
 
     nitf = cntl->nitf;
     numColsFR = cntl->numColumns * (cntl->columnSkip);
@@ -4969,13 +4969,13 @@ nitf_Uint32 nitf_ImageIO_updateMyResidual(
 }
 
 NITFPRIV(void) nitf_ImageIO_setPadColumnCount(_nitf_ImageIOControl* cntl,
-    nitf_Uint32 nBlockCols,
+    uint32_t nBlockCols,
     int scaleByBandCount)
 {
     _nitf_ImageIO* nitf;           /* nitf_ImageIO object */
     _nitf_ImageIOBlock *blockIO;   /* Current block to set */
-    nitf_Uint32 bandIdx;           /* Current band index */
-    nitf_Uint32 bandCount;         /* Total number of bands */
+    uint32_t bandIdx;           /* Current band index */
+    uint32_t bandCount;         /* Total number of bands */
 
     nitf = cntl->nitf;
     bandCount = cntl->numBandSubset;
@@ -5020,7 +5020,7 @@ NITFPRIV(void) nitf_ImageIO_setPadRowCount(_nitf_ImageIOControl* cntl)
 {
     _nitf_ImageIO *nitf;          /* nitf_ImageIO object */
     _nitf_ImageIOBlock *blockIO;  /* blockIO being set */
-    nitf_Uint32 blockIdx;         /* Current block index */
+    uint32_t blockIdx;         /* Current block index */
 
     nitf = cntl->nitf;
 
@@ -5054,13 +5054,13 @@ NITFPRIV(void) nitf_ImageIO_setPadRowCount(_nitf_ImageIOControl* cntl)
 }
 
 NITFPRIV(int)
-nitf_ImageIO_setup_common(_nitf_ImageIOControl *cntl, nitf_Uint32 nBlockCols,
+nitf_ImageIO_setup_common(_nitf_ImageIOControl *cntl, uint32_t nBlockCols,
         nitf_Error *error)
 {
     _nitf_ImageIO *nitf;
     _nitf_ImageIOBlock **blockIOs;  /* The block I/O control structures */
-    nitf_Uint32 bytes;              /* Number of bytes per pixel */
-    nitf_Uint32 bandCount;          /* Number of bands */
+    uint32_t bytes;              /* Number of bytes per pixel */
+    uint32_t bandCount;          /* Number of bands */
 
     nitf = cntl->nitf;
     bytes = nitf->pixel.bytes;
@@ -5094,29 +5094,29 @@ nitf_ImageIO_setup_common(_nitf_ImageIOControl *cntl, nitf_Uint32 nBlockCols,
 int nitf_ImageIO_setup_SBR(_nitf_ImageIOControl * cntl, nitf_Error * error)
 {
     _nitf_ImageIO *nitf;        /* Parent _nitf_ImageIO object */
-    nitf_Uint32 startBlockRow;  /* Starting blockRow */
-    nitf_Uint32 startBlockCol;  /* Starting blockCol */
-    nitf_Uint32 endBlockCol;    /* Ending blockCol */
-    nitf_Uint32 nBlockCols;     /* Number of blockCols */
-    nitf_Uint32 startBlock;     /* Block number of start block */
-    nitf_Uint32 startColumnInBlock0;/* Start column in the first block (pixels) */
-    nitf_Uint32 residual;       /* Partial sample columns previous block */
-    nitf_Uint32 myResidual;     /* Partial sample columsn current block */
-    nitf_Uint32 bytes;          /* Bytes per pixel */
+    uint32_t startBlockRow;  /* Starting blockRow */
+    uint32_t startBlockCol;  /* Starting blockCol */
+    uint32_t endBlockCol;    /* Ending blockCol */
+    uint32_t nBlockCols;     /* Number of blockCols */
+    uint32_t startBlock;     /* Block number of start block */
+    uint32_t startColumnInBlock0;/* Start column in the first block (pixels) */
+    uint32_t residual;       /* Partial sample columns previous block */
+    uint32_t myResidual;     /* Partial sample columsn current block */
+    uint32_t bytes;          /* Bytes per pixel */
     _nitf_ImageIOBlock *blockIO;  /* The current block I/O control structure */
-    nitf_Uint32 columnCountFR;  /* Remaining column transfer count (bytes) */
+    uint32_t columnCountFR;  /* Remaining column transfer count (bytes) */
     /* Start column for current block (pixels) */
-    nitf_Uint32 startColumnThisBlock;
-    nitf_Uint32 blockNumber;    /* Current block number */
-    nitf_Uint32 userOff;        /* Offsets into user buffers */
-    nitf_Uint32 bandCnt;        /* Number of bands in the read */
-    nitf_Uint32 bandIdx;        /* Current band index */
-    nitf_Uint32 blockIdx;       /* Current block index */
-    nitf_Uint32 band;           /* Current band */
-    nitf_Uint8 *writeBuffer;    /* Write buffer */
-    nitf_Uint8 *readBuffer;     /* Read buffer */
-    nitf_Uint8 blockColIdx;     /* Current block column index */
-    nitf_Uint8 *cacheBuffer;    /* Current cach buffer */
+    uint32_t startColumnThisBlock;
+    uint32_t blockNumber;    /* Current block number */
+    uint32_t userOff;        /* Offsets into user buffers */
+    uint32_t bandCnt;        /* Number of bands in the read */
+    uint32_t bandIdx;        /* Current band index */
+    uint32_t blockIdx;       /* Current block index */
+    uint32_t band;           /* Current band */
+    uint8_t *writeBuffer;    /* Write buffer */
+    uint8_t *readBuffer;     /* Read buffer */
+    uint8_t blockColIdx;     /* Current block column index */
+    uint8_t *cacheBuffer;    /* Current cach buffer */
     NITF_BOOL freeCacheBuffer;  /* Sets block control free flag */
     NITF_BOOL freeCacheBufferReset; /* Resets freeCacheBuffer flag */
 
@@ -5205,7 +5205,7 @@ int nitf_ImageIO_setup_SBR(_nitf_ImageIOControl * cntl, nitf_Error * error)
              * number of rows must be accumulated before
              * you can reuse the buffer.
              */
-            readBuffer = (nitf_Uint8 *) NITF_MALLOC((cntl->rowSkip) *
+            readBuffer = (uint8_t *) NITF_MALLOC((cntl->rowSkip) *
                                                     (nitf->numColumnsPerBlock +
                                                      cntl->columnSkip) *
                                                     bytes * bandCnt);
@@ -5221,7 +5221,7 @@ int nitf_ImageIO_setup_SBR(_nitf_ImageIOControl * cntl, nitf_Error * error)
     else
     {
         writeBuffer =
-            (nitf_Uint8 *) NITF_MALLOC(nitf->numColumnsPerBlock * bytes);
+            (uint8_t *) NITF_MALLOC(nitf->numColumnsPerBlock * bytes);
         if (writeBuffer == NULL)
         {
             nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -5251,7 +5251,7 @@ int nitf_ImageIO_setup_SBR(_nitf_ImageIOControl * cntl, nitf_Error * error)
         if ((nitf->blockingMode != NITF_IMAGE_IO_BLOCKING_MODE_S)
             && nitf->cachedWriteFlag)
         {
-            cacheBuffer = (nitf_Uint8 *) NITF_MALLOC(nitf->blockSize);
+            cacheBuffer = (uint8_t *) NITF_MALLOC(nitf->blockSize);
             if (cacheBuffer == NULL)
             {
                 nitf_Error_initf(error, NITF_CTXT,
@@ -5272,7 +5272,7 @@ int nitf_ImageIO_setup_SBR(_nitf_ImageIOControl * cntl, nitf_Error * error)
                     && freeCacheBuffer  && nitf->cachedWriteFlag)
             {
                 cacheBuffer =
-                    (nitf_Uint8 *) NITF_MALLOC(nitf->blockSize);
+                    (uint8_t *) NITF_MALLOC(nitf->blockSize);
                 if (cacheBuffer == NULL)
                 {
                     nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -5388,29 +5388,29 @@ int nitf_ImageIO_done_SBR(_nitf_ImageIOControl * cntl, nitf_Error * error)
 int nitf_ImageIO_setup_P(_nitf_ImageIOControl * cntl, nitf_Error * error)
 {
     _nitf_ImageIO *nitf = NULL; /* Parent _nitf_ImageIO object */
-    nitf_Uint32 startBlockRow;  /* Starting blockRow */
-    nitf_Uint32 startBlockCol;  /* Starting blockCol */
-    nitf_Uint32 endBlockCol;    /* Ending blockCol */
-    nitf_Uint32 nBlockCols;     /* Number of blockCols */
-    nitf_Uint32 startBlock;     /* Block number of start block */
-    nitf_Uint32 startColumnInBlock0; /* Start column in the first block (pixels) */
-    nitf_Uint32 residual;       /* Partial sample columns previous block */
-    nitf_Uint32 myResidual;
-    nitf_Uint32 bytes;          /* Bytes per pixel */
+    uint32_t startBlockRow;  /* Starting blockRow */
+    uint32_t startBlockCol;  /* Starting blockCol */
+    uint32_t endBlockCol;    /* Ending blockCol */
+    uint32_t nBlockCols;     /* Number of blockCols */
+    uint32_t startBlock;     /* Block number of start block */
+    uint32_t startColumnInBlock0; /* Start column in the first block (pixels) */
+    uint32_t residual;       /* Partial sample columns previous block */
+    uint32_t myResidual;
+    uint32_t bytes;          /* Bytes per pixel */
     _nitf_ImageIOBlock *blockIO = NULL; /* The current block I/O control structure */
-    nitf_Uint32 columnCountFR;  /* Remaining column transfer count (bytes) */
+    uint32_t columnCountFR;  /* Remaining column transfer count (bytes) */
     /* Start column for current block (pixels) */
-    nitf_Uint32 startColumnThisBlock;
-    nitf_Uint32 blockNumber;    /* Current block number */
-    nitf_Uint32 userOff;        /* Offsets into user buffers */
-    nitf_Uint32 bandCnt;        /* Number of bands in the read */
-    nitf_Uint32 bandIdx;        /* Current band index */
-    nitf_Uint32 blockIdx;       /* Current block index */
-    nitf_Uint32 band;           /* Current band */
-    nitf_Uint8 *ioBuffer = NULL; /* I/O buffer */
-    nitf_Uint8 *unpackedBuffer = NULL; /* Unpacked data buffer */
-    nitf_Uint8 blockColIdx;     /* Current block column index */
-    nitf_Uint8 *cacheBuffer = NULL; /* Current cach buffer */
+    uint32_t startColumnThisBlock;
+    uint32_t blockNumber;    /* Current block number */
+    uint32_t userOff;        /* Offsets into user buffers */
+    uint32_t bandCnt;        /* Number of bands in the read */
+    uint32_t bandIdx;        /* Current band index */
+    uint32_t blockIdx;       /* Current block index */
+    uint32_t band;           /* Current band */
+    uint8_t *ioBuffer = NULL; /* I/O buffer */
+    uint8_t *unpackedBuffer = NULL; /* Unpacked data buffer */
+    uint8_t blockColIdx;     /* Current block column index */
+    uint8_t *cacheBuffer = NULL; /* Current cach buffer */
     NITF_BOOL freeCacheBuffer;  /* Sets block control free flag */
     NITF_BOOL freeCacheBufferReset; /* Resets freeCacheBuffer flag */
 
@@ -5471,7 +5471,7 @@ int nitf_ImageIO_setup_P(_nitf_ImageIOControl * cntl, nitf_Error * error)
     /* Allocate I/O and unpacked buffer */
     if (cntl->downSampling)
     {
-        unpackedBuffer = (nitf_Uint8 *) NITF_MALLOC((cntl->rowSkip) *
+        unpackedBuffer = (uint8_t *) NITF_MALLOC((cntl->rowSkip) *
                                                     (nitf->numColumnsPerBlock +
                                                     cntl->columnSkip) *
                                                     bytes * (nitf->numBands));
@@ -5487,7 +5487,7 @@ int nitf_ImageIO_setup_P(_nitf_ImageIOControl * cntl, nitf_Error * error)
         unpackedBuffer = NULL;
 
 
-    ioBuffer = (nitf_Uint8 *) NITF_MALLOC(nitf->numColumnsPerBlock *
+    ioBuffer = (uint8_t *) NITF_MALLOC(nitf->numColumnsPerBlock *
                                           nitf->numBands * bytes);
     if (ioBuffer == NULL)
     {
@@ -5510,7 +5510,7 @@ int nitf_ImageIO_setup_P(_nitf_ImageIOControl * cntl, nitf_Error * error)
         if (nitf->cachedWriteFlag)
         {
             cacheBuffer =
-                (nitf_Uint8 *) NITF_MALLOC(nitf->blockSize);
+                (uint8_t *) NITF_MALLOC(nitf->blockSize);
             if (cacheBuffer == NULL)
             {
                 nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -5661,12 +5661,12 @@ int nitf_ImageIO_done_P(_nitf_ImageIOControl * cntl, nitf_Error * error)
 NITFPRIV(_nitf_ImageIOControl *)
 nitf_ImageIOControl_construct(_nitf_ImageIO * nitf,
                               nitf_IOInterface* io,
-                              nitf_Uint8 ** user,
+                              uint8_t ** user,
                               nitf_SubWindow * subWindow, int reading,
                               nitf_Error * error)
 {
     _nitf_ImageIOControl *cntl; /* The result */
-    nitf_Uint32 bandIdx;
+    uint32_t bandIdx;
 
     cntl =
         (_nitf_ImageIOControl *) NITF_MALLOC(sizeof(_nitf_ImageIOControl));
@@ -5701,7 +5701,7 @@ nitf_ImageIOControl_construct(_nitf_ImageIO * nitf,
     {
         cntl->downSampleIn =
             (NITF_DATA **) NITF_MALLOC(subWindow->numBands *
-                                       sizeof(nitf_Uint8 *));
+                                       sizeof(uint8_t *));
         if (cntl->downSampleIn == NULL)
         {
             nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -5711,7 +5711,7 @@ nitf_ImageIOControl_construct(_nitf_ImageIO * nitf,
         }
         cntl->downSampleOut =
             (NITF_DATA **) NITF_MALLOC(subWindow->numBands *
-                                       sizeof(nitf_Uint8 *));
+                                       sizeof(uint8_t *));
         if (cntl->downSampleOut == NULL)
         {
             nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -5727,8 +5727,8 @@ nitf_ImageIOControl_construct(_nitf_ImageIO * nitf,
     }
 
     cntl->bandSubset =
-        (nitf_Uint32 *) NITF_MALLOC(subWindow->numBands *
-                                    sizeof(nitf_Uint32));
+        (uint32_t *) NITF_MALLOC(subWindow->numBands *
+                                    sizeof(uint32_t));
     if (cntl->bandSubset == NULL)
     {
         nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -5739,10 +5739,10 @@ nitf_ImageIOControl_construct(_nitf_ImageIO * nitf,
 
     if (subWindow->bandList != NULL)
         memmove(cntl->bandSubset, subWindow->bandList,
-                subWindow->numBands * sizeof(nitf_Uint32));
+                subWindow->numBands * sizeof(uint32_t));
     else if (subWindow->numBands == nitf->numBands)
     {
-        nitf_Uint32 i;
+        uint32_t i;
         for (i = 0; i < nitf->numBands; i++)
             cntl->bandSubset[i] = i;
     }
@@ -5791,7 +5791,7 @@ nitf_ImageIOControl_construct(_nitf_ImageIO * nitf,
     {
         /* Full resolution */
         cntl->columnSave =
-            (nitf_Uint8 *) NITF_MALLOC((cntl->numRows) * (cntl->rowSkip) *
+            (uint8_t *) NITF_MALLOC((cntl->numRows) * (cntl->rowSkip) *
                                        (cntl->columnSkip) *
                                        (cntl->numBandSubset) *
                                        (nitf->pixel.bytes));
@@ -5830,8 +5830,8 @@ nitf_ImageIOControl_construct(_nitf_ImageIO * nitf,
 NITFPRIV(void) nitf_ImageIOControl_destruct(_nitf_ImageIOControl ** cntl)
 {
     _nitf_ImageIOBlock *blocks;     /* Block I/Os as a linrar array */
-    nitf_Uint32 i, j;
-    nitf_Uint32 nBlockCols;
+    uint32_t i, j;
+    uint32_t nBlockCols;
 
     /* Actual object */
     _nitf_ImageIOControl *cntlActual;
@@ -5970,13 +5970,13 @@ NITFPRIV(void) nitf_ImageIOReadControl_destruct(_nitf_ImageIOReadControl **
 
 NITFPRIV(int) nitf_ImageIO_bigEndian(void)
 {
-    nitf_Uint8 p8[2] =          /* For big-endian test */
+    uint8_t p8[2] =          /* For big-endian test */
         {
             1, 2
         };
-    nitf_Uint16 *p16;           /* For big-endian test */
+    uint16_t *p16;           /* For big-endian test */
 
-    p16 = (nitf_Uint16 *) p8;
+    p16 = (uint16_t *) p8;
     /* 0x102 => big-endian */
     return ((*p16 == 0x102) ? 1 : 0);
 }
@@ -5985,11 +5985,11 @@ NITFPRIV(int) nitf_ImageIO_checkSubWindow(_nitf_ImageIO * nitf,
                                           nitf_SubWindow * subWindow,
                                           int *all, nitf_Error * error)
 {
-    nitf_Uint32 rowSkip;        /* Row skip factor */
-    nitf_Uint32 colSkip;        /* Column skip factor */
-    nitf_Uint32 bandIdx;        /* Current band index */
-    nitf_Uint32 numRowsFR;      /* Number of rows at full resolution */
-    nitf_Uint32 numColsFR;      /* Number of columns at full resolution */
+    uint32_t rowSkip;        /* Row skip factor */
+    uint32_t colSkip;        /* Column skip factor */
+    uint32_t bandIdx;        /* Current band index */
+    uint32_t numRowsFR;      /* Number of rows at full resolution */
+    uint32_t numColsFR;      /* Number of columns at full resolution */
 
     if (subWindow->downsampler != NULL)
     {
@@ -6193,15 +6193,15 @@ NITFPRIV(int) nitf_ImageIO_mkMasks(nitf_ImageIO * img,
                                    nitf_Error * error)
 {
     _nitf_ImageIO *nitf;        /* Parent _nitf_ImageIO structure */
-    nitf_Uint32 nBlocksTotal;   /* Total number of blocks */
-    nitf_Uint32 maskSizeMemory; /* Block mask size in bytes in memory */
-    nitf_Uint32 maskSizeFile;   /* Block mask size in bytes in the file */
-    nitf_Uint64 maskOffset;     /* Current mask offset */
-    nitf_Uint64 *maskp;         /* Current mask entry */
+    uint32_t nBlocksTotal;   /* Total number of blocks */
+    uint32_t maskSizeMemory; /* Block mask size in bytes in memory */
+    uint32_t maskSizeFile;   /* Block mask size in bytes in the file */
+    uint64_t maskOffset;     /* Current mask offset */
+    uint64_t *maskp;         /* Current mask entry */
     size_t bytesPerBlock;       /* Total bytes in one block */
-    nitf_Uint32 headerOffset;   /* File offset of masks due to mask header */
-    nitf_Uint32 padOffset;      /* File offset of pad mask due to block mask */
-    nitf_Uint32 i;
+    uint32_t headerOffset;   /* File offset of masks due to mask header */
+    uint32_t padOffset;      /* File offset of pad mask due to block mask */
+    uint32_t i;
 
     nitf = (_nitf_ImageIO *) img;
 
@@ -6232,9 +6232,9 @@ NITFPRIV(int) nitf_ImageIO_mkMasks(nitf_ImageIO * img,
 
     /* Allocate Block mask */
 
-    maskSizeFile = nBlocksTotal * sizeof(nitf_Uint32);
-    maskSizeMemory = (nBlocksTotal + 1) * sizeof(nitf_Uint64);
-    nitf->blockMask = (nitf_Uint64 *) NITF_MALLOC(maskSizeMemory);
+    maskSizeFile = nBlocksTotal * sizeof(uint32_t);
+    maskSizeMemory = (nBlocksTotal + 1) * sizeof(uint64_t);
+    nitf->blockMask = (uint64_t *) NITF_MALLOC(maskSizeMemory);
 
     if (nitf->blockMask == NULL)
     {
@@ -6263,10 +6263,10 @@ NITFPRIV(int) nitf_ImageIO_mkMasks(nitf_ImageIO * img,
          * you must allocate a 32-bit array for read and copy after
          * byte-swapping
          */
-        nitf_Uint32 *fileMask;   /* Buffer to hold file mask */
-        nitf_Uint32 i;
+        uint32_t *fileMask;   /* Buffer to hold file mask */
+        uint32_t i;
 
-        fileMask = (nitf_Uint32 *) NITF_MALLOC(maskSizeFile);
+        fileMask = (uint32_t *) NITF_MALLOC(maskSizeFile);
         if (fileMask == NULL)
         {
             nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -6280,7 +6280,7 @@ NITFPRIV(int) nitf_ImageIO_mkMasks(nitf_ImageIO * img,
 
         if (!nitf_ImageIO_readFromFile(io,
                                        nitf->imageBase + headerOffset,
-                                       (nitf_Uint8 *) fileMask,
+                                       (uint8_t *) fileMask,
                                        maskSizeFile, error))
         {
             NITF_FREE(fileMask);
@@ -6289,7 +6289,7 @@ NITFPRIV(int) nitf_ImageIO_mkMasks(nitf_ImageIO * img,
 
         /* The offsets are stored as big-endian binary */
         if (!nitf_ImageIO_bigEndian())
-            nitf_ImageIO_swapOnly_4((nitf_Uint8 *) fileMask, nBlocksTotal, 0);
+            nitf_ImageIO_swapOnly_4((uint8_t *) fileMask, nBlocksTotal, 0);
 
         for (i = 0;i < nBlocksTotal;i++)
             nitf->blockMask[i] = fileMask[i];
@@ -6305,7 +6305,7 @@ NITFPRIV(int) nitf_ImageIO_mkMasks(nitf_ImageIO * img,
     if (nitf->padMask != NULL)  /* Should not happen */
         return NITF_SUCCESS;
 
-    nitf->padMask = (nitf_Uint64 *) NITF_MALLOC(maskSizeMemory);
+    nitf->padMask = (uint64_t *) NITF_MALLOC(maskSizeMemory);
     if (nitf->padMask == NULL)
     {
         nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -6331,10 +6331,10 @@ NITFPRIV(int) nitf_ImageIO_mkMasks(nitf_ImageIO * img,
          * you must allocate a 32-bit array for read and copy after
          * byte-swapping
          */
-        nitf_Uint32 *fileMask;   /* Buffer to hold file mask */
-        nitf_Uint32 i;
+        uint32_t *fileMask;   /* Buffer to hold file mask */
+        uint32_t i;
 
-        fileMask = (nitf_Uint32 *) NITF_MALLOC(maskSizeFile);
+        fileMask = (uint32_t *) NITF_MALLOC(maskSizeFile);
         if (fileMask == NULL)
         {
             nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -6346,7 +6346,7 @@ NITFPRIV(int) nitf_ImageIO_mkMasks(nitf_ImageIO * img,
         if (!nitf_ImageIO_readFromFile(io,
                                        nitf->imageBase + headerOffset +
                                        padOffset,
-                                       (nitf_Uint8 *) fileMask,
+                                       (uint8_t *) fileMask,
                                        maskSizeFile, error))
         {
             NITF_FREE(fileMask);
@@ -6355,7 +6355,7 @@ NITFPRIV(int) nitf_ImageIO_mkMasks(nitf_ImageIO * img,
 
         /* The offsets are stored as big-endian binary */
         if (nitf_ImageIO_bigEndian())
-            nitf_ImageIO_swapOnly_4((nitf_Uint8 *) fileMask, nBlocksTotal, 0);
+            nitf_ImageIO_swapOnly_4((uint8_t *) fileMask, nBlocksTotal, 0);
 
         for (i = 0; i < nBlocksTotal;i++)
             nitf->padMask[i] = fileMask[i];
@@ -6368,14 +6368,14 @@ NITFPRIV(int) nitf_ImageIO_mkMasks(nitf_ImageIO * img,
 
 /*========================= Pad Pixel Scan Functions ========================*/
 
-NITF_IMAGE_IO_PAD_SCANNER(_nitf_Image_IO_pad_scan_1, nitf_Uint8)
-NITF_IMAGE_IO_PAD_SCANNER(_nitf_Image_IO_pad_scan_2, nitf_Uint16)
-NITF_IMAGE_IO_PAD_SCANNER(_nitf_Image_IO_pad_scan_4, nitf_Uint32)
-NITF_IMAGE_IO_PAD_SCANNER(_nitf_Image_IO_pad_scan_8, nitf_Uint64)
+NITF_IMAGE_IO_PAD_SCANNER(_nitf_Image_IO_pad_scan_1, uint8_t)
+NITF_IMAGE_IO_PAD_SCANNER(_nitf_Image_IO_pad_scan_2, uint16_t)
+NITF_IMAGE_IO_PAD_SCANNER(_nitf_Image_IO_pad_scan_4, uint32_t)
+NITF_IMAGE_IO_PAD_SCANNER(_nitf_Image_IO_pad_scan_8, uint64_t)
 
 NITFPRIV(int) nitf_ImageIO_initMaskHeader(_nitf_ImageIO * nitf,
                                           nitf_IOInterface* io,
-                                          nitf_Uint32 blockCount,
+                                          uint32_t blockCount,
                                           int reading,
                                           nitf_Error * error)
 {
@@ -6436,11 +6436,11 @@ NITFPRIV(int) nitf_ImageIO_initMaskHeader(_nitf_ImageIO * nitf,
 
         if (maskHeader->blockRecordLength != 0)
             maskHeader->imageDataOffset +=
-                blockCount * sizeof(nitf_Uint32);
+                blockCount * sizeof(uint32_t);
 
         if (maskHeader->padRecordLength != 0)
             maskHeader->imageDataOffset +=
-                blockCount * sizeof(nitf_Uint32);
+                blockCount * sizeof(uint32_t);
 
         /* Set the pad scanner function based on the pad pixel length */
         switch (maskHeader->padPixelValueLength)
@@ -6481,8 +6481,8 @@ NITFPRIV(int) nitf_ImageIO_readMaskHeader(_nitf_ImageIO * nitf,
 {
     /* The structure to initialize */
     _nitf_ImageIO_MaskHeader *maskHeader;
-    nitf_Uint8 buffer[NITF_IMAGE_IO_MASK_HEADER_LEN];
-    nitf_Uint8 *bp;             /* Points into buffer */
+    uint8_t buffer[NITF_IMAGE_IO_MASK_HEADER_LEN];
+    uint8_t *bp;             /* Points into buffer */
 
     maskHeader = &(nitf->maskHeader);
 
@@ -6494,13 +6494,13 @@ NITFPRIV(int) nitf_ImageIO_readMaskHeader(_nitf_ImageIO * nitf,
         return NITF_FAILURE;
 
     bp = buffer;
-    memcpy(&(maskHeader->imageDataOffset), bp, sizeof(nitf_Uint32));
+    memcpy(&(maskHeader->imageDataOffset), bp, sizeof(uint32_t));
     bp += 4;
-    memcpy(&(maskHeader->blockRecordLength), bp, sizeof(nitf_Uint16));
+    memcpy(&(maskHeader->blockRecordLength), bp, sizeof(uint16_t));
     bp += 2;
-    memcpy(&(maskHeader->padRecordLength), bp, sizeof(nitf_Uint16));
+    memcpy(&(maskHeader->padRecordLength), bp, sizeof(uint16_t));
     bp += 2;
-    memcpy(&(maskHeader->padPixelValueLength), bp, sizeof(nitf_Uint16));
+    memcpy(&(maskHeader->padPixelValueLength), bp, sizeof(uint16_t));
 
     /*      Byte swap structure  if needed */
 
@@ -6541,10 +6541,10 @@ NITFPRIV(int) nitf_ImageIO_writeMasks(_nitf_ImageIO * nitf,
 {
     /* Copy of the structure to write */
     _nitf_ImageIO_MaskHeader maskHeader;
-    nitf_Uint8 buffer[NITF_IMAGE_IO_MASK_HEADER_LEN];
-    nitf_Uint16 padCodeLength;  /* Pad code length for header */
-    nitf_Uint64 maskOffset;     /* Offset of block or pad mask */
-    nitf_Uint32 maskSizeFile;   /* Block mask size in bytes in the file */
+    uint8_t buffer[NITF_IMAGE_IO_MASK_HEADER_LEN];
+    uint16_t padCodeLength;  /* Pad code length for header */
+    uint64_t maskOffset;     /* Offset of block or pad mask */
+    uint32_t maskSizeFile;   /* Block mask size in bytes in the file */
 
     /* Do not write anything if the IC is not a mask type */
 
@@ -6573,7 +6573,7 @@ NITFPRIV(int) nitf_ImageIO_writeMasks(_nitf_ImageIO * nitf,
     if (!nitf_ImageIO_bigEndian())
     {
         nitf_ImageIO_swapMaskHeader(&maskHeader);
-        nitf_Utils_byteSwap((nitf_Uint8*)&(padCodeLength), 2);
+        nitf_Utils_byteSwap((uint8_t*)&(padCodeLength), 2);
     }
 
         /* Format and write the header buffer */
@@ -6614,11 +6614,11 @@ NITFPRIV(int) nitf_ImageIO_writeMasks(_nitf_ImageIO * nitf,
               Because the in memory offset is 64-bit and the file is 32-bit
               you must allocate a 32-bit array and byte-swap after copying
         */
-        nitf_Uint32 *fileMask;   /* Buffer to hold file mask */
-        nitf_Uint32 i;
+        uint32_t *fileMask;   /* Buffer to hold file mask */
+        uint32_t i;
 
-        maskSizeFile = nitf->nBlocksTotal * sizeof(nitf_Uint32);
-        fileMask = (nitf_Uint32 *) NITF_MALLOC(maskSizeFile);
+        maskSizeFile = nitf->nBlocksTotal * sizeof(uint32_t);
+        fileMask = (uint32_t *) NITF_MALLOC(maskSizeFile);
         if (fileMask == NULL)
         {
             nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -6639,19 +6639,19 @@ NITFPRIV(int) nitf_ImageIO_writeMasks(_nitf_ImageIO * nitf,
             }
 
         if (!nitf_ImageIO_bigEndian())
-            nitf_ImageIO_swapOnly_4((nitf_Uint8 *) fileMask,
+            nitf_ImageIO_swapOnly_4((uint8_t *) fileMask,
                                     nitf->nBlocksTotal, 0);
 
         if (!nitf_ImageIO_writeToFile(io, maskOffset,
-                                      (nitf_Uint8 *) fileMask,
+                                      (uint8_t *) fileMask,
                                       (size_t)nitf->nBlocksTotal *
-                                      sizeof(nitf_Uint32), error))
+                                      sizeof(uint32_t), error))
         {
             NITF_FREE(fileMask);
             return NITF_FAILURE;
         }
 
-        maskOffset += nitf->nBlocksTotal * sizeof(nitf_Uint32);
+        maskOffset += nitf->nBlocksTotal * sizeof(uint32_t);
         NITF_FREE(fileMask);
     }
     /*
@@ -6664,11 +6664,11 @@ NITFPRIV(int) nitf_ImageIO_writeMasks(_nitf_ImageIO * nitf,
           Because the in memory offset is 64-bit and the file is 32-bit
           you must allocate a 32-bit array and byte-swap after copying
         */
-        nitf_Uint32 *fileMask;   /* Buffer to hold file mask */
-        nitf_Uint32 i;
+        uint32_t *fileMask;   /* Buffer to hold file mask */
+        uint32_t i;
 
-        maskSizeFile = nitf->nBlocksTotal * sizeof(nitf_Uint32);
-        fileMask = (nitf_Uint32 *) NITF_MALLOC(maskSizeFile);
+        maskSizeFile = nitf->nBlocksTotal * sizeof(uint32_t);
+        fileMask = (uint32_t *) NITF_MALLOC(maskSizeFile);
         if (fileMask == NULL)
         {
             nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -6689,20 +6689,20 @@ NITFPRIV(int) nitf_ImageIO_writeMasks(_nitf_ImageIO * nitf,
             }
 
         if (!nitf_ImageIO_bigEndian())
-            nitf_ImageIO_swapOnly_4((nitf_Uint8 *) fileMask,
+            nitf_ImageIO_swapOnly_4((uint8_t *) fileMask,
                                     nitf->nBlocksTotal, 0);
 
         if (!nitf_ImageIO_writeToFile(io, maskOffset,
-                                      (nitf_Uint8 *) fileMask,
+                                      (uint8_t *) fileMask,
                                       (size_t)nitf->nBlocksTotal *
-                                      sizeof(nitf_Uint32), error))
+                                      sizeof(uint32_t), error))
         {
             NITF_FREE(fileMask);
             return NITF_FAILURE;
         }
 
         NITF_FREE(fileMask);
-        maskOffset += nitf->nBlocksTotal * sizeof(nitf_Uint32);
+        maskOffset += nitf->nBlocksTotal * sizeof(uint32_t);
     }
     return NITF_SUCCESS;
 }
@@ -6711,10 +6711,10 @@ NITFPRIV(int) nitf_ImageIO_writeMasks(_nitf_ImageIO * nitf,
 NITFPRIV(void) nitf_ImageIO_swapMaskHeader(_nitf_ImageIO_MaskHeader *
         header)
 {
-    nitf_Utils_byteSwap((nitf_Uint8*)&(header->imageDataOffset), 4);
-    nitf_Utils_byteSwap((nitf_Uint8*)&(header->blockRecordLength), 2);
-    nitf_Utils_byteSwap((nitf_Uint8*)&(header->padRecordLength), 2);
-    nitf_Utils_byteSwap((nitf_Uint8*)&(header->padPixelValueLength), 2);
+    nitf_Utils_byteSwap((uint8_t*)&(header->imageDataOffset), 4);
+    nitf_Utils_byteSwap((uint8_t*)&(header->blockRecordLength), 2);
+    nitf_Utils_byteSwap((uint8_t*)&(header->padRecordLength), 2);
+    nitf_Utils_byteSwap((uint8_t*)&(header->padPixelValueLength), 2);
 
     return;
 }
@@ -6758,12 +6758,12 @@ NITFPRIV(int) nitf_ImageIO_readRequest(_nitf_ImageIOControl * cntl,
                                        nitf_Error * error)
 {
     _nitf_ImageIO *nitf;       /* Parent _nitf_ImageIO object */
-    nitf_Uint32 nBlockCols;    /* Number of block columns */
-    nitf_Uint32 numRows;       /* Number of rows in the requested sub-window */
-    nitf_Uint32 numBands;      /* Number of bands */
-    nitf_Uint32 col;           /* Block column index */
-    nitf_Uint32 row;           /* Current row in sub-window */
-    nitf_Uint32 band;          /* Current band in sub-window */
+    uint32_t nBlockCols;    /* Number of block columns */
+    uint32_t numRows;       /* Number of rows in the requested sub-window */
+    uint32_t numBands;      /* Number of bands */
+    uint32_t col;           /* Block column index */
+    uint32_t row;           /* Current row in sub-window */
+    uint32_t band;          /* Current band in sub-window */
     _nitf_ImageIOBlock *blockIO; /* The current block IO structure */
 
     nitf = cntl->nitf;
@@ -6841,18 +6841,18 @@ NITFPRIV(int) nitf_ImageIO_readRequestDownSample(_nitf_ImageIOControl *
                                                  nitf_Error * error)
 {
     _nitf_ImageIO *nitf; /* Parent _nitf_ImageIO object */
-    nitf_Uint32 nBlockCols;   /* Number of block columns */
-    nitf_Uint32 numRowsFull; /* Number of rows to read in full res sub-window */
-    nitf_Uint32 numBands;     /* Number of bands */
-    nitf_Uint32 col;          /* Block column index */
-    nitf_Uint32 row;          /* Current row in sub-window */
-    nitf_Uint32 band;         /* Current band in sub-window */
+    uint32_t nBlockCols;   /* Number of block columns */
+    uint32_t numRowsFull; /* Number of rows to read in full res sub-window */
+    uint32_t numBands;     /* Number of bands */
+    uint32_t col;          /* Block column index */
+    uint32_t row;          /* Current row in sub-window */
+    uint32_t band;         /* Current band in sub-window */
     _nitf_ImageIOBlock *blockIO; /* The current  block IO structure */
-    nitf_Uint8 *columnSave;   /* Column save buffer ptr,current block column */
+    uint8_t *columnSave;   /* Column save buffer ptr,current block column */
     NITF_BOOL noUserInc;      /* Do not increment user buffer pointer if TRUE */
-    nitf_Uint32 bytes;        /* Pixel size in bytes */
-    nitf_Uint32 rowSkipCount; /* Number of rows since the last row skip */
-    nitf_Uint32 numColsDR;    /* Number of columns, down-sample resolution */
+    uint32_t bytes;        /* Pixel size in bytes */
+    uint32_t rowSkipCount; /* Number of rows since the last row skip */
+    uint32_t numColsDR;    /* Number of columns, down-sample resolution */
 
     nitf = cntl->nitf;
 
@@ -6989,7 +6989,7 @@ NITFPRIV(int) nitf_ImageIO_readRequestDownSample(_nitf_ImageIOControl *
             if (rowSkipCount == (cntl->rowSkip - 1))
             {
                 /* For down-sampler call */
-                nitf_Uint32 colsInLastWindow;
+                uint32_t colsInLastWindow;
 
                 /* Partial neighborhoods happen in last block */
                 if (col == (nBlockCols - 1))
@@ -7025,10 +7025,10 @@ NITFPRIV(int) nitf_ImageIO_readRequestDownSample(_nitf_ImageIOControl *
 
         if (rowSkipCount != 0)
         {
-            nitf_Uint32 padRows; /* Number of pad rows */
+            uint32_t padRows; /* Number of pad rows */
             /* For down-sampler call */
-            nitf_Uint32 colsInLastWindow;
-            nitf_Uint32 i;
+            uint32_t colsInLastWindow;
+            uint32_t i;
 
             if (cntl->padBuffer == NULL)
                 if (!nitf_ImageIO_allocatePad(cntl, error))
@@ -7086,13 +7086,13 @@ NITFPRIV(int) nitf_ImageIO_allocatePad(_nitf_ImageIOControl * cntl,
                                        nitf_Error * error)
 {
     _nitf_ImageIO *nitf;        /* NITF block structure */
-    nitf_Uint8 *padBufp1;       /* Pad buffer pointer 1 */
-    nitf_Uint8 *padBufp2;       /* Pad buffer pointer 2 */
-    nitf_Uint32 i;
+    uint8_t *padBufp1;       /* Pad buffer pointer 1 */
+    uint8_t *padBufp2;       /* Pad buffer pointer 2 */
+    uint32_t i;
 
     nitf = cntl->nitf;
 
-    cntl->padBuffer = (nitf_Uint8 *) NITF_MALLOC(cntl->padBufferSize);
+    cntl->padBuffer = (uint8_t *) NITF_MALLOC(cntl->padBufferSize);
     if (cntl->padBuffer == NULL)
     {
         nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -7130,8 +7130,8 @@ NITFPRIV(int) nitf_ImageIO_readPad(_nitf_ImageIOBlock * blockIO,
 
 
 NITFPRIV(int) nitf_ImageIO_readFromFile(nitf_IOInterface* io,
-                                        nitf_Uint64 fileOffset,
-                                        nitf_Uint8 * buffer,
+                                        uint64_t fileOffset,
+                                        uint8_t * buffer,
                                         size_t count,
                                         nitf_Error * error)
 {
@@ -7153,8 +7153,8 @@ NITFPRIV(int) nitf_ImageIO_readFromFile(nitf_IOInterface* io,
 }
 
 NITFPRIV(int) nitf_ImageIO_writeToFile(nitf_IOInterface* io,
-                                       nitf_Uint64 fileOffset,
-                                       const nitf_Uint8 * buffer,
+                                       uint64_t fileOffset,
+                                       const uint8_t * buffer,
                                        size_t count,
                                        nitf_Error * error)
 {
@@ -7176,15 +7176,15 @@ NITFPRIV(int) nitf_ImageIO_writeToFile(nitf_IOInterface* io,
 NITFPRIV(int) nitf_ImageIO_writeToBlock(_nitf_ImageIOBlock * blockIO,
                                         nitf_IOInterface* io,
                                         size_t blockOffset,
-                                        const nitf_Uint8 * buffer,
+                                        const uint8_t * buffer,
                                         size_t count,
                                         nitf_Error * error)
 {
     _nitf_ImageIO *nitf = ((_nitf_ImageIOControl *)(blockIO->cntl))->nitf; /* Associated image I/O object */
     _nitf_ImageIOBlockCacheControl *blockCntl; /* Associated block control */
-    nitf_Uint64 fileOffset;                 /* Offset in file for write */
+    uint64_t fileOffset;                 /* Offset in file for write */
     _NITF_IMAGE_IO_PAD_SCAN_FUNC scanner;   /* Pad scanning function */
-    const nitf_Int64 nBlocks = nitf->nBlocksTotal;
+    const int64_t nBlocks = nitf->nBlocksTotal;
     const NITF_BOOL lastBlock = (blockIO->number == (nBlocks - 1));
     blockCntl = &(blockIO->blockControl);
     scanner = nitf->padScanner;
@@ -7192,7 +7192,7 @@ NITFPRIV(int) nitf_ImageIO_writeToBlock(_nitf_ImageIOBlock * blockIO,
     if (blockCntl->block == NULL)
     {
         blockCntl->block =
-            (nitf_Uint8 *) NITF_MALLOC(nitf->blockSize);
+            (uint8_t *) NITF_MALLOC(nitf->blockSize);
         if (blockCntl->block == NULL)
         {
             nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -7263,12 +7263,12 @@ NITFPRIV(int) nitf_ImageIO_writeToBlock(_nitf_ImageIOBlock * blockIO,
                 if (nitf->blockingMode == NITF_IMAGE_IO_BLOCKING_MODE_S)
                 {
 
-                    nitf_Uint32 nBlocksPerBand;  /* Number of blocks per band */
-                    nitf_Uint32 nBlocksTotal;    /* Number of blocks total */
-                    nitf_Uint32 numBands;      /* Number of bands */
-                    nitf_Uint32 fullNumber;  /* Block number if full mask */
-                    nitf_Uint32 srcIdx;      /* Index of copy source */
-                    nitf_Uint32 dstIdx;      /* Index of copy destination */
+                    uint32_t nBlocksPerBand;  /* Number of blocks per band */
+                    uint32_t nBlocksTotal;    /* Number of blocks total */
+                    uint32_t numBands;      /* Number of bands */
+                    uint32_t fullNumber;  /* Block number if full mask */
+                    uint32_t srcIdx;      /* Index of copy source */
+                    uint32_t dstIdx;      /* Index of copy destination */
 
                     nBlocksPerBand = (nitf->nBlocksPerRow) * (nitf->nBlocksPerColumn);
                     nBlocksTotal = nitf->nBlocksTotal;
@@ -7295,12 +7295,12 @@ NITFPRIV(int) nitf_ImageIO_writeToBlock(_nitf_ImageIOBlock * blockIO,
                     memmove(&(blockIO->blockMask[blockIO->number+1]),
                             &(blockIO->blockMask[blockIO->number]),
                             (nitf->nBlocksPerRow * nitf->nBlocksPerColumn -
-                             blockIO->number) * sizeof(nitf_Uint64));
+                             blockIO->number) * sizeof(uint64_t));
 #endif
                 memmove(&(blockIO->blockMask[blockIO->number+1]),
                         &(blockIO->blockMask[blockIO->number]),
                         (nitf->nBlocksPerRow * nitf->nBlocksPerColumn -
-                         blockIO->number) * sizeof(nitf_Uint64));
+                         blockIO->number) * sizeof(uint64_t));
 
                 blockIO->blockMask[blockIO->number] = NITF_IMAGE_IO_NO_BLOCK;
                 blockIO->padMask[blockIO->number] = NITF_IMAGE_IO_NO_BLOCK;
@@ -7410,7 +7410,7 @@ int nitf_ImageIO_cachedReader(_nitf_ImageIOBlock * blockIO,
 {
     _nitf_ImageIO *nitf;        /* Associated ImageIO object */
     _nitf_ImageIOControl *cntl; /* Associated control object */
-    nitf_Uint64 blockSize;
+    uint64_t blockSize;
 
     cntl = blockIO->cntl;
     nitf = cntl->nitf;
@@ -7437,7 +7437,7 @@ int nitf_ImageIO_cachedReader(_nitf_ImageIOBlock * blockIO,
                 if (nitf->blockControl.block == NULL)
                 {
                     nitf->blockControl.block =
-                        (nitf_Uint8 *) NITF_MALLOC(nitf->blockSize);
+                        (uint8_t *) NITF_MALLOC(nitf->blockSize);
                     if (nitf->blockControl.block == NULL)
                     {
                         nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -7501,7 +7501,7 @@ int nitf_ImageIO_cachedReader(_nitf_ImageIOBlock * blockIO,
 /*========================= Start Direct Block Reading  ================================*/
 NITFPROT(NRT_BOOL) nitf_ImageIO_setupDirectBlockRead(nitf_ImageIO *nitf,
                                                      nitf_IOInterface *io,
-                                                     nitf_Uint32 numBands,
+                                                     uint32_t numBands,
                                                      nitf_Error *error)
 {
     _nitf_ImageIO *nitfI;
@@ -7535,14 +7535,14 @@ NITFPROT(NRT_BOOL) nitf_ImageIO_setupDirectBlockRead(nitf_ImageIO *nitf,
     return NITF_SUCCESS;
 }
 
-NITFPROT(nitf_Uint8*) nitf_ImageIO_readBlockDirect(nitf_ImageIO* nitf,
+NITFPROT(uint8_t*) nitf_ImageIO_readBlockDirect(nitf_ImageIO* nitf,
                                                    nitf_IOInterface* io,
-                                                   nitf_Uint32 blockNumber,
-                                                   nitf_Uint64* blockSize,
+                                                   uint32_t blockNumber,
+                                                   uint64_t* blockSize,
                                                    nitf_Error * error)
 {
     _nitf_ImageIO *nitfI;        /* Associated ImageIO object */
-    nitf_Uint64 imageDataOffset;
+    uint64_t imageDataOffset;
 
     nitfI = (_nitf_ImageIO*) nitf;
     imageDataOffset = nitfI->blockMask[blockNumber];
@@ -7557,7 +7557,7 @@ NITFPROT(nitf_Uint8*) nitf_ImageIO_readBlockDirect(nitf_ImageIO* nitf,
             if (nitfI->blockControl.block == NULL)
             {
                 nitfI->blockControl.block =
-                    (nitf_Uint8 *) NITF_MALLOC(nitfI->blockSize);
+                    (uint8_t *) NITF_MALLOC(nitfI->blockSize);
                 if (nitfI->blockControl.block == NULL)
                 {
                     nitf_Error_initf(error, NITF_CTXT, NITF_ERR_MEMORY,
@@ -7618,12 +7618,12 @@ NITFPROT(nitf_Uint8*) nitf_ImageIO_readBlockDirect(nitf_ImageIO* nitf,
 NITFPROT(NRT_BOOL) nitf_ImageIO_writeBlockDirect(nitf_ImageIO* object,
                                                  nitf_IOInterface* io,
                                                  const void* buffer,
-                                                 nitf_Uint32 blockNumber,
+                                                 uint32_t blockNumber,
                                                  nitf_Error * error)
 {
     _nitf_ImageIO *nitf;        /* Parent _nitf_ImageIO object */
-    nitf_Uint64 fileOffset;     /* Offset in filw for write */
-    nitf_Uint64 imageDataOffset;
+    uint64_t fileOffset;     /* Offset in filw for write */
+    uint64_t imageDataOffset;
     /* Internal representation */
     _nitf_ImageIOWriteControl *cntl;
     /* Associated IO control object */
@@ -7728,9 +7728,9 @@ int nitf_ImageIO_uncachedWriter(_nitf_ImageIOBlock * blockIO,
         && (blockIO->currentRow >= (nitf->numRows - 1)))
     {
         size_t writeCount;      /* Amount to write each row */
-        nitf_Uint64 offset;     /* File offset for each write */
+        uint64_t offset;     /* File offset for each write */
         size_t increment;       /* Byte increment between writes */
-        nitf_Uint32 rowIdx;     /* Rwo counter */
+        uint32_t rowIdx;     /* Rwo counter */
 
         if (cntl->padBuffer == NULL)
             if (!nitf_ImageIO_allocatePad(cntl, error))
@@ -7760,7 +7760,7 @@ int nitf_ImageIO_cachedWriter(_nitf_ImageIOBlock * blockIO,
 {
     _nitf_ImageIOControl *cntl; /* Associated image I/O control object */
     _nitf_ImageIO *nitf;        /* Associated image I/O object */
-    nitf_Uint32 i;
+    uint32_t i;
 
     cntl = blockIO->cntl;
     nitf = cntl->nitf;
@@ -7828,17 +7828,17 @@ void nitf_ImageIO_setDefaultParameters(_nitf_ImageIO * object)
 }
 
 
-void nitf_ImageIO_unformatExtend_1(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatExtend_1(uint8_t * buffer,
                                    size_t count,
-                                   nitf_Uint32 shiftCount)
+                                   uint32_t shiftCount)
 {
-    nitf_Int8 shift;            /* Shift count */
-    nitf_Int8 *bp8;             /* Buffer pointer, 8 bit */
-    nitf_Int16 tmp8;            /* Temp value, 8 bit */
+    int8_t shift;            /* Shift count */
+    int8_t *bp8;             /* Buffer pointer, 8 bit */
+    int16_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
-    shift = (nitf_Int8) shiftCount;
-    bp8 = (nitf_Int8 *) buffer;
+    shift = (int8_t) shiftCount;
+    bp8 = (int8_t *) buffer;
     for (i = 0; i < count; i++)
     {
         tmp8 = *bp8 << shift;
@@ -7849,17 +7849,17 @@ void nitf_ImageIO_unformatExtend_1(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_unformatExtend_2(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatExtend_2(uint8_t * buffer,
                                    size_t count,
-                                   nitf_Uint32 shiftCount)
+                                   uint32_t shiftCount)
 {
-    nitf_Int16 shift;           /* Shift count */
-    nitf_Int16 *bp16;           /* Buffer pointer, 16 bit */
-    nitf_Int16 tmp16;           /* Temp value, 16 bit */
+    int16_t shift;           /* Shift count */
+    int16_t *bp16;           /* Buffer pointer, 16 bit */
+    int16_t tmp16;           /* Temp value, 16 bit */
     size_t i;
 
-    shift = (nitf_Int16) shiftCount;
-    bp16 = (nitf_Int16 *) buffer;
+    shift = (int16_t) shiftCount;
+    bp16 = (int16_t *) buffer;
     for (i = 0; i < count; i++)
     {
         tmp16 = *bp16 << shift;
@@ -7870,17 +7870,17 @@ void nitf_ImageIO_unformatExtend_2(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_unformatExtend_4(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatExtend_4(uint8_t * buffer,
                                    size_t count,
-                                   nitf_Uint32 shiftCount)
+                                   uint32_t shiftCount)
 {
-    nitf_Int32 shift;           /* Shift count */
-    nitf_Int32 *bp32;           /* Buffer pointer, 32 bit */
-    nitf_Int32 tmp32;           /* Temp value, 32 bit */
+    int32_t shift;           /* Shift count */
+    int32_t *bp32;           /* Buffer pointer, 32 bit */
+    int32_t tmp32;           /* Temp value, 32 bit */
     size_t i;
 
-    shift = (nitf_Int32) shiftCount;
-    bp32 = (nitf_Int32 *) buffer;
+    shift = (int32_t) shiftCount;
+    bp32 = (int32_t *) buffer;
     for (i = 0; i < count; i++)
     {
         tmp32 = *bp32 << shift;
@@ -7893,17 +7893,17 @@ void nitf_ImageIO_unformatExtend_4(nitf_Uint8 * buffer,
 
 /* Uses 64 bit types */
 
-void nitf_ImageIO_unformatExtend_8(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatExtend_8(uint8_t * buffer,
                                    size_t count,
-                                   nitf_Uint32 shiftCount)
+                                   uint32_t shiftCount)
 {
-    nitf_Int64 shift;           /* Shift count */
-    nitf_Int64 *bp64;           /* Buffer pointer, 64 bit */
-    nitf_Int64 tmp64;           /* Temp value, 64 bit */
+    int64_t shift;           /* Shift count */
+    int64_t *bp64;           /* Buffer pointer, 64 bit */
+    int64_t tmp64;           /* Temp value, 64 bit */
     size_t i;
 
-    shift = (nitf_Int64) shiftCount;
-    bp64 = (nitf_Int64 *) buffer;
+    shift = (int64_t) shiftCount;
+    bp64 = (int64_t *) buffer;
     for (i = 0; i < count; i++)
     {
         tmp64 = *bp64 << shift;
@@ -7916,16 +7916,16 @@ void nitf_ImageIO_unformatExtend_8(nitf_Uint8 * buffer,
 
 /*========================= nitf_ImageIO_unformatShift_* =====================*/
 
-void nitf_ImageIO_unformatShift_1(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatShift_1(uint8_t * buffer,
                                   size_t count,
-                                  nitf_Uint32 shiftCount)
+                                  uint32_t shiftCount)
 {
-    nitf_Int8 shift;            /* Shift count */
-    nitf_Int8 *bp8;             /* Buffer pointer, 8 bit */
+    int8_t shift;            /* Shift count */
+    int8_t *bp8;             /* Buffer pointer, 8 bit */
     size_t i;
 
-    shift = (nitf_Int8) shiftCount;
-    bp8 = (nitf_Int8 *) buffer;
+    shift = (int8_t) shiftCount;
+    bp8 = (int8_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp8++) >>= shift;
 
@@ -7933,16 +7933,16 @@ void nitf_ImageIO_unformatShift_1(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_unformatShift_2(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatShift_2(uint8_t * buffer,
                                   size_t count,
-                                  nitf_Uint32 shiftCount)
+                                  uint32_t shiftCount)
 {
-    nitf_Int16 shift;           /* Shift count */
-    nitf_Int16 *bp16;           /* Buffer pointer, 16 bit */
+    int16_t shift;           /* Shift count */
+    int16_t *bp16;           /* Buffer pointer, 16 bit */
     size_t i;
 
-    shift = (nitf_Int16) shiftCount;
-    bp16 = (nitf_Int16 *) buffer;
+    shift = (int16_t) shiftCount;
+    bp16 = (int16_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp16++) >>= shift;
 
@@ -7950,16 +7950,16 @@ void nitf_ImageIO_unformatShift_2(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_unformatShift_4(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatShift_4(uint8_t * buffer,
                                   size_t count,
-                                  nitf_Uint32 shiftCount)
+                                  uint32_t shiftCount)
 {
-    nitf_Int32 shift;           /* Shift count */
-    nitf_Int32 *bp32;           /* Buffer pointer, 32 bit */
+    int32_t shift;           /* Shift count */
+    int32_t *bp32;           /* Buffer pointer, 32 bit */
     size_t i;
 
-    shift = (nitf_Int32) shiftCount;
-    bp32 = (nitf_Int32 *) buffer;
+    shift = (int32_t) shiftCount;
+    bp32 = (int32_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp32++) >>= shift;
 
@@ -7969,32 +7969,32 @@ void nitf_ImageIO_unformatShift_4(nitf_Uint8 * buffer,
 
 /* Uses 64 bit types */
 
-void nitf_ImageIO_unformatShift_8(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatShift_8(uint8_t * buffer,
                                   size_t count,
-                                  nitf_Uint32 shiftCount)
+                                  uint32_t shiftCount)
 {
-    nitf_Int64 shift;           /* Shift count */
-    nitf_Int64 *bp64;           /* Buffer pointer, 64 bit */
+    int64_t shift;           /* Shift count */
+    int64_t *bp64;           /* Buffer pointer, 64 bit */
     size_t i;
 
-    shift = (nitf_Int64) shiftCount;
-    bp64 = (nitf_Int64 *) buffer;
+    shift = (int64_t) shiftCount;
+    bp64 = (int64_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp64++) >>= shift;
 
     return;
 }
 
-void nitf_ImageIO_unformatUShift_1(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatUShift_1(uint8_t * buffer,
                                    size_t count,
-                                   nitf_Uint32 shiftCount)
+                                   uint32_t shiftCount)
 {
-    nitf_Uint8 shift;           /* Shift count */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
+    uint8_t shift;           /* Shift count */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
     size_t i;
 
-    shift = (nitf_Uint8) shiftCount;
-    bp8 = (nitf_Uint8 *) buffer;
+    shift = (uint8_t) shiftCount;
+    bp8 = (uint8_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp8++) >>= shift;
 
@@ -8002,16 +8002,16 @@ void nitf_ImageIO_unformatUShift_1(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_unformatUShift_2(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatUShift_2(uint8_t * buffer,
                                    size_t count,
-                                   nitf_Uint32 shiftCount)
+                                   uint32_t shiftCount)
 {
-    nitf_Uint16 shift;          /* Shift count */
-    nitf_Uint16 *bp16;          /* Buffer pointer, 16 bit */
+    uint16_t shift;          /* Shift count */
+    uint16_t *bp16;          /* Buffer pointer, 16 bit */
     size_t i;
 
-    shift = (nitf_Uint16) shiftCount;
-    bp16 = (nitf_Uint16 *) buffer;
+    shift = (uint16_t) shiftCount;
+    bp16 = (uint16_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp16++) >>= shift;
 
@@ -8019,16 +8019,16 @@ void nitf_ImageIO_unformatUShift_2(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_unformatUShift_4(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatUShift_4(uint8_t * buffer,
                                    size_t count,
-                                   nitf_Uint32 shiftCount)
+                                   uint32_t shiftCount)
 {
-    nitf_Uint32 shift;          /* Shift count */
-    nitf_Uint32 *bp32;          /* Buffer pointer, 32 bit */
+    uint32_t shift;          /* Shift count */
+    uint32_t *bp32;          /* Buffer pointer, 32 bit */
     size_t i;
 
-    shift = (nitf_Uint32) shiftCount;
-    bp32 = (nitf_Uint32 *) buffer;
+    shift = (uint32_t) shiftCount;
+    bp32 = (uint32_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp32++) >>= shift;
 
@@ -8037,37 +8037,37 @@ void nitf_ImageIO_unformatUShift_4(nitf_Uint8 * buffer,
 
 
 /* Uses 64 bit types */
-void nitf_ImageIO_unformatUShift_8(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatUShift_8(uint8_t * buffer,
                                    size_t count,
-                                   nitf_Uint32 shiftCount)
+                                   uint32_t shiftCount)
 {
-    nitf_Uint64 shift;          /* Shift count */
-    nitf_Uint64 *bp64;          /* Buffer pointer, 64 bit */
+    uint64_t shift;          /* Shift count */
+    uint64_t *bp64;          /* Buffer pointer, 64 bit */
     size_t i;
 
-    shift = (nitf_Uint64) shiftCount;
-    bp64 = (nitf_Uint64 *) buffer;
+    shift = (uint64_t) shiftCount;
+    bp64 = (uint64_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp64++) >>= shift;
 
     return;
 }
 
-void nitf_ImageIO_swapOnly_2(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_swapOnly_2(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Uint16 *bp16;          /* Buffer pointer, 16 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    uint16_t *bp16;          /* Buffer pointer, 16 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
     /* Silence compiler warnings about unused variables */
     (void)shiftCount;
 
-    bp16 = (nitf_Uint16 *) buffer;
+    bp16 = (uint16_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp16++;
+        bp8 = (uint8_t *) bp16++;
         tmp8 = bp8[0];
         bp8[0] = bp8[1];
         bp8[1] = tmp8;
@@ -8077,21 +8077,21 @@ void nitf_ImageIO_swapOnly_2(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_swapOnly_4(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_swapOnly_4(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Uint32 *bp32;          /* Buffer pointer, 32 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    uint32_t *bp32;          /* Buffer pointer, 32 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
     /* Silence compiler warnings about unused variables */
     (void)shiftCount;
 
-    bp32 = (nitf_Uint32 *) buffer;
+    bp32 = (uint32_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) (bp32++);
+        bp8 = (uint8_t *) (bp32++);
 
         tmp8 = bp8[0];
         bp8[0] = bp8[3];
@@ -8104,21 +8104,21 @@ void nitf_ImageIO_swapOnly_4(nitf_Uint8 * buffer,
     return;
 }
 
-void nitf_ImageIO_swapOnly_4c(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_swapOnly_4c(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Uint32 *bp32;          /* Buffer pointer, 32 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    uint32_t *bp32;          /* Buffer pointer, 32 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
     /* Silence compiler warnings about unused variables */
     (void)shiftCount;
 
-    bp32 = (nitf_Uint32 *) buffer;
+    bp32 = (uint32_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) (bp32++);
+        bp8 = (uint8_t *) (bp32++);
 
         tmp8 = bp8[0];
         bp8[0] = bp8[1];
@@ -8132,21 +8132,21 @@ void nitf_ImageIO_swapOnly_4c(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_swapOnly_8(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_swapOnly_8(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Uint64 *bp64;          /* Buffer pointer, 64 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    uint64_t *bp64;          /* Buffer pointer, 64 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
     /* Silence compiler warnings about unused variables */
     (void)shiftCount;
 
-    bp64 = (nitf_Uint64 *) buffer;
+    bp64 = (uint64_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) (bp64++);
+        bp8 = (uint8_t *) (bp64++);
 
         tmp8 = bp8[0];
         bp8[0] = bp8[7];
@@ -8166,21 +8166,21 @@ void nitf_ImageIO_swapOnly_8(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_swapOnly_8c(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_swapOnly_8c(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Uint64 *bp64;          /* Buffer pointer, 64 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    uint64_t *bp64;          /* Buffer pointer, 64 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
     /* Silence compiler warnings about unused variables */
     (void)shiftCount;
 
-    bp64 = (nitf_Uint64 *) buffer;
+    bp64 = (uint64_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) (bp64++);
+        bp8 = (uint8_t *) (bp64++);
 
         tmp8 = bp8[4];
         bp8[4] = bp8[7];
@@ -8200,21 +8200,21 @@ void nitf_ImageIO_swapOnly_8c(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_swapOnly_16c(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_swapOnly_16c(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Uint64 *bp64;          /* Buffer pointer, 64 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    uint64_t *bp64;          /* Buffer pointer, 64 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
     /* Silence compiler warnings about unused variables */
     (void)shiftCount;
 
-    bp64 = (nitf_Uint64 *) buffer;
+    bp64 = (uint64_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) (bp64++);
+        bp8 = (uint8_t *) (bp64++);
 
         tmp8 = bp8[0];
         bp8[0] = bp8[7];
@@ -8229,7 +8229,7 @@ void nitf_ImageIO_swapOnly_16c(nitf_Uint8 * buffer,
         bp8[3] = bp8[4];
         bp8[4] = tmp8;
 
-        bp8 = (nitf_Uint8 *) (bp64++);
+        bp8 = (uint8_t *) (bp64++);
 
         tmp8 = bp8[0];
         bp8[0] = bp8[7];
@@ -8249,22 +8249,22 @@ void nitf_ImageIO_swapOnly_16c(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_unformatSwapExtend_2(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatSwapExtend_2(uint8_t * buffer,
                                        size_t count,
-                                       nitf_Uint32 shiftCount)
+                                       uint32_t shiftCount)
 {
-    nitf_Int16 shift;           /* Shift count */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Int16 *bp16;           /* Buffer pointer, 16 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
-    nitf_Uint16 tmp16;          /* Temp value, 16 bit */
+    int16_t shift;           /* Shift count */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    int16_t *bp16;           /* Buffer pointer, 16 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
+    uint16_t tmp16;          /* Temp value, 16 bit */
     size_t i;
 
-    shift = (nitf_Int16) shiftCount;
-    bp16 = (nitf_Int16 *) buffer;
+    shift = (int16_t) shiftCount;
+    bp16 = (int16_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp16;
+        bp8 = (uint8_t *) bp16;
         tmp8 = bp8[0];
         bp8[0] = bp8[1];
         bp8[1] = tmp8;
@@ -8277,22 +8277,22 @@ void nitf_ImageIO_unformatSwapExtend_2(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_unformatSwapExtend_4(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatSwapExtend_4(uint8_t * buffer,
                                        size_t count,
-                                       nitf_Uint32 shiftCount)
+                                       uint32_t shiftCount)
 {
-    nitf_Int32 shift;           /* Shift count */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Int32 *bp32;           /* Buffer pointer, 32 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
-    nitf_Uint8 tmp32;           /* Temp value, 32 bit */
+    int32_t shift;           /* Shift count */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    int32_t *bp32;           /* Buffer pointer, 32 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
+    uint8_t tmp32;           /* Temp value, 32 bit */
     size_t i;
 
-    shift = (nitf_Int32) shiftCount;
-    bp32 = (nitf_Int32 *) buffer;
+    shift = (int32_t) shiftCount;
+    bp32 = (int32_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) (bp32++);
+        bp8 = (uint8_t *) (bp32++);
 
         tmp8 = bp8[0];
         bp8[0] = bp8[3];
@@ -8310,22 +8310,22 @@ void nitf_ImageIO_unformatSwapExtend_4(nitf_Uint8 * buffer,
 
 
 /* Uses 64 bit types */
-void nitf_ImageIO_unformatSwapExtend_8(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatSwapExtend_8(uint8_t * buffer,
                                        size_t count,
-                                       nitf_Uint32 shiftCount)
+                                       uint32_t shiftCount)
 {
-    nitf_Int64 shift;           /* Shift count */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Int64 *bp64;           /* Buffer pointer, 64 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
-    nitf_Uint64 tmp64;          /* Temp value, 64 bit */
+    int64_t shift;           /* Shift count */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    int64_t *bp64;           /* Buffer pointer, 64 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
+    uint64_t tmp64;          /* Temp value, 64 bit */
     size_t i;
 
-    shift = (nitf_Int64) shiftCount;
-    bp64 = (nitf_Int64 *) buffer;
+    shift = (int64_t) shiftCount;
+    bp64 = (int64_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp64;
+        bp8 = (uint8_t *) bp64;
 
         tmp8 = bp8[0];
         bp8[0] = bp8[7];
@@ -8348,21 +8348,21 @@ void nitf_ImageIO_unformatSwapExtend_8(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_unformatSwapShift_2(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatSwapShift_2(uint8_t * buffer,
                                       size_t count,
-                                      nitf_Uint32 shiftCount)
+                                      uint32_t shiftCount)
 {
-    nitf_Int16 shift;           /* Shift count */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Int16 *bp16;           /* Buffer pointer, 16 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    int16_t shift;           /* Shift count */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    int16_t *bp16;           /* Buffer pointer, 16 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
-    shift = (nitf_Int16) shiftCount;
-    bp16 = (nitf_Int16 *) buffer;
+    shift = (int16_t) shiftCount;
+    bp16 = (int16_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp16;
+        bp8 = (uint8_t *) bp16;
         tmp8 = bp8[0];
         bp8[0] = bp8[1];
         bp8[1] = tmp8;
@@ -8374,21 +8374,21 @@ void nitf_ImageIO_unformatSwapShift_2(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_unformatSwapShift_4(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatSwapShift_4(uint8_t * buffer,
                                       size_t count,
-                                      nitf_Uint32 shiftCount)
+                                      uint32_t shiftCount)
 {
-    nitf_Int32 shift;           /* Shift count */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Int32 *bp32;           /* Buffer pointer, 32 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    int32_t shift;           /* Shift count */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    int32_t *bp32;           /* Buffer pointer, 32 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
-    shift = (nitf_Int32) shiftCount;
-    bp32 = (nitf_Int32 *) buffer;
+    shift = (int32_t) shiftCount;
+    bp32 = (int32_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp32;
+        bp8 = (uint8_t *) bp32;
 
         tmp8 = bp8[0];
         bp8[0] = bp8[3];
@@ -8405,21 +8405,21 @@ void nitf_ImageIO_unformatSwapShift_4(nitf_Uint8 * buffer,
 
 
 /* Uses 64 bit types */
-void nitf_ImageIO_unformatSwapShift_8(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatSwapShift_8(uint8_t * buffer,
                                       size_t count,
-                                      nitf_Uint32 shiftCount)
+                                      uint32_t shiftCount)
 {
-    nitf_Int64 shift;           /* Shift count */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Int64 *bp64;           /* Buffer pointer, 64 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    int64_t shift;           /* Shift count */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    int64_t *bp64;           /* Buffer pointer, 64 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
-    shift = (nitf_Int64) shiftCount;
-    bp64 = (nitf_Int64 *) buffer;
+    shift = (int64_t) shiftCount;
+    bp64 = (int64_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp64;
+        bp8 = (uint8_t *) bp64;
 
         tmp8 = bp8[0];
         bp8[0] = bp8[7];
@@ -8441,21 +8441,21 @@ void nitf_ImageIO_unformatSwapShift_8(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_unformatSwapUShift_2(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatSwapUShift_2(uint8_t * buffer,
                                        size_t count,
-                                       nitf_Uint32 shiftCount)
+                                       uint32_t shiftCount)
 {
-    nitf_Uint16 shift;          /* Shift count */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Uint16 *bp16;          /* Buffer pointer, 16 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    uint16_t shift;          /* Shift count */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    uint16_t *bp16;          /* Buffer pointer, 16 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
-    shift = (nitf_Uint16) shiftCount;
-    bp16 = (nitf_Uint16 *) buffer;
+    shift = (uint16_t) shiftCount;
+    bp16 = (uint16_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp16;
+        bp8 = (uint8_t *) bp16;
         tmp8 = bp8[0];
         bp8[0] = bp8[1];
         bp8[1] = tmp8;
@@ -8466,21 +8466,21 @@ void nitf_ImageIO_unformatSwapUShift_2(nitf_Uint8 * buffer,
     return;
 }
 
-void nitf_ImageIO_unformatSwapUShift_4(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatSwapUShift_4(uint8_t * buffer,
                                        size_t count,
-                                       nitf_Uint32 shiftCount)
+                                       uint32_t shiftCount)
 {
-    nitf_Uint32 shift;          /* Shift count */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Uint32 *bp32;          /* Buffer pointer, 32 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    uint32_t shift;          /* Shift count */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    uint32_t *bp32;          /* Buffer pointer, 32 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
-    shift = (nitf_Uint32) shiftCount;
-    bp32 = (nitf_Uint32 *) buffer;
+    shift = (uint32_t) shiftCount;
+    bp32 = (uint32_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp32;
+        bp8 = (uint8_t *) bp32;
 
         tmp8 = bp8[0];
         bp8[0] = bp8[3];
@@ -8497,21 +8497,21 @@ void nitf_ImageIO_unformatSwapUShift_4(nitf_Uint8 * buffer,
 
 
 /* Uses 64 bit types */
-void nitf_ImageIO_unformatSwapUShift_8(nitf_Uint8 * buffer,
+void nitf_ImageIO_unformatSwapUShift_8(uint8_t * buffer,
                                        size_t count,
-                                       nitf_Uint32 shiftCount)
+                                       uint32_t shiftCount)
 {
-    nitf_Uint64 shift;          /* Shift count */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Uint64 *bp64;          /* Buffer pointer, 64 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    uint64_t shift;          /* Shift count */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    uint64_t *bp64;          /* Buffer pointer, 64 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
-    shift = (nitf_Uint64) shiftCount;
-    bp64 = (nitf_Uint64 *) buffer;
+    shift = (uint64_t) shiftCount;
+    bp64 = (uint64_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp64;
+        bp8 = (uint8_t *) bp64;
 
         tmp8 = bp8[0];
         bp8[0] = bp8[7];
@@ -8536,22 +8536,22 @@ void nitf_ImageIO_unformatSwapUShift_8(nitf_Uint8 * buffer,
 void nitf_ImageIO_unpack_P_1(_nitf_ImageIOBlock * blockIO,
                              nitf_Error * error)
 {
-    nitf_Uint8 *src;            /* Source buffer */
-    nitf_Uint8 *dst;            /* Destination buffer */
+    uint8_t *src;            /* Source buffer */
+    uint8_t *dst;            /* Destination buffer */
     size_t count;               /* Number of pixels to transfer */
-    nitf_Uint32 skip;           /* Source buffer skip count */
+    uint32_t skip;           /* Source buffer skip count */
     size_t i;
-    const nitf_Uint32 bytes = blockIO->cntl->nitf->pixel.bytes;
-    const nitf_Uint32 firstBand = blockIO->cntl->bandSubset[0];
-    const nitf_Uint32 bandOffset = firstBand * bytes;
+    const uint32_t bytes = blockIO->cntl->nitf->pixel.bytes;
+    const uint32_t firstBand = blockIO->cntl->bandSubset[0];
+    const uint32_t bandOffset = firstBand * bytes;
 
     /* Silence compiler warnings about unused variables */
     (void)error;
 
-    src = (nitf_Uint8 *) (blockIO->rwBuffer.buffer
+    src = (uint8_t *) (blockIO->rwBuffer.buffer
                           + blockIO->rwBuffer.offset.mark
                           + bandOffset);
-    dst = (nitf_Uint8 *) (blockIO->unpacked.buffer
+    dst = (uint8_t *) (blockIO->unpacked.buffer
                           + blockIO->unpacked.offset.mark);
     count = blockIO->pixelCountFR;
     skip = blockIO->cntl->nitf->numBands;
@@ -8568,22 +8568,22 @@ void nitf_ImageIO_unpack_P_1(_nitf_ImageIOBlock * blockIO,
 void nitf_ImageIO_unpack_P_2(_nitf_ImageIOBlock * blockIO,
                              nitf_Error * error)
 {
-    nitf_Uint16 *src;           /* Source buffer */
-    nitf_Uint16 *dst;           /* Destination buffer */
+    uint16_t *src;           /* Source buffer */
+    uint16_t *dst;           /* Destination buffer */
     size_t count;               /* Number of pixels to transfer */
-    nitf_Uint32 skip;           /* Source buffer skip count */
+    uint32_t skip;           /* Source buffer skip count */
     size_t i;
-    const nitf_Uint32 bytes = blockIO->cntl->nitf->pixel.bytes;
-    const nitf_Uint32 firstBand = blockIO->cntl->bandSubset[0];
-    const nitf_Uint32 bandOffset = firstBand * bytes;
+    const uint32_t bytes = blockIO->cntl->nitf->pixel.bytes;
+    const uint32_t firstBand = blockIO->cntl->bandSubset[0];
+    const uint32_t bandOffset = firstBand * bytes;
 
     /* Silence compiler warnings about unused variables */
     (void)error;
 
-    src = (nitf_Uint16 *) (blockIO->rwBuffer.buffer
+    src = (uint16_t *) (blockIO->rwBuffer.buffer
                            + blockIO->rwBuffer.offset.mark
                            + bandOffset);
-    dst = (nitf_Uint16 *) (blockIO->unpacked.buffer
+    dst = (uint16_t *) (blockIO->unpacked.buffer
                            + blockIO->unpacked.offset.mark);
     count = blockIO->pixelCountFR;
     skip = blockIO->cntl->nitf->numBands;
@@ -8599,22 +8599,22 @@ void nitf_ImageIO_unpack_P_2(_nitf_ImageIOBlock * blockIO,
 void nitf_ImageIO_unpack_P_4(_nitf_ImageIOBlock * blockIO,
                              nitf_Error * error)
 {
-    nitf_Uint32 *src;           /* Source buffer */
-    nitf_Uint32 *dst;           /* Destination buffer */
+    uint32_t *src;           /* Source buffer */
+    uint32_t *dst;           /* Destination buffer */
     size_t count;               /* Number of pixels to transfer */
-    nitf_Uint32 skip;           /* Source buffer skip count */
+    uint32_t skip;           /* Source buffer skip count */
     size_t i;
-    const nitf_Uint32 bytes = blockIO->cntl->nitf->pixel.bytes;
-    const nitf_Uint32 firstBand = blockIO->cntl->bandSubset[0];
-    const nitf_Uint32 bandOffset = firstBand * bytes;
+    const uint32_t bytes = blockIO->cntl->nitf->pixel.bytes;
+    const uint32_t firstBand = blockIO->cntl->bandSubset[0];
+    const uint32_t bandOffset = firstBand * bytes;
 
     /* Silence compiler warnings about unused variables */
     (void)error;
 
-    src = (nitf_Uint32 *) (blockIO->rwBuffer.buffer
+    src = (uint32_t *) (blockIO->rwBuffer.buffer
                            + blockIO->rwBuffer.offset.mark
                            + bandOffset);
-    dst = (nitf_Uint32 *) (blockIO->unpacked.buffer
+    dst = (uint32_t *) (blockIO->unpacked.buffer
                            + blockIO->unpacked.offset.mark);
     count = blockIO->pixelCountFR;
     skip = blockIO->cntl->nitf->numBands;
@@ -8631,22 +8631,22 @@ void nitf_ImageIO_unpack_P_4(_nitf_ImageIOBlock * blockIO,
 void nitf_ImageIO_unpack_P_8(_nitf_ImageIOBlock * blockIO,
                              nitf_Error * error)
 {
-    nitf_Uint64 *src;           /* Source buffer */
-    nitf_Uint64 *dst;           /* Destination buffer */
+    uint64_t *src;           /* Source buffer */
+    uint64_t *dst;           /* Destination buffer */
     size_t count;               /* Number of pixels to transfer */
-    nitf_Uint32 skip;           /* Source buffer skip count */
+    uint32_t skip;           /* Source buffer skip count */
     size_t i;
-    const nitf_Uint32 bytes = blockIO->cntl->nitf->pixel.bytes;
-    const nitf_Uint32 firstBand = blockIO->cntl->bandSubset[0];
-    const nitf_Uint32 bandOffset = firstBand * bytes;
+    const uint32_t bytes = blockIO->cntl->nitf->pixel.bytes;
+    const uint32_t firstBand = blockIO->cntl->bandSubset[0];
+    const uint32_t bandOffset = firstBand * bytes;
 
     /* Silence compiler warnings about unused variables */
     (void)error;
 
-    src = (nitf_Uint64 *) (blockIO->rwBuffer.buffer
+    src = (uint64_t *) (blockIO->rwBuffer.buffer
                            + blockIO->rwBuffer.offset.mark
                            + bandOffset);
-    dst = (nitf_Uint64 *) (blockIO->unpacked.buffer
+    dst = (uint64_t *) (blockIO->unpacked.buffer
                            + blockIO->unpacked.offset.mark);
     count = blockIO->pixelCountFR;
     skip = blockIO->cntl->nitf->numBands;
@@ -8663,24 +8663,24 @@ void nitf_ImageIO_unpack_P_8(_nitf_ImageIOBlock * blockIO,
 void nitf_ImageIO_unpack_P_16(_nitf_ImageIOBlock * blockIO,
                               nitf_Error * error)
 {
-    nitf_Uint64 *src1;          /* Source buffer 1 */
-    nitf_Uint64 *dst1;          /* Destination buffer 1 */
-    nitf_Uint64 *src2;          /* Source buffer 2 */
-    nitf_Uint64 *dst2;          /* Destination buffer 2 */
+    uint64_t *src1;          /* Source buffer 1 */
+    uint64_t *dst1;          /* Destination buffer 1 */
+    uint64_t *src2;          /* Source buffer 2 */
+    uint64_t *dst2;          /* Destination buffer 2 */
     size_t count;               /* Number of pixels to transfer */
-    nitf_Uint32 skip;           /* Source buffer skip count */
+    uint32_t skip;           /* Source buffer skip count */
     size_t i;
-    const nitf_Uint32 bytes = blockIO->cntl->nitf->pixel.bytes;
-    const nitf_Uint32 firstBand = blockIO->cntl->bandSubset[0];
-    const nitf_Uint32 bandOffset = firstBand * bytes;
+    const uint32_t bytes = blockIO->cntl->nitf->pixel.bytes;
+    const uint32_t firstBand = blockIO->cntl->bandSubset[0];
+    const uint32_t bandOffset = firstBand * bytes;
 
     /* Silence compiler warnings about unused variables */
     (void)error;
 
-    src1 = (nitf_Uint64 *) (blockIO->rwBuffer.buffer
+    src1 = (uint64_t *) (blockIO->rwBuffer.buffer
                             + blockIO->rwBuffer.offset.mark
                             + bandOffset);
-    dst1 = (nitf_Uint64 *) (blockIO->unpacked.buffer
+    dst1 = (uint64_t *) (blockIO->unpacked.buffer
                             + blockIO->unpacked.offset.mark);
     src2 = src1 + 1;
     dst2 = dst1 + 1;
@@ -8699,17 +8699,17 @@ void nitf_ImageIO_unpack_P_16(_nitf_ImageIOBlock * blockIO,
 
 void nitf_ImageIO_pack_P_1(_nitf_ImageIOBlock * blockIO, nitf_Error * error)
 {
-    nitf_Uint8 *src;            /* Source buffer */
-    nitf_Uint8 *dst;            /* Destination buffer */
+    uint8_t *src;            /* Source buffer */
+    uint8_t *dst;            /* Destination buffer */
     size_t count;               /* Number of pixels to transfer */
-    nitf_Uint32 skip;           /* Source buffer skip count */
+    uint32_t skip;           /* Source buffer skip count */
     size_t i;
 
     /* Silence compiler warnings about unused variables */
     (void)error;
 
-    src = (nitf_Uint8 *) (blockIO->user.buffer + blockIO->user.offset.mark);
-    dst = (nitf_Uint8 *) (blockIO->rwBuffer.buffer);
+    src = (uint8_t *) (blockIO->user.buffer + blockIO->user.offset.mark);
+    dst = (uint8_t *) (blockIO->rwBuffer.buffer);
     dst += blockIO->band;
     count = blockIO->pixelCountFR;
     skip = blockIO->cntl->nitf->numBands;
@@ -8725,17 +8725,17 @@ void nitf_ImageIO_pack_P_1(_nitf_ImageIOBlock * blockIO, nitf_Error * error)
 
 void nitf_ImageIO_pack_P_2(_nitf_ImageIOBlock * blockIO, nitf_Error * error)
 {
-    nitf_Uint16 *src;           /* Source buffer */
-    nitf_Uint16 *dst;           /* Destination buffer */
+    uint16_t *src;           /* Source buffer */
+    uint16_t *dst;           /* Destination buffer */
     size_t count;               /* Number of pixels to transfer */
-    nitf_Uint32 skip;           /* Source buffer skip count */
+    uint32_t skip;           /* Source buffer skip count */
     size_t i;
 
     /* Silence compiler warnings about unused variables */
     (void)error;
 
-    src = (nitf_Uint16 *) (blockIO->user.buffer + blockIO->user.offset.mark);
-    dst = (nitf_Uint16 *) (blockIO->rwBuffer.buffer);
+    src = (uint16_t *) (blockIO->user.buffer + blockIO->user.offset.mark);
+    dst = (uint16_t *) (blockIO->rwBuffer.buffer);
     dst += blockIO->band;
     count = blockIO->pixelCountFR;
     skip = blockIO->cntl->nitf->numBands;
@@ -8751,17 +8751,17 @@ void nitf_ImageIO_pack_P_2(_nitf_ImageIOBlock * blockIO, nitf_Error * error)
 
 void nitf_ImageIO_pack_P_4(_nitf_ImageIOBlock * blockIO, nitf_Error * error)
 {
-    nitf_Uint32 *src;           /* Source buffer */
-    nitf_Uint32 *dst;           /* Destination buffer */
+    uint32_t *src;           /* Source buffer */
+    uint32_t *dst;           /* Destination buffer */
     size_t count;               /* Number of pixels to transfer */
-    nitf_Uint32 skip;           /* Source buffer skip count */
+    uint32_t skip;           /* Source buffer skip count */
     size_t i;
 
     /* Silence compiler warnings about unused variables */
     (void)error;
 
-    src = (nitf_Uint32 *) (blockIO->user.buffer + blockIO->user.offset.mark);
-    dst = (nitf_Uint32 *) (blockIO->rwBuffer.buffer);
+    src = (uint32_t *) (blockIO->user.buffer + blockIO->user.offset.mark);
+    dst = (uint32_t *) (blockIO->rwBuffer.buffer);
     dst += blockIO->band;
     count = blockIO->pixelCountFR;
     skip = blockIO->cntl->nitf->numBands;
@@ -8777,17 +8777,17 @@ void nitf_ImageIO_pack_P_4(_nitf_ImageIOBlock * blockIO, nitf_Error * error)
 
 void nitf_ImageIO_pack_P_8(_nitf_ImageIOBlock * blockIO, nitf_Error * error)
 {
-    nitf_Uint64 *src;           /* Source buffer */
-    nitf_Uint64 *dst;           /* Destination buffer */
+    uint64_t *src;           /* Source buffer */
+    uint64_t *dst;           /* Destination buffer */
     size_t count;               /* Number of pixels to transfer */
-    nitf_Uint32 skip;           /* Source buffer skip count */
+    uint32_t skip;           /* Source buffer skip count */
     size_t i;
 
     /* Silence compiler warnings about unused variables */
     (void)error;
 
-    src = (nitf_Uint64 *) (blockIO->user.buffer + blockIO->user.offset.mark);
-    dst = (nitf_Uint64 *) (blockIO->rwBuffer.buffer);
+    src = (uint64_t *) (blockIO->user.buffer + blockIO->user.offset.mark);
+    dst = (uint64_t *) (blockIO->rwBuffer.buffer);
     dst += blockIO->band;
     count = blockIO->pixelCountFR;
     skip = blockIO->cntl->nitf->numBands;
@@ -8803,19 +8803,19 @@ void nitf_ImageIO_pack_P_8(_nitf_ImageIOBlock * blockIO, nitf_Error * error)
 
 void nitf_ImageIO_pack_P_16(_nitf_ImageIOBlock * blockIO, nitf_Error * error)
 {
-    nitf_Uint64 *src1;          /* Source buffer 1 */
-    nitf_Uint64 *dst1;          /* Destination buffer 1 */
-    nitf_Uint64 *src2;          /* Source buffer 2 */
-    nitf_Uint64 *dst2;          /* Destination buffer 2 */
+    uint64_t *src1;          /* Source buffer 1 */
+    uint64_t *dst1;          /* Destination buffer 1 */
+    uint64_t *src2;          /* Source buffer 2 */
+    uint64_t *dst2;          /* Destination buffer 2 */
     size_t count;               /* Number of pixels to transfer */
-    nitf_Uint32 skip;           /* Source buffer skip count */
+    uint32_t skip;           /* Source buffer skip count */
     size_t i;
 
     /* Silence compiler warnings about unused variables */
     (void)error;
 
-    src1 = (nitf_Uint64 *) (blockIO->user.buffer + blockIO->user.offset.mark);
-    dst1 = (nitf_Uint64 *) (blockIO->rwBuffer.buffer);
+    src1 = (uint64_t *) (blockIO->user.buffer + blockIO->user.offset.mark);
+    dst1 = (uint64_t *) (blockIO->rwBuffer.buffer);
     dst1 += blockIO->band;
     src2 = src1 + 1;
     dst2 = dst1 + 1;
@@ -8833,15 +8833,15 @@ void nitf_ImageIO_pack_P_16(_nitf_ImageIOBlock * blockIO, nitf_Error * error)
 }
 
 
-void nitf_ImageIO_formatShift_1(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_formatShift_1(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Int8 shift;            /* Shift count */
-    nitf_Int8 *bp8;             /* Buffer pointer, 8 bit */
+    int8_t shift;            /* Shift count */
+    int8_t *bp8;             /* Buffer pointer, 8 bit */
     size_t i;
 
-    shift = (nitf_Int8) shiftCount;
-    bp8 = (nitf_Int8 *) buffer;
+    shift = (int8_t) shiftCount;
+    bp8 = (int8_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp8++) <<= shift;
 
@@ -8849,15 +8849,15 @@ void nitf_ImageIO_formatShift_1(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_formatShift_2(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_formatShift_2(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Int16 shift;           /* Shift count */
-    nitf_Int16 *bp16;           /* Buffer pointer, 16 bit */
+    int16_t shift;           /* Shift count */
+    int16_t *bp16;           /* Buffer pointer, 16 bit */
     size_t i;
 
-    shift = (nitf_Int16) shiftCount;
-    bp16 = (nitf_Int16 *) buffer;
+    shift = (int16_t) shiftCount;
+    bp16 = (int16_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp16++) <<= shift;
 
@@ -8865,15 +8865,15 @@ void nitf_ImageIO_formatShift_2(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_formatShift_4(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_formatShift_4(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Int32 shift;           /* Shift count */
-    nitf_Int32 *bp32;           /* Buffer pointer, 32 bit */
+    int32_t shift;           /* Shift count */
+    int32_t *bp32;           /* Buffer pointer, 32 bit */
     size_t i;
 
-    shift = (nitf_Int32) shiftCount;
-    bp32 = (nitf_Int32 *) buffer;
+    shift = (int32_t) shiftCount;
+    bp32 = (int32_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp32++) <<= shift;
 
@@ -8883,45 +8883,45 @@ void nitf_ImageIO_formatShift_4(nitf_Uint8 * buffer,
 
 /* Uses 64 bit types */
 
-void nitf_ImageIO_formatShift_8(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_formatShift_8(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Int64 shift;           /* Shift count */
-    nitf_Int64 *bp64;           /* Buffer pointer, 64 bit */
+    int64_t shift;           /* Shift count */
+    int64_t *bp64;           /* Buffer pointer, 64 bit */
     size_t i;
 
-    shift = (nitf_Int64) shiftCount;
-    bp64 = (nitf_Int64 *) buffer;
+    shift = (int64_t) shiftCount;
+    bp64 = (int64_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp64++) <<= shift;
 
     return;
 }
 
-void nitf_ImageIO_formatMask_1(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_formatMask_1(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Uint8 mask;            /* The mask */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
+    uint8_t mask;            /* The mask */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
     size_t i;
 
-    mask = ((nitf_Uint8) - 1) << (8 - shiftCount);
-    bp8 = (nitf_Uint8 *) buffer;
+    mask = ((uint8_t) - 1) << (8 - shiftCount);
+    bp8 = (uint8_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp8++) &= mask;
 
     return;
 }
 
-void nitf_ImageIO_formatMask_2(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_formatMask_2(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Uint8 mask;            /* The mask */
-    nitf_Uint16 *bp16;          /* Buffer pointer, 16 bit */
+    uint8_t mask;            /* The mask */
+    uint16_t *bp16;          /* Buffer pointer, 16 bit */
     size_t i;
 
-    mask = ((nitf_Uint16) - 1) << (16 - shiftCount);
-    bp16 = (nitf_Uint16 *) buffer;
+    mask = ((uint16_t) - 1) << (16 - shiftCount);
+    bp16 = (uint16_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp16++) &= mask;
 
@@ -8929,15 +8929,15 @@ void nitf_ImageIO_formatMask_2(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_formatMask_4(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_formatMask_4(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Uint8 mask;            /* The mask */
-    nitf_Uint32 *bp32;          /* Buffer pointer, 32 bit */
+    uint8_t mask;            /* The mask */
+    uint32_t *bp32;          /* Buffer pointer, 32 bit */
     size_t i;
 
-    mask = ((nitf_Uint32) - 1) << (32 - shiftCount);
-    bp32 = (nitf_Uint32 *) buffer;
+    mask = ((uint32_t) - 1) << (32 - shiftCount);
+    bp32 = (uint32_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp32++) &= mask;
 
@@ -8947,15 +8947,15 @@ void nitf_ImageIO_formatMask_4(nitf_Uint8 * buffer,
 
 /* Uses 64 bit types */
 
-void nitf_ImageIO_formatMask_8(nitf_Uint8 * buffer,
-        size_t count, nitf_Uint32 shiftCount)
+void nitf_ImageIO_formatMask_8(uint8_t * buffer,
+        size_t count, uint32_t shiftCount)
 {
-    nitf_Uint8 mask;            /* The mask */
-    nitf_Uint64 *bp64;          /* Buffer pointer, 64 bit */
+    uint8_t mask;            /* The mask */
+    uint64_t *bp64;          /* Buffer pointer, 64 bit */
     size_t i;
 
-    mask = ((nitf_Uint64) - 1) << (64 - shiftCount);
-    bp64 = (nitf_Uint64 *) buffer;
+    mask = ((uint64_t) - 1) << (64 - shiftCount);
+    bp64 = (uint64_t *) buffer;
     for (i = 0; i < count; i++)
         *(bp64++) &= mask;
 
@@ -8963,21 +8963,21 @@ void nitf_ImageIO_formatMask_8(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_formatShiftSwap_2(nitf_Uint8 * buffer,
+void nitf_ImageIO_formatShiftSwap_2(uint8_t * buffer,
                                     size_t count,
-                                    nitf_Uint32 shiftCount)
+                                    uint32_t shiftCount)
 {
-    nitf_Int16 shift;           /* Shift count */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Int16 *bp16;           /* Buffer pointer, 16 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    int16_t shift;           /* Shift count */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    int16_t *bp16;           /* Buffer pointer, 16 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
-    shift = (nitf_Int16) shiftCount;
-    bp16 = (nitf_Int16 *) buffer;
+    shift = (int16_t) shiftCount;
+    bp16 = (int16_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp16;
+        bp8 = (uint8_t *) bp16;
         tmp8 = bp8[0];
         bp8[0] = bp8[1];
         bp8[1] = tmp8;
@@ -8989,21 +8989,21 @@ void nitf_ImageIO_formatShiftSwap_2(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_formatShiftSwap_4(nitf_Uint8 * buffer,
+void nitf_ImageIO_formatShiftSwap_4(uint8_t * buffer,
                                     size_t count,
-                                    nitf_Uint32 shiftCount)
+                                    uint32_t shiftCount)
 {
-    nitf_Int32 shift;           /* Shift count */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Int32 *bp32;           /* Buffer pointer, 32 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    int32_t shift;           /* Shift count */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    int32_t *bp32;           /* Buffer pointer, 32 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
-    shift = (nitf_Int32) shiftCount;
-    bp32 = (nitf_Int32 *) buffer;
+    shift = (int32_t) shiftCount;
+    bp32 = (int32_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp32;
+        bp8 = (uint8_t *) bp32;
 
         tmp8 = bp8[0];
         bp8[0] = bp8[3];
@@ -9020,21 +9020,21 @@ void nitf_ImageIO_formatShiftSwap_4(nitf_Uint8 * buffer,
 
 
 /* Uses 64 bit types */
-void nitf_ImageIO_formatShiftSwap_8(nitf_Uint8 * buffer,
+void nitf_ImageIO_formatShiftSwap_8(uint8_t * buffer,
                                     size_t count,
-                                    nitf_Uint32 shiftCount)
+                                    uint32_t shiftCount)
 {
-    nitf_Int64 shift;           /* Shift count */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Int64 *bp64;           /* Buffer pointer, 64 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    int64_t shift;           /* Shift count */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    int64_t *bp64;           /* Buffer pointer, 64 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
-    shift = (nitf_Int64) shiftCount;
-    bp64 = (nitf_Int64 *) buffer;
+    shift = (int64_t) shiftCount;
+    bp64 = (int64_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp64;
+        bp8 = (uint8_t *) bp64;
 
         tmp8 = bp8[0];
         bp8[0] = bp8[7];
@@ -9056,23 +9056,23 @@ void nitf_ImageIO_formatShiftSwap_8(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_formatMaskSwap_2(nitf_Uint8 * buffer,
+void nitf_ImageIO_formatMaskSwap_2(uint8_t * buffer,
                                    size_t count,
-                                   nitf_Uint32 shiftCount)
+                                   uint32_t shiftCount)
 {
-    nitf_Uint8 mask;            /* The mask */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Uint16 *bp16;          /* Buffer pointer, 16 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    uint8_t mask;            /* The mask */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    uint16_t *bp16;          /* Buffer pointer, 16 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
-    mask = ((nitf_Uint16) - 1) << (16 - shiftCount);
-    bp16 = (nitf_Uint16 *) buffer;
+    mask = ((uint16_t) - 1) << (16 - shiftCount);
+    bp16 = (uint16_t *) buffer;
     for (i = 0; i < count; i++)
     {
         *(bp16++) &= mask;
 
-        bp8 = (nitf_Uint8 *) bp16;
+        bp8 = (uint8_t *) bp16;
         tmp8 = bp8[0];
         bp8[0] = bp8[1];
         bp8[1] = tmp8;
@@ -9082,21 +9082,21 @@ void nitf_ImageIO_formatMaskSwap_2(nitf_Uint8 * buffer,
 }
 
 
-void nitf_ImageIO_formatMaskSwap_4(nitf_Uint8 * buffer,
+void nitf_ImageIO_formatMaskSwap_4(uint8_t * buffer,
                                    size_t count,
-                                   nitf_Uint32 shiftCount)
+                                   uint32_t shiftCount)
 {
-    nitf_Uint8 mask;            /* The mask */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Uint32 *bp32;          /* Buffer pointer, 32 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    uint8_t mask;            /* The mask */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    uint32_t *bp32;          /* Buffer pointer, 32 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
-    mask = ((nitf_Uint32) - 1) << (32 - shiftCount);
-    bp32 = (nitf_Uint32 *) buffer;
+    mask = ((uint32_t) - 1) << (32 - shiftCount);
+    bp32 = (uint32_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp32;
+        bp8 = (uint8_t *) bp32;
 
         *(bp32++) &= mask;
 
@@ -9113,21 +9113,21 @@ void nitf_ImageIO_formatMaskSwap_4(nitf_Uint8 * buffer,
 
 
 /* Uses 64 bit types */
-void nitf_ImageIO_formatMaskSwap_8(nitf_Uint8 * buffer,
+void nitf_ImageIO_formatMaskSwap_8(uint8_t * buffer,
                                    size_t count,
-                                   nitf_Uint32 shiftCount)
+                                   uint32_t shiftCount)
 {
-    nitf_Uint8 mask;            /* The mask */
-    nitf_Uint8 *bp8;            /* Buffer pointer, 8 bit */
-    nitf_Uint64 *bp64;          /* Buffer pointer, 64 bit */
-    nitf_Uint8 tmp8;            /* Temp value, 8 bit */
+    uint8_t mask;            /* The mask */
+    uint8_t *bp8;            /* Buffer pointer, 8 bit */
+    uint64_t *bp64;          /* Buffer pointer, 64 bit */
+    uint8_t tmp8;            /* Temp value, 8 bit */
     size_t i;
 
-    mask = ((nitf_Uint64) - 1) << (64 - shiftCount);
-    bp64 = (nitf_Uint64 *) buffer;
+    mask = ((uint64_t) - 1) << (64 - shiftCount);
+    bp64 = (uint64_t *) buffer;
     for (i = 0; i < count; i++)
     {
-        bp8 = (nitf_Uint8 *) bp64;
+        bp8 = (uint8_t *) bp64;
 
         *(bp64++) &= mask;
 
@@ -9155,7 +9155,7 @@ void nitf_ImageIO_formatMaskSwap_8(nitf_Uint8 * buffer,
 
 NITFPRIV(NITF_BOOL) nitf_ImageIO_bPixelFreeBlock(nitf_DecompressionControl
         * control,
-        nitf_Uint8 * block,
+        uint8_t * block,
         nitf_Error * error)
 {
     /* Silence compiler warnings about unused variables */
@@ -9191,10 +9191,10 @@ nitf_ImageIO_bPixelOpen(nitf_ImageSubheader * subheader,
 
 NITFPRIV(NITF_BOOL) nitf_ImageIO_bPixelStart(nitf_DecompressionControl * control,
                                              nitf_IOInterface* io,
-                                             nitf_Uint64 offset,
-                                             nitf_Uint64 fileLength,
+                                             uint64_t offset,
+                                             uint64_t fileLength,
                                              nitf_BlockingInfo * blockInfo,
-                                             nitf_Uint64 * blockMask,
+                                             uint64_t * blockMask,
                                              nitf_Error * error)
 {
     nitf_ImageIO_BPixelControl *icntl;
@@ -9209,7 +9209,7 @@ NITFPRIV(NITF_BOOL) nitf_ImageIO_bPixelStart(nitf_DecompressionControl * control
     icntl->blockInfo = blockInfo;
     icntl->blockMask = blockMask;
     icntl->blockSizeCompressed = (blockInfo->length + 7) / 8;
-    icntl->buffer = (nitf_Uint8 *) NITF_MALLOC(icntl->blockSizeCompressed);
+    icntl->buffer = (uint8_t *) NITF_MALLOC(icntl->blockSizeCompressed);
     if (icntl->buffer == NULL)
     {
         nitf_Error_init(error, "Error creating control object",
@@ -9222,19 +9222,19 @@ NITFPRIV(NITF_BOOL) nitf_ImageIO_bPixelStart(nitf_DecompressionControl * control
 }
 
 
-NITFPRIV(nitf_Uint8 *)
+NITFPRIV(uint8_t *)
 nitf_ImageIO_bPixelReadBlock(nitf_DecompressionControl * control,
-                             nitf_Uint32 blockNumber,
-                             nitf_Uint64* blockSize,
+                             uint32_t blockNumber,
+                             uint64_t* blockSize,
                              nitf_Error * error)
 {
     /* Actual control type */
     nitf_ImageIO_BPixelControl *icntl;
     size_t uncompressedLen;     /* Length of uncompressed block */
-    nitf_Uint8 *block;          /* Uncompressed result */
-    nitf_Uint8 *blockPtr;       /* Pointer in uncompressed result */
-    nitf_Uint8 *compPtr;        /* Pointer in compressed input */
-    nitf_Uint8 current;         /* Current byte of compressed data */
+    uint8_t *block;          /* Uncompressed result */
+    uint8_t *blockPtr;       /* Pointer in uncompressed result */
+    uint8_t *compPtr;        /* Pointer in compressed input */
+    uint8_t current;         /* Current byte of compressed data */
     size_t i;
 
     icntl = (nitf_ImageIO_BPixelControl *) control;
@@ -9257,7 +9257,7 @@ nitf_ImageIO_bPixelReadBlock(nitf_DecompressionControl * control,
 
     /* Allocate block */
 
-    block = (nitf_Uint8 *) NITF_MALLOC(uncompressedLen);
+    block = (uint8_t *) NITF_MALLOC(uncompressedLen);
     if (block == NULL)
     {
         nitf_Error_init(error, "Error creating block buffer",
@@ -9303,7 +9303,7 @@ nitf_ImageIO_bPixelClose(nitf_DecompressionControl **control)
 
 NITFPRIV(NITF_BOOL) nitf_ImageIO_12PixelFreeBlock(nitf_DecompressionControl
         * control,
-        nitf_Uint8 * block,
+        uint8_t * block,
         nitf_Error * error)
 {
     /* Silence compiler warnings about unused variables */
@@ -9340,10 +9340,10 @@ nitf_ImageIO_12PixelOpen(nitf_ImageSubheader * subheader,
 NITFPRIV(NITF_BOOL)
 nitf_ImageIO_12PixelStart(nitf_DecompressionControl* control,
                           nitf_IOInterface* io,
-                          nitf_Uint64 offset,
-                          nitf_Uint64 fileLength,
+                          uint64_t offset,
+                          uint64_t fileLength,
                           nitf_BlockingInfo * blockInfo,
-                          nitf_Uint64 * blockMask,
+                          uint64_t * blockMask,
                           nitf_Error * error)
 {
     nitf_ImageIO_12PixelControl *icntl;
@@ -9370,7 +9370,7 @@ nitf_ImageIO_12PixelStart(nitf_DecompressionControl* control,
 
     icntl->blockSizeCompressed = 3*(icntl->blockPixelCount/2) + 2*(icntl->odd);
 
-    icntl->buffer = (nitf_Uint8 *) NITF_MALLOC(icntl->blockSizeCompressed);
+    icntl->buffer = (uint8_t *) NITF_MALLOC(icntl->blockSizeCompressed);
     if (icntl->buffer == NULL)
     {
         nitf_Error_init(error, "Error creating control object",
@@ -9382,21 +9382,21 @@ nitf_ImageIO_12PixelStart(nitf_DecompressionControl* control,
     return NITF_SUCCESS;
 }
 
-NITFPRIV(nitf_Uint8 *)
+NITFPRIV(uint8_t *)
 nitf_ImageIO_12PixelReadBlock(nitf_DecompressionControl* control,
-                              nitf_Uint32 blockNumber,
-                              nitf_Uint64* blockSize,
+                              uint32_t blockNumber,
+                              uint64_t* blockSize,
                               nitf_Error* error)
 {
     /* Actual control type */
     nitf_ImageIO_12PixelControl *icntl;
     size_t uncompressedLen;        /* Length of uncompressed block */
-    nitf_Uint8 *block;             /* Uncompressed result */
-    nitf_Uint16 *blockPtr;         /* Pointer in uncompressed result */
-    nitf_Uint8 *compPtr;           /* Pointer in compressed input */
-    nitf_Uint16 a;                 /* Components of compressed pixel */
-    nitf_Uint16 b;
-    nitf_Uint16 c;
+    uint8_t *block;             /* Uncompressed result */
+    uint16_t *blockPtr;         /* Pointer in uncompressed result */
+    uint8_t *compPtr;           /* Pointer in compressed input */
+    uint16_t a;                 /* Components of compressed pixel */
+    uint16_t b;
+    uint16_t c;
     size_t i;
 
     icntl = (nitf_ImageIO_12PixelControl *) control;
@@ -9416,7 +9416,7 @@ nitf_ImageIO_12PixelReadBlock(nitf_DecompressionControl* control,
 
     /* Allocate block */
 
-    block = (nitf_Uint8 *) NITF_MALLOC(uncompressedLen);
+    block = (uint8_t *) NITF_MALLOC(uncompressedLen);
     if (block == NULL)
     {
         nitf_Error_init(error, "Error creating block buffer",
@@ -9426,7 +9426,7 @@ nitf_ImageIO_12PixelReadBlock(nitf_DecompressionControl* control,
 
     /* Decompress the result */
 
-    blockPtr = (nitf_Uint16 *) block;
+    blockPtr = (uint16_t *) block;
     compPtr = icntl->buffer;
     for (i = 0; i < icntl->blockPixelCount/2; i++)
     {
@@ -9446,7 +9446,7 @@ nitf_ImageIO_12PixelReadBlock(nitf_DecompressionControl* control,
       *(blockPtr++) = (a << 4) + (b >>4);
     }
 
-    *blockSize = icntl->blockPixelCount * sizeof(nitf_Uint16);
+    *blockSize = icntl->blockPixelCount * sizeof(uint16_t);
 
     return block;
 }
@@ -9473,9 +9473,9 @@ nitf_CompressionControl  *nitf_ImageIO_12PixelComOpen
 ( nitf_ImageSubheader * subheader, nrt_HashTable* options, nitf_Error * error)
 {
   nitf_ImageIO_12PixelComControl *icntl;   /* The result */
-  nitf_Uint32 numRowsPerBlock;      /* Number of rows per block */
-  nitf_Uint32 numColumnsPerBlock;   /* Number of columns per block */
-  nitf_Uint32 numBands, xBands;     /* Number of bands */
+  uint32_t numRowsPerBlock;      /* Number of rows per block */
+  uint32_t numColumnsPerBlock;   /* Number of columns per block */
+  uint32_t numBands, xBands;     /* Number of bands */
 
   icntl =
       (nitf_ImageIO_12PixelComControl *)
@@ -9512,10 +9512,10 @@ CATCH_ERROR:
 
 NITF_BOOL
 nitf_ImageIO_12PixelComStart(nitf_CompressionControl *object,
-                             nitf_Uint64 offset,
-                             nitf_Uint64 dataLength,
-                             nitf_Uint64 * blockMask,
-                             nitf_Uint64 * padMask,
+                             uint64_t offset,
+                             uint64_t dataLength,
+                             uint64_t * blockMask,
+                             uint64_t * padMask,
                              nitf_Error * error)
 {
   nitf_ImageIO_12PixelComControl *icntl;  /* The internal data structure */
@@ -9536,7 +9536,7 @@ nitf_ImageIO_12PixelComStart(nitf_CompressionControl *object,
 
   if (icntl->buffer == NULL)
   {
-    icntl->buffer = (nitf_Uint8 *) NITF_MALLOC(icntl->blockSizeCompressed);
+    icntl->buffer = (uint8_t *) NITF_MALLOC(icntl->blockSizeCompressed);
     if (icntl->buffer == NULL)
       return(NITF_FAILURE);
   }
@@ -9547,17 +9547,17 @@ nitf_ImageIO_12PixelComStart(nitf_CompressionControl *object,
 NITF_BOOL
 nitf_ImageIO_12PixelComWriteBlock(nitf_CompressionControl * object,
                                   nitf_IOInterface* io,
-                                  const nitf_Uint8 *data,
+                                  const uint8_t *data,
                                   NITF_BOOL pad,
                                   NITF_BOOL noData,
                                   nitf_Error *error)
 {
   nitf_ImageIO_12PixelComControl *icntl;  /* The internal data structure */
   size_t pairs;                /* Number of pixel pairs */
-  nitf_Uint16 *dp;             /* Pointer into input buffer */
-  nitf_Uint8 *bp;              /* Pointer into output buffer */
-  nitf_Uint16 i1;              /* First pixel in input pair */
-  nitf_Uint16 i2;              /* Second pixel in input pair */
+  uint16_t *dp;             /* Pointer into input buffer */
+  uint8_t *bp;              /* Pointer into output buffer */
+  uint16_t i1;              /* First pixel in input pair */
+  uint16_t i2;              /* Second pixel in input pair */
   nitf_Off fileOffset;         /* File offset for write */
   size_t i;
 
@@ -9573,7 +9573,7 @@ nitf_ImageIO_12PixelComWriteBlock(nitf_CompressionControl * object,
 
   pairs = icntl->blockPixelCount/2;
   bp = icntl->buffer;
-  dp = (nitf_Uint16 *) data;
+  dp = (uint16_t *) data;
   for(i=0;i<pairs;i++)
   {
     i1 = *(dp++);
@@ -9720,7 +9720,7 @@ NITFPRIV(void) nitf_ImageIOControl_print(_nitf_ImageIOControl * cntl,
                                          FILE * file, int full)
 {
 #ifdef NITF_DEBUG
-    nitf_Uint32 i;
+    uint32_t i;
 
     if (file == NULL)
         file = stdout;
@@ -9845,13 +9845,13 @@ NITFPRIV(void) nitf_ImageIOBlock_print(_nitf_ImageIOBlock * blockIO,
 }
 
 NITFAPI(NITF_BOOL) nitf_ImageIO_getMaskInfo(nitf_ImageIO *nitf,
-                                            nitf_Uint32 *imageDataOffset,
-                                            nitf_Uint32 *blockRecordLength,
-                                            nitf_Uint32 *padRecordLength,
-                                            nitf_Uint32 *padPixelValueLength,
-                                            nitf_Uint8 **padValue,
-                                            nitf_Uint64 **blockMask,
-                                            nitf_Uint64 **padMask)
+                                            uint32_t *imageDataOffset,
+                                            uint32_t *blockRecordLength,
+                                            uint32_t *padRecordLength,
+                                            uint32_t *padPixelValueLength,
+                                            uint8_t **padValue,
+                                            uint64_t **blockMask,
+                                            uint64_t **padMask)
 {
     _nitf_ImageIO *initf = (_nitf_ImageIO *) nitf;
 

--- a/modules/c/nitf/source/ImageReader.c
+++ b/modules/c/nitf/source/ImageReader.c
@@ -33,7 +33,7 @@ nitf_ImageReader_getBlockingInfo(nitf_ImageReader * imageReader,
 
 NITFAPI(NITF_BOOL) nitf_ImageReader_read(nitf_ImageReader * imageReader,
                                          nitf_SubWindow * subWindow,
-                                         nitf_Uint8 ** user,
+                                         uint8_t ** user,
                                          int *padded, nitf_Error * error)
 {
     return (NITF_BOOL) nitf_ImageIO_read(imageReader->imageDeblocker,
@@ -41,9 +41,9 @@ NITFAPI(NITF_BOOL) nitf_ImageReader_read(nitf_ImageReader * imageReader,
                                          subWindow, user, padded, error);
 }
 
-NITFAPI(nitf_Uint8*) nitf_ImageReader_readBlock(nitf_ImageReader * imageReader,
-                                                nitf_Uint32 blockNumber,
-                                                nitf_Uint64* blockSize,
+NITFAPI(uint8_t*) nitf_ImageReader_readBlock(nitf_ImageReader * imageReader,
+                                                uint32_t blockNumber,
+                                                uint64_t* blockSize,
                                                 nitf_Error * error)
 {
     if(!imageReader->directBlockRead)

--- a/modules/c/nitf/source/ImageSubheader.c
+++ b/modules/c/nitf/source/ImageSubheader.c
@@ -38,9 +38,9 @@
 #define _NITF_BLOCK_DEFAULT_MIN (1024)
 
 NITFPRIV(void)
-nitf_ImageSubheader_computeBlockingImpl(nitf_Uint32 numDims,
-                                        nitf_Uint32* numDimsPerBlock,
-                                        nitf_Uint32* numBlocksPerDim)
+nitf_ImageSubheader_computeBlockingImpl(uint32_t numDims,
+                                        uint32_t* numDimsPerBlock,
+                                        uint32_t* numBlocksPerDim)
 {
     /* for 2500C - if > 8192, then NROWS/NCOLS specifies NPPBV/NPPBH */
     if (*numDimsPerBlock > _NITF_BLOCK_DIM_MAX)
@@ -165,7 +165,7 @@ CATCH_ERROR:
 NITFAPI(nitf_ImageSubheader *)
 nitf_ImageSubheader_clone(nitf_ImageSubheader * source, nitf_Error * error)
 {
-    nitf_Uint32 nbands, i;
+    uint32_t nbands, i;
 
     nitf_ImageSubheader *subhdr = NULL;
     if (source)
@@ -452,7 +452,7 @@ nitf_ImageSubheader_getCornersAsLatLons(nitf_ImageSubheader* subheader,
 NITFAPI(void) nitf_ImageSubheader_destruct(nitf_ImageSubheader ** subhdr)
 {
     nitf_Error e;
-    nitf_Uint32 nbands, i;
+    uint32_t nbands, i;
 
     if (!*subhdr)
         return;
@@ -541,17 +541,17 @@ NITFAPI(void) nitf_ImageSubheader_destruct(nitf_ImageSubheader ** subhdr)
 
 NITFAPI(NITF_BOOL)
 nitf_ImageSubheader_setPixelInformation(nitf_ImageSubheader * subhdr,
-                                        const char *pvtype, nitf_Uint32 nbpp,
-                                        nitf_Uint32 abpp,
+                                        const char *pvtype, uint32_t nbpp,
+                                        uint32_t abpp,
                                         const char *justification,
                                         const char *irep,
-                                        const char *icat, nitf_Uint32 bandCount,
+                                        const char *icat, uint32_t bandCount,
                                         nitf_BandInfo ** bands,
                                         nitf_Error * error)
 {
-    nitf_Uint32 nbands;         /* The NBANDS value */
-    nitf_Uint32 xbands;         /* The XBANDS value */
-    nitf_Uint32 bandCountOld;   /* The current band count */
+    uint32_t nbands;         /* The NBANDS value */
+    uint32_t xbands;         /* The XBANDS value */
+    uint32_t bandCountOld;   /* The current band count */
 
     /*    Get currrent band count (need to free old bands) */
 
@@ -602,7 +602,7 @@ nitf_ImageSubheader_setPixelInformation(nitf_ImageSubheader * subhdr,
 
     if (subhdr->bandInfo != NULL)       /* Free existing band data */
     {
-        nitf_Uint32 i;
+        uint32_t i;
 
         for (i = 0; i < bandCountOld; i++)
         {
@@ -616,13 +616,13 @@ nitf_ImageSubheader_setPixelInformation(nitf_ImageSubheader * subhdr,
 }
 
 
-NITFAPI(nitf_Uint32) nitf_ImageSubheader_getBandCount(nitf_ImageSubheader *
+NITFAPI(uint32_t) nitf_ImageSubheader_getBandCount(nitf_ImageSubheader *
         subhdr,
         nitf_Error * error)
 {
-    nitf_Uint32 nbands;         /* The NBANDS field */
-    nitf_Uint32 xbands;         /* The XBANDS field */
-    nitf_Uint32 bandCount;      /* The result */
+    uint32_t nbands;         /* The NBANDS field */
+    uint32_t xbands;         /* The XBANDS field */
+    uint32_t bandCount;      /* The result */
 
     /*    Get the required subheader values */
 
@@ -662,9 +662,9 @@ NITFAPI(nitf_Uint32) nitf_ImageSubheader_getBandCount(nitf_ImageSubheader *
 
 NITFAPI(nitf_BandInfo *)
 nitf_ImageSubheader_getBandInfo(nitf_ImageSubheader * subhdr,
-                                nitf_Uint32 band, nitf_Error * error)
+                                uint32_t band, nitf_Error * error)
 {
-    nitf_Uint32 bandCount;      /* The band count for the range check */
+    uint32_t bandCount;      /* The band count for the range check */
 
     /*   Range check */
 
@@ -687,13 +687,13 @@ nitf_ImageSubheader_getBandInfo(nitf_ImageSubheader * subhdr,
 
 NITFAPI(NITF_BOOL) nitf_ImageSubheader_createBands(nitf_ImageSubheader *
         subhdr,
-        nitf_Uint32 numBands,
+        uint32_t numBands,
         nitf_Error * error)
 {
     nitf_BandInfo *bandInfo = NULL;     /* temp BandInfo object */
     nitf_BandInfo **infos = NULL;       /* new BandInfo array */
-    nitf_Uint32 curBandCount;   /* current band count */
-    nitf_Uint32 totalBandCount; /* total band count */
+    uint32_t curBandCount;   /* current band count */
+    uint32_t totalBandCount; /* total band count */
     int i;
     char buf[256];              /* temp buf */
 
@@ -774,13 +774,13 @@ CATCH_ERROR:
 
 NITFAPI(NITF_BOOL) nitf_ImageSubheader_removeBand(
     nitf_ImageSubheader * subhdr,
-    nitf_Uint32 index,
+    uint32_t index,
     nitf_Error * error
 )
 {
     nitf_BandInfo *bandInfo = NULL;     /* temp BandInfo object */
     nitf_BandInfo **infos = NULL;       /* new BandInfo array */
-    nitf_Uint32 curBandCount;   /* current band count */
+    uint32_t curBandCount;   /* current band count */
     int i;
     char buf[256];              /* temp buf */
 
@@ -860,14 +860,14 @@ CATCH_ERROR:
  *  8192
  */
 
-NITFPRIV(nitf_Uint32) selectBlockSize(nitf_Uint32 size)
+NITFPRIV(uint32_t) selectBlockSize(uint32_t size)
 {
-    nitf_Uint32 blockSize;      /* Current block size */
-    nitf_Uint32 blockSizeMin;   /* Block size that give minimum pad */
-    nitf_Uint32 padSize;        /* Current pad size */
-    nitf_Uint32 padSizeMin;     /* Current minimum pad size */
+    uint32_t blockSize;      /* Current block size */
+    uint32_t blockSizeMin;   /* Block size that give minimum pad */
+    uint32_t padSize;        /* Current pad size */
+    uint32_t padSizeMin;     /* Current minimum pad size */
 
-    nitf_Uint32 remainder;      /* Remainder of size/blockSize */
+    uint32_t remainder;      /* Remainder of size/blockSize */
 
     /*   Start at MAX and work backwards */
 
@@ -899,8 +899,8 @@ NITFPRIV(nitf_Uint32) selectBlockSize(nitf_Uint32 size)
 
 NITFAPI(NITF_BOOL) nitf_ImageSubheader_getDimensions(nitf_ImageSubheader *
         subhdr,
-        nitf_Uint32 * numRows,
-        nitf_Uint32 * numCols,
+        uint32_t * numRows,
+        uint32_t * numCols,
         nitf_Error * error)
 {
 
@@ -920,15 +920,15 @@ NITFAPI(NITF_BOOL) nitf_ImageSubheader_getDimensions(nitf_ImageSubheader *
 
 NITFAPI(NITF_BOOL) nitf_ImageSubheader_getBlocking(nitf_ImageSubheader *
         subhdr,
-        nitf_Uint32 * numRows,
-        nitf_Uint32 * numCols,
-        nitf_Uint32 *
+        uint32_t * numRows,
+        uint32_t * numCols,
+        uint32_t *
         numRowsPerBlock,
-        nitf_Uint32 *
+        uint32_t *
         numColsPerBlock,
-        nitf_Uint32 *
+        uint32_t *
         numBlocksPerRow,
-        nitf_Uint32 *
+        uint32_t *
         numBlocksPerCol,
         char *imode,
         nitf_Error * error)
@@ -999,12 +999,12 @@ NITFAPI(NITF_BOOL) nitf_ImageSubheader_getCompression(nitf_ImageSubheader *
 
 NITFAPI(NITF_BOOL) nitf_ImageSubheader_setDimensions(nitf_ImageSubheader *
         subhdr,
-        nitf_Uint32 numRows,
-        nitf_Uint32 numCols,
+        uint32_t numRows,
+        uint32_t numCols,
         nitf_Error * error)
 {
-    nitf_Uint32 numRowsPerBlock;        /* The number of rows/block */
-    nitf_Uint32 numColsPerBlock;        /* The number of columns/block */
+    uint32_t numRowsPerBlock;        /* The number of rows/block */
+    uint32_t numColsPerBlock;        /* The number of columns/block */
 
     if (numRows <= _NITF_BLOCK_DIM_MAX)
         numRowsPerBlock = numRows;
@@ -1024,12 +1024,12 @@ NITFAPI(NITF_BOOL) nitf_ImageSubheader_setDimensions(nitf_ImageSubheader *
 
 NITFAPI(void)
 nitf_ImageSubheader_computeBlocking(
-        nitf_Uint32 numRows,
-        nitf_Uint32 numCols,
-        nitf_Uint32* numRowsPerBlock,
-        nitf_Uint32* numColsPerBlock,
-        nitf_Uint32* numBlocksPerCol,
-        nitf_Uint32* numBlocksPerRow)
+        uint32_t numRows,
+        uint32_t numCols,
+        uint32_t* numRowsPerBlock,
+        uint32_t* numColsPerBlock,
+        uint32_t* numBlocksPerCol,
+        uint32_t* numBlocksPerRow)
 {
     /*
        The number of blocks per column is a backwards way of saying the number
@@ -1046,15 +1046,15 @@ nitf_ImageSubheader_computeBlocking(
 }
 
 NITFAPI(NITF_BOOL) nitf_ImageSubheader_setBlocking(nitf_ImageSubheader *subhdr,
-        nitf_Uint32 numRows,
-        nitf_Uint32 numCols,
-        nitf_Uint32 numRowsPerBlock,
-        nitf_Uint32 numColsPerBlock,
+        uint32_t numRows,
+        uint32_t numCols,
+        uint32_t numRowsPerBlock,
+        uint32_t numColsPerBlock,
         const char *imode,
         nitf_Error *error)
 {
-    nitf_Uint32 numBlocksPerRow;        /* Number of blocks/row */
-    nitf_Uint32 numBlocksPerCol;        /* Number of blocks/column */
+    uint32_t numBlocksPerRow;        /* Number of blocks/row */
+    uint32_t numBlocksPerCol;        /* Number of blocks/column */
 
     nitf_ImageSubheader_computeBlocking(numRows,
                                         numCols,
@@ -1110,7 +1110,7 @@ NITFAPI(int) nitf_ImageSubheader_insertImageComment
     nitf_Error * error
 )
 {
-    nitf_Uint32 numComments;
+    uint32_t numComments;
     nitf_ListIterator iterPos;
     nitf_Field* field = NULL;
     char numCommentBuf[NITF_NICOM_SZ + 1];
@@ -1175,7 +1175,7 @@ NITFAPI(NITF_BOOL) nitf_ImageSubheader_removeImageComment
     nitf_Error * error
 )
 {
-    nitf_Uint32 numComments;    /* number of comments */
+    uint32_t numComments;    /* number of comments */
     char commentBuf[NITF_NICOM_SZ + 1];
     nitf_ListIterator iterPos;
     nitf_Field* field = NULL;

--- a/modules/c/nitf/source/ImageWriter.c
+++ b/modules/c/nitf/source/ImageWriter.c
@@ -29,11 +29,11 @@
  */
 typedef struct _ImageWriterImpl
 {
-    nitf_Uint32 numBitsPerPixel;
-    nitf_Uint32 numImageBands;
-    nitf_Uint32 numMultispectralImageBands;
-    nitf_Uint32 numRows;
-    nitf_Uint32 numCols;
+    uint32_t numBitsPerPixel;
+    uint32_t numImageBands;
+    uint32_t numMultispectralImageBands;
+    uint32_t numRows;
+    uint32_t numCols;
     nitf_ImageSource *imageSource;
     nitf_ImageIO *imageBlocker;
     NRT_BOOL directBlockWrite;
@@ -61,11 +61,11 @@ NITFPRIV(NITF_BOOL) ImageWriter_write(NITF_DATA * data,
                                       nitf_IOInterface* output,
                                       nitf_Error * error)
 {
-    nitf_Uint8 **user = NULL;
-    nitf_Uint8 *userContig = NULL;
-    nitf_Uint32 row, band, block;
+    uint8_t **user = NULL;
+    uint8_t *userContig = NULL;
+    uint32_t row, band, block;
     size_t rowSize, blockSize, numBlocks;
-    nitf_Uint32 numImageBands = 0;
+    uint32_t numImageBands = 0;
     nitf_Off offset;
     nitf_BandSource *bandSrc = NULL;
     nitf_BlockingInfo* blockInfo = NULL;
@@ -101,7 +101,7 @@ NITFPRIV(NITF_BOOL) ImageWriter_write(NITF_DATA * data,
 
         nitf_BlockingInfo_destruct(&blockInfo);
 
-        userContig = (nitf_Uint8 *) NITF_MALLOC(sizeof(nitf_Uint8*) * blockSize);
+        userContig = (uint8_t *) NITF_MALLOC(sizeof(uint8_t*) * blockSize);
         if (!userContig)
         {
             nitf_Error_init(error, NITF_STRERROR(NITF_ERRNO), NITF_CTXT,
@@ -139,7 +139,7 @@ NITFPRIV(NITF_BOOL) ImageWriter_write(NITF_DATA * data,
     }
     else
     {
-        user = (nitf_Uint8 **) NITF_MALLOC(sizeof(nitf_Uint8*) * numImageBands);
+        user = (uint8_t **) NITF_MALLOC(sizeof(uint8_t*) * numImageBands);
         if (!user)
         {
             nitf_Error_init(error, NITF_STRERROR(NITF_ERRNO), NITF_CTXT,
@@ -148,7 +148,7 @@ NITFPRIV(NITF_BOOL) ImageWriter_write(NITF_DATA * data,
         }
         for (band = 0; band < numImageBands; band++)
         {
-            user[band] = (nitf_Uint8 *) NITF_MALLOC(rowSize);
+            user[band] = (uint8_t *) NITF_MALLOC(rowSize);
             if (!user[band])
             {
                 nitf_Error_init(error, NITF_STRERROR(NITF_ERRNO), NITF_CTXT,
@@ -311,7 +311,7 @@ NITFAPI(NITF_BOOL) nitf_ImageWriter_setDirectBlockWrite(nitf_ImageWriter *imageW
         nitf_Error *error)
 {
     ImageWriterImpl *impl;
-    nitf_Uint32 numImageBands;
+    uint32_t numImageBands;
 
     impl = (ImageWriterImpl*)imageWriter->data;
     numImageBands = impl->numImageBands + impl->numMultispectralImageBands;
@@ -327,8 +327,8 @@ NITFAPI(NITF_BOOL) nitf_ImageWriter_setDirectBlockWrite(nitf_ImageWriter *imageW
 }
 
 NITFAPI(NITF_BOOL) nitf_ImageWriter_setPadPixel(nitf_ImageWriter* imageWriter,
-                                                nitf_Uint8* value,
-                                                nitf_Uint32 length,
+                                                uint8_t* value,
+                                                uint32_t length,
                                                 nitf_Error* error)
 {
     ImageWriterImpl *impl = (ImageWriterImpl*)imageWriter->data;

--- a/modules/c/nitf/source/LookupTable.c
+++ b/modules/c/nitf/source/LookupTable.c
@@ -22,8 +22,8 @@
 
 #include "nitf/LookupTable.h"
 
-NITFAPI(nitf_LookupTable *) nitf_LookupTable_construct(nitf_Uint32 tables,
-        nitf_Uint32 entries,
+NITFAPI(nitf_LookupTable *) nitf_LookupTable_construct(uint32_t tables,
+        uint32_t entries,
         nitf_Error * error)
 {
     nitf_LookupTable *lt = NULL;
@@ -104,8 +104,8 @@ NITFAPI(void) nitf_LookupTable_destruct(nitf_LookupTable ** lt)
 
 
 NITFAPI(NITF_BOOL) nitf_LookupTable_init(nitf_LookupTable * lut,
-        nitf_Uint32 numTables,
-        nitf_Uint32 numEntries,
+        uint32_t numTables,
+        uint32_t numEntries,
         const NITF_DATA * tables,
         nitf_Error * error)
 {
@@ -125,7 +125,7 @@ NITFAPI(NITF_BOOL) nitf_LookupTable_init(nitf_LookupTable * lut,
     {
         if (!lut->table)
         {
-            lut->table = (nitf_Uint8 *) NITF_MALLOC(numTables * numEntries);
+            lut->table = (uint8_t *) NITF_MALLOC(numTables * numEntries);
             if (!lut->table)
             {
                 nitf_Error_initf(error, NITF_CTXT,

--- a/modules/c/nitf/source/RESubheader.c
+++ b/modules/c/nitf/source/RESubheader.c
@@ -76,7 +76,7 @@ CATCH_ERROR:
 NITFAPI(nitf_RESubheader *)
 nitf_RESubheader_clone(nitf_RESubheader * source, nitf_Error * error)
 {
-    nitf_Uint32 subLen;
+    uint32_t subLen;
     nitf_RESubheader *subhdr = NULL;
     if (source)
     {

--- a/modules/c/nitf/source/Reader.c
+++ b/modules/c/nitf/source/Reader.c
@@ -158,7 +158,7 @@ readValue(nitf_Reader* reader,
           nitf_Error* error);
 NITFPRIV(NITF_BOOL)
 handleTRE(nitf_Reader* reader,
-          nitf_Uint32 length,
+          uint32_t length,
           nitf_TRE* tre,
           nitf_Error* error);
 
@@ -289,14 +289,14 @@ readValue(nitf_Reader* reader, nitf_Field* field, int length, nitf_Error* error)
     {
         if (length == NITF_INT16_SZ)
         {
-            nitf_Int16 int16 = (nitf_Int16)NITF_NTOHS(*((nitf_Int16*)buf));
+            int16_t int16 = (int16_t)NITF_NTOHS(*((int16_t*)buf));
             if (!nitf_Field_setRawData(
                         field, (NITF_DATA*)&int16, length, error))
                 goto CATCH_ERROR;
         }
         else if (length == NITF_INT32_SZ)
         {
-            nitf_Int32 int32 = (nitf_Int32)NITF_NTOHL(*((nitf_Int32*)buf));
+            int32_t int32 = (int32_t)NITF_NTOHL(*((int32_t*)buf));
             if (!nitf_Field_setRawData(
                         field, (NITF_DATA*)&int32, length, error))
                 goto CATCH_ERROR;
@@ -522,9 +522,9 @@ readImageSubheader(nitf_Reader* reader,
     /* List iterator pointing to the image segment */
     nitf_ListIterator listIter = nitf_List_begin(reader->record->images);
 
-    nitf_Uint32 numComments; /* Number of comment fields */
-    nitf_Uint32 nbands; /* An integer representing the \nbands field */
-    nitf_Uint32 xbands; /* An integer representing the xbands field */
+    uint32_t numComments; /* Number of comment fields */
+    uint32_t nbands; /* An integer representing the \nbands field */
+    uint32_t xbands; /* An integer representing the xbands field */
     nitf_Off subheaderStart; /* Start position of image subheader */
     nitf_Off subheaderEnd; /* End position of image subheader */
     nitf_Off expectedSubheaderLength = 0; /* What the file header says the
@@ -720,7 +720,7 @@ readLabelSubheader(nitf_Reader* reader,
     /* label sub-header object */
     subhdr = ((nitf_LabelSegment*)nitf_ListIterator_get(&listIter))->subheader;
 
-    /* nitf_Uint32 lxshdl, lxsofl; */
+    /* uint32_t lxshdl, lxsofl; */
     TRY_READ_MEMBER_VALUE(reader, subhdr, NITF_LA);
     TRY_READ_MEMBER_VALUE(reader, subhdr, NITF_LID);
     TRY_READ_MEMBER_VALUE(reader, subhdr, NITF_LSCLAS);
@@ -802,14 +802,14 @@ readDESubheader(nitf_Reader* reader,
     nitf_DESubheader* subhdr;
     nitf_FileHeader* hdr;
     /* Length of the sub-header */
-    nitf_Uint32 subLen;
+    uint32_t subLen;
     nitf_Off currentOffset;
     /* Position where this DE Subheader begins */
     nitf_Off subheaderStart;
     /* End position of DE Subheader */
     nitf_Off subheaderEnd;
     /* What the header says the length ought to be */
-    nitf_Uint32 expectedSubheaderLength = 0;
+    uint32_t expectedSubheaderLength = 0;
     char desID[NITF_DESTAG_SZ + 1]; /* DES ID string */
 
     nitf_ListIterator listIter =
@@ -940,7 +940,7 @@ readRESubheader(nitf_Reader* reader,
     int i;
     nitf_RESegment* segment;
     nitf_RESubheader* subhdr;
-    nitf_Uint32 subLen;
+    uint32_t subLen;
     /* List iterator pointing to the reserved extension segment */
     nitf_ListIterator listIter =
             nitf_List_begin(reader->record->reservedExtensions);
@@ -1005,16 +1005,16 @@ NITFPRIV(NITF_BOOL) readHeader(nitf_Reader* reader, nitf_Error* error)
     nitf_FileHeader* fileHeader = reader->record->header;
 
     /* generic uint32 */
-    nitf_Uint32 num32;
+    uint32_t num32;
 
     /* Number of bytes consumed when reading header */
-    nitf_Uint32 actualHeaderLength;
+    uint32_t actualHeaderLength;
 
     /* What the header says its lenght ought to be */
-    nitf_Uint32 expectedHeaderLength = 0;
+    uint32_t expectedHeaderLength = 0;
 
     nitf_Version fver;
-    /*nitf_Uint32 udhdl, udhofl, xhdl, xhdlofl; */
+    /*uint32_t udhdl, udhofl, xhdl, xhdlofl; */
 
     char fileLenBuf[NITF_FL_SZ + 1]; /* File length buffer */
     char streamingBuf[NITF_FL_SZ];
@@ -1152,7 +1152,7 @@ NITFPRIV(NITF_BOOL) readHeader(nitf_Reader* reader, nitf_Error* error)
     TRY_READ_XHD(reader);
 
     actualHeaderLength =
-            (nitf_Uint32)nitf_IOInterface_tell(reader->input, error);
+            (uint32_t)nitf_IOInterface_tell(reader->input, error);
     NITF_TRY_GET_UINT32(fileHeader->NITF_HL, &expectedHeaderLength, error);
     if (actualHeaderLength != expectedHeaderLength)
     {
@@ -1185,7 +1185,7 @@ readExtras(nitf_Reader* reader,
            nitf_Error* error)
 {
     /* Total length of the extras seciton */
-    nitf_Uint32 totalLength;
+    uint32_t totalLength;
     /* Offset in the stream to the end of the section */
     nitf_Off sectionEndOffset;
     /* The current io offset */
@@ -1271,7 +1271,7 @@ readTRE(nitf_Reader* reader, nitf_Extensions* ext, nitf_Error* error)
     nitf_TRE* tre = NULL;
 
     /* length of the TRE object */
-    nitf_Uint32 length;
+    uint32_t length;
     nitf_Field* lengthValue;
 
     memset(etag, 0, NITF_ETAG_SZ + 1);
@@ -1321,7 +1321,7 @@ CATCH_ERROR:
 
 NITFPRIV(NITF_BOOL)
 handleTRE(nitf_Reader* reader,
-          nitf_Uint32 length,
+          uint32_t length,
           nitf_TRE* tre,
           nitf_Error* error)
 {
@@ -1411,8 +1411,8 @@ CATCH_ERROR:
 NITFPRIV(nitf_BandInfo**)
 readBandInfo(nitf_Reader* reader, unsigned int nbands, nitf_Error* error)
 {
-    nitf_Uint32 i;
-    nitf_Uint32 numLuts, bandEntriesPerLut;
+    uint32_t i;
+    uint32_t numLuts, bandEntriesPerLut;
     nitf_BandInfo** bandInfo = NULL;
     if (nbands > 0)
     {
@@ -1491,10 +1491,10 @@ nitf_Reader_read(nitf_Reader* reader, nitf_IOHandle ioHandle, nitf_Error* error)
 NITFAPI(nitf_Record*)
 nitf_Reader_readIO(nitf_Reader* reader, nitf_IOInterface* io, nitf_Error* error)
 {
-    nitf_Uint32 i = 0; /* iterator */
-    nitf_Uint32 num32; /* generic uint32 */
-    nitf_Uint32 length32;
-    nitf_Uint64 length;
+    uint32_t i = 0; /* iterator */
+    uint32_t num32; /* generic uint32 */
+    uint32_t length32;
+    uint64_t length;
     nitf_Version fver;
 
     reader->record = nitf_Record_construct(NITF_VER_21, error);

--- a/modules/c/nitf/source/Record.c
+++ b/modules/c/nitf/source/Record.c
@@ -55,105 +55,105 @@
 #define TRE_OVERFLOW_STR "TRE_OVERFLOW"
 #define TRE_OVERFLOW_VERSION 1
 
-NITFAPI(nitf_Uint32)
+NITFAPI(uint32_t)
 nitf_Record_getNumReservedExtensions(const nitf_Record* record,
                                      nitf_Error* error)
 {
     const nitf_FileHeader* fhdr = record->header;
-    nitf_Uint32 num;
+    uint32_t num;
 
     /*  This can only really happen if they have junk in NUMI */
     if (!nitf_Field_get(fhdr->NITF_NUMRES,
                         &num,
                         NITF_CONV_UINT,
-                        sizeof(nitf_Uint32),
+                        sizeof(uint32_t),
                         error))
-        return (nitf_Uint32)-1;
+        return (uint32_t)-1;
 
     return num;
 }
 
-NITFAPI(nitf_Uint32)
+NITFAPI(uint32_t)
 nitf_Record_getNumDataExtensions(const nitf_Record* record, nitf_Error* error)
 {
     const nitf_FileHeader* fhdr = record->header;
-    nitf_Uint32 num;
+    uint32_t num;
 
     /*  This can only really happen if they have junk in the field */
     if (!nitf_Field_get(fhdr->NITF_NUMDES,
                         &num,
                         NITF_CONV_UINT,
-                        sizeof(nitf_Uint32),
+                        sizeof(uint32_t),
                         error))
-        return (nitf_Uint32)-1;
+        return (uint32_t)-1;
 
     return num;
 }
 
-NITFAPI(nitf_Uint32)
+NITFAPI(uint32_t)
 nitf_Record_getNumGraphics(const nitf_Record* record, nitf_Error* error)
 {
     const nitf_FileHeader* fhdr = record->header;
-    nitf_Uint32 num;
+    uint32_t num;
 
     /*  This can only really happen if they have junk in the field */
     if (!nitf_Field_get(fhdr->NITF_NUMS,
                         &num,
                         NITF_CONV_UINT,
-                        sizeof(nitf_Uint32),
+                        sizeof(uint32_t),
                         error))
-        return (nitf_Uint32)-1;
+        return (uint32_t)-1;
 
     return num;
 }
 
-NITFAPI(nitf_Uint32)
+NITFAPI(uint32_t)
 nitf_Record_getNumTexts(const nitf_Record* record, nitf_Error* error)
 {
     const nitf_FileHeader* fhdr = record->header;
-    nitf_Uint32 num;
+    uint32_t num;
 
     /*  This can only really happen if they have junk in the field */
     if (!nitf_Field_get(fhdr->NITF_NUMT,
                         &num,
                         NITF_CONV_UINT,
-                        sizeof(nitf_Uint32),
+                        sizeof(uint32_t),
                         error))
-        return (nitf_Uint32)-1;
+        return (uint32_t)-1;
 
     return num;
 }
 
-NITFAPI(nitf_Uint32)
+NITFAPI(uint32_t)
 nitf_Record_getNumLabels(const nitf_Record* record, nitf_Error* error)
 {
     const nitf_FileHeader* fhdr = record->header;
-    nitf_Uint32 num;
+    uint32_t num;
 
     /*  This can only really happen if they have junk in the field */
     if (!nitf_Field_get(fhdr->NITF_NUMX,
                         &num,
                         NITF_CONV_UINT,
-                        sizeof(nitf_Uint32),
+                        sizeof(uint32_t),
                         error))
-        return (nitf_Uint32)-1;
+        return (uint32_t)-1;
 
     return num;
 }
 
-NITFAPI(nitf_Uint32)
+NITFAPI(uint32_t)
 nitf_Record_getNumImages(const nitf_Record* record, nitf_Error* error)
 {
     const nitf_FileHeader* fhdr = record->header;
-    nitf_Uint32 num;
+    uint32_t num;
 
     /*  This can only really happen if they have junk in the field */
     if (!nitf_Field_get(fhdr->NITF_NUMI,
                         &num,
                         NITF_CONV_UINT,
-                        sizeof(nitf_Uint32),
+                        sizeof(uint32_t),
                         error))
-        return (nitf_Uint32)-1;
+        return (uint32_t)-1;
     return num;
 }
 
@@ -176,16 +176,16 @@ nitf_Record_getNumImages(const nitf_Record* record, nitf_Error* error)
  * \param error The error that occured if index is zero
  */
 
-NITFPRIV(nitf_Uint32)
+NITFPRIV(uint32_t)
 addOverflowSegment(nitf_Record* record,
-                   nitf_Uint32 segmentIndex,
+                   uint32_t segmentIndex,
                    char* segmentType,
                    nitf_Field* securityClass,
                    nitf_FileSecurity* fileSecurity,
                    nitf_DESegment** overflow,
                    nitf_Error* error)
 {
-    nitf_Uint32 overflowIndex;
+    uint32_t overflowIndex;
 
     /* Create the segment */
 
@@ -251,7 +251,7 @@ addOverflowSegment(nitf_Record* record,
 NITFPRIV(NITF_BOOL)
 moveTREs(nitf_Extensions* source,
          nitf_Extensions* destination,
-         nitf_Uint32 skipLength,
+         uint32_t skipLength,
          nitf_Error* error)
 {
     nitf_ExtensionsIterator srcIter; /* Source extension iterator */
@@ -263,14 +263,14 @@ moveTREs(nitf_Extensions* source,
 
     if (skipLength != 0)
     {
-        nitf_Int32 skipLeft; /* Amount left to skip */
-        nitf_Uint32 treLength; /* Length of current TRE */
+        int32_t skipLeft; /* Amount left to skip */
+        uint32_t treLength; /* Length of current TRE */
 
         skipLeft = skipLength;
         while (nitf_ExtensionsIterator_notEqualTo(&srcIter, &srcEnd))
         {
             tre = nitf_ExtensionsIterator_get(&srcIter);
-            treLength = (nitf_Uint32)tre->handler->getCurrentSize(tre, error);
+            treLength = (uint32_t)tre->handler->getCurrentSize(tre, error);
             skipLeft -= treLength;
             if (skipLeft < 1)
                 break;
@@ -314,14 +314,14 @@ moveTREs(nitf_Extensions* source,
 NITFPRIV(NITF_BOOL)
 fixOverflowIndexes(nitf_Record* record,
                    char* type,
-                   nitf_Uint32 segmentIndex,
+                   uint32_t segmentIndex,
                    nitf_Error* error)
 {
     nitf_ListIterator deIter; /* For DE iterating */
     nitf_ListIterator deEnd; /* End point */
     nitf_DESubheader* subheader; /* Current DE segment subheader */
     char oflw[NITF_DESOFLW_SZ + 1]; /* Parent segment type (DESOFLW) */
-    nitf_Uint32 item; /* Segment index (DESITEM) */
+    uint32_t item; /* Segment index (DESITEM) */
 
     /*
      * Scan extensions for ones that have the same type
@@ -393,13 +393,13 @@ fixOverflowIndexes(nitf_Record* record,
 
 NITFPRIV(NITF_BOOL)
 fixSegmentIndexes(nitf_Record* record,
-                  nitf_Uint32 segmentIndex,
+                  uint32_t segmentIndex,
                   nitf_Error* error)
 {
     nitf_FileHeader* header; /* File header */
     nitf_ListIterator segIter; /* Current segment list */
     nitf_ListIterator segEnd; /* Current segment list end */
-    nitf_Uint32 deIndex; /* Desegment index */
+    uint32_t deIndex; /* Desegment index */
 
     /* File header */
 
@@ -611,7 +611,7 @@ CATCH_ERROR:
 
 NITFPRIV(nitf_ImageSegment*)
 createDefaultImageSegment(nitf_Version version,
-                          nitf_Uint32 displayLevel,
+                          uint32_t displayLevel,
                           nitf_Error* error)
 {
     /* Create the new segment */
@@ -919,8 +919,8 @@ nitf_Record_newImageSegment(nitf_Record* record, nitf_Error* error)
     nitf_ImageSegment* segment = NULL;
     nitf_ComponentInfo* info = NULL;
     nitf_ComponentInfo** infoArray = NULL;
-    nitf_Uint32 num;
-    nitf_Uint32 i;
+    uint32_t num;
+    uint32_t i;
     nitf_Version version;
 
     /* Get current num of images */
@@ -1005,8 +1005,8 @@ nitf_Record_newGraphicSegment(nitf_Record* record, nitf_Error* error)
     nitf_GraphicSubheader* header = NULL;
     nitf_ComponentInfo* info = NULL;
     nitf_ComponentInfo** infoArray = NULL;
-    nitf_Uint32 num;
-    nitf_Uint32 i;
+    uint32_t num;
+    uint32_t i;
     nitf_Version version;
 
     /* Get current num of graphics */
@@ -1113,8 +1113,8 @@ nitf_Record_newTextSegment(nitf_Record* record, nitf_Error* error)
     nitf_TextSubheader* header = NULL;
     nitf_ComponentInfo* info = NULL;
     nitf_ComponentInfo** infoArray = NULL;
-    nitf_Uint32 num;
-    nitf_Uint32 i;
+    uint32_t num;
+    uint32_t i;
     nitf_Version version;
 
     /* Get current num of texts */
@@ -1221,8 +1221,8 @@ nitf_Record_newDataExtensionSegment(nitf_Record* record, nitf_Error* error)
     nitf_DESubheader* header = NULL;
     nitf_ComponentInfo* info = NULL;
     nitf_ComponentInfo** infoArray = NULL;
-    nitf_Uint32 num;
-    nitf_Uint32 i;
+    uint32_t num;
+    uint32_t i;
     nitf_Version version;
 
     /* Get current num of DEs */
@@ -1323,13 +1323,13 @@ CATCH_ERROR:
 
 NITFAPI(NITF_BOOL)
 nitf_Record_removeImageSegment(nitf_Record* record,
-                               nitf_Uint32 segmentNumber,
+                               uint32_t segmentNumber,
                                nitf_Error* error)
 {
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_ComponentInfo** infoArray = NULL;
     nitf_ImageSegment* segment = NULL;
-    nitf_Uint32 i;
+    uint32_t i;
     nitf_ListIterator iter = nitf_List_at(record->images, segmentNumber);
 
     if (iter.current == NULL)
@@ -1397,13 +1397,13 @@ CATCH_ERROR:
 
 NITFAPI(NITF_BOOL)
 nitf_Record_removeGraphicSegment(nitf_Record* record,
-                                 nitf_Uint32 segmentNumber,
+                                 uint32_t segmentNumber,
                                  nitf_Error* error)
 {
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_ComponentInfo** infoArray = NULL;
     nitf_GraphicSegment* segment = NULL;
-    nitf_Uint32 i;
+    uint32_t i;
     nitf_ListIterator iter = nitf_List_at(record->graphics, segmentNumber);
 
     if (iter.current == NULL)
@@ -1468,13 +1468,13 @@ CATCH_ERROR:
 
 NITFAPI(NITF_BOOL)
 nitf_Record_removeLabelSegment(nitf_Record* record,
-                               nitf_Uint32 segmentNumber,
+                               uint32_t segmentNumber,
                                nitf_Error* error)
 {
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_ComponentInfo** infoArray = NULL;
     nitf_LabelSegment* segment = NULL;
-    nitf_Uint32 i;
+    uint32_t i;
 
     nitf_ListIterator iter = nitf_List_at(record->labels, segmentNumber);
 
@@ -1541,13 +1541,13 @@ CATCH_ERROR:
 
 NITFAPI(NITF_BOOL)
 nitf_Record_removeTextSegment(nitf_Record* record,
-                              nitf_Uint32 segmentNumber,
+                              uint32_t segmentNumber,
                               nitf_Error* error)
 {
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_ComponentInfo** infoArray = NULL;
     nitf_TextSegment* segment = NULL;
-    nitf_Uint32 i;
+    uint32_t i;
     nitf_ListIterator iter = nitf_List_at(record->texts, segmentNumber);
 
     if (iter.current == NULL)
@@ -1608,13 +1608,13 @@ CATCH_ERROR:
 
 NITFAPI(NITF_BOOL)
 nitf_Record_removeDataExtensionSegment(nitf_Record* record,
-                                       nitf_Uint32 segmentNumber,
+                                       uint32_t segmentNumber,
                                        nitf_Error* error)
 {
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_ComponentInfo** infoArray = NULL;
     nitf_DESegment* segment = NULL;
-    nitf_Uint32 i;
+    uint32_t i;
     nitf_ListIterator iter =
             nitf_List_at(record->dataExtensions, segmentNumber);
 
@@ -1683,13 +1683,13 @@ CATCH_ERROR:
 
 NITFAPI(NITF_BOOL)
 nitf_Record_removeReservedExtensionSegment(nitf_Record* record,
-                                           nitf_Uint32 segmentNumber,
+                                           uint32_t segmentNumber,
                                            nitf_Error* error)
 {
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_ComponentInfo** infoArray = NULL;
     nitf_RESegment* segment = NULL;
-    nitf_Uint32 i;
+    uint32_t i;
 
     nitf_ListIterator iter =
             nitf_List_at(record->reservedExtensions, segmentNumber);
@@ -1758,11 +1758,11 @@ CATCH_ERROR:
 
 NITFAPI(NITF_BOOL)
 nitf_Record_moveImageSegment(nitf_Record* record,
-                             nitf_Uint32 oldIndex,
-                             nitf_Uint32 newIndex,
+                             uint32_t oldIndex,
+                             uint32_t newIndex,
                              nitf_Error* error)
 {
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_ComponentInfo* tempInfo = NULL;
 
     NITF_TRY_GET_UINT32(record->header->numImages, &num, error);
@@ -1797,11 +1797,11 @@ CATCH_ERROR:
 
 NITFAPI(NITF_BOOL)
 nitf_Record_moveGraphicSegment(nitf_Record* record,
-                               nitf_Uint32 oldIndex,
-                               nitf_Uint32 newIndex,
+                               uint32_t oldIndex,
+                               uint32_t newIndex,
                                nitf_Error* error)
 {
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_ComponentInfo* tempInfo = NULL;
 
     NITF_TRY_GET_UINT32(record->header->numGraphics, &num, error);
@@ -1839,11 +1839,11 @@ CATCH_ERROR:
 
 NITFAPI(NITF_BOOL)
 nitf_Record_moveLabelSegment(nitf_Record* record,
-                             nitf_Uint32 oldIndex,
-                             nitf_Uint32 newIndex,
+                             uint32_t oldIndex,
+                             uint32_t newIndex,
                              nitf_Error* error)
 {
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_ComponentInfo* tempInfo = NULL;
 
     NITF_TRY_GET_UINT32(record->header->numLabels, &num, error);
@@ -1878,11 +1878,11 @@ CATCH_ERROR:
 
 NITFAPI(NITF_BOOL)
 nitf_Record_moveTextSegment(nitf_Record* record,
-                            nitf_Uint32 oldIndex,
-                            nitf_Uint32 newIndex,
+                            uint32_t oldIndex,
+                            uint32_t newIndex,
                             nitf_Error* error)
 {
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_ComponentInfo* tempInfo = NULL;
 
     NITF_TRY_GET_UINT32(record->header->numTexts, &num, error);
@@ -1917,11 +1917,11 @@ CATCH_ERROR:
 
 NITFAPI(NITF_BOOL)
 nitf_Record_moveDataExtensionSegment(nitf_Record* record,
-                                     nitf_Uint32 oldIndex,
-                                     nitf_Uint32 newIndex,
+                                     uint32_t oldIndex,
+                                     uint32_t newIndex,
                                      nitf_Error* error)
 {
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_ComponentInfo* tempInfo = NULL;
 
     NITF_TRY_GET_UINT32(record->header->numDataExtensions, &num, error);
@@ -1957,11 +1957,11 @@ CATCH_ERROR:
 
 NITFAPI(NITF_BOOL)
 nitf_Record_moveReservedExtensionSegment(nitf_Record* record,
-                                         nitf_Uint32 oldIndex,
-                                         nitf_Uint32 newIndex,
+                                         uint32_t oldIndex,
+                                         uint32_t newIndex,
                                          nitf_Error* error)
 {
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_ComponentInfo* tempInfo = NULL;
 
     NITF_TRY_GET_UINT32(record->header->numReservedExtensions, &num, error);
@@ -2078,16 +2078,16 @@ nitf_Record_unmergeTREs(nitf_Record* record, nitf_Error* error)
     nitf_ListIterator segEnd;
 
     /* Current segment index */
-    nitf_Uint32 segIndex;
+    uint32_t segIndex;
 
     /* Length of TREs in current section */
-    nitf_Uint32 length;
+    uint32_t length;
 
     /* Max length for this type of section */
-    nitf_Uint32 maxLength;
+    uint32_t maxLength;
 
     /* Overflow index of current extension */
-    nitf_Uint32 overflowIndex;
+    uint32_t overflowIndex;
 
     /* Overflow segment */
     nitf_DESegment* overflow = NULL;
@@ -2244,10 +2244,10 @@ NITFAPI(NITF_BOOL) nitf_Record_mergeTREs(nitf_Record* record, nitf_Error* error)
     nitf_ListIterator deEnd;
 
     /* Current DE segment index (one based) */
-    nitf_Uint32 deIndex;
+    uint32_t deIndex;
 
     /* Number of DE segments removed */
-    nitf_Int32 deRemoved;
+    int32_t deRemoved;
 
     deIter = nitf_List_begin(record->dataExtensions);
     deEnd = nitf_List_end(record->dataExtensions);
@@ -2290,7 +2290,7 @@ NITFAPI(NITF_BOOL) nitf_Record_mergeTREs(nitf_Record* record, nitf_Error* error)
         /* This is an overflow */
         if (strcmp(desid, TRE_OVERFLOW_STR) == 0)
         {
-            nitf_Uint32 segIndex;
+            uint32_t segIndex;
             char type[NITF_DESOFLW_SZ + 1];
             NITF_BOOL eflag;
 

--- a/modules/c/nitf/source/RowSource.c
+++ b/modules/c/nitf/source/RowSource.c
@@ -34,13 +34,13 @@ typedef struct _RowSourceImpl
     void *algorithm;            /* The algorithm object */
     /* Pointer to the next row function */
     NITF_ROW_SOURCE_NEXT_ROW nextRow;
-    nitf_Uint32 band;           /* Associate output band */
-    nitf_Uint32 numRows;        /* Number of rows */
-    nitf_Uint32 rowLength;      /* Length of each row in bytes (single band) */
+    uint32_t band;           /* Associate output band */
+    uint32_t numRows;        /* Number of rows */
+    uint32_t rowLength;      /* Length of each row in bytes (single band) */
 
-    nitf_Uint8 *rowBuffer;      /* The row buffer */
-    nitf_Uint8 *nextPtr;        /* Points to next byte to be transfered */
-    nitf_Uint64 bytesLeft;      /* Bytes left to be processed */
+    uint8_t *rowBuffer;      /* The row buffer */
+    uint8_t *nextPtr;        /* Points to next byte to be transfered */
+    uint64_t bytesLeft;      /* Bytes left to be processed */
 }
 RowSourceImpl;
 
@@ -54,8 +54,8 @@ NITFPRIV(NITF_BOOL) RowSource_read(NITF_DATA * data, void* buf, nitf_Off size,  
                                    nitf_Error * error)  /* For error returns */
 {
     RowSourceImpl *impl;        /* Instance data */
-    nitf_Uint64 xfrCount;       /* Transfer count */
-    nitf_Uint64 remainder;      /* Amount left to transfer */
+    uint64_t xfrCount;       /* Transfer count */
+    uint64_t remainder;      /* Amount left to transfer */
     char *bufPtr;               /* Current location in output buffer */
 
     impl = (RowSourceImpl *) data;
@@ -133,9 +133,9 @@ static nitf_IDataSource iRowSource =
 NITFAPI(nitf_BandSource *) nitf_RowSource_construct(void *algorithm,
         NITF_ROW_SOURCE_NEXT_ROW
         nextRow,
-        nitf_Uint32 band,
-        nitf_Uint32 numRows,
-        nitf_Uint32 rowLength,
+        uint32_t band,
+        uint32_t numRows,
+        uint32_t rowLength,
         nitf_Error * error)
 {
     nitf_BandSource *source;    /* The result */

--- a/modules/c/nitf/source/SegmentReader.c
+++ b/modules/c/nitf/source/SegmentReader.c
@@ -61,7 +61,7 @@ NITFAPI(nitf_Off) nitf_SegmentReader_seek(nitf_SegmentReader * segmentReader,
                                        nitf_Off offset,
                                        int whence, nitf_Error * error)
 {
-    nitf_Uint64 baseOffset;     /* Bas offset to the data */
+    uint64_t baseOffset;     /* Bas offset to the data */
     nitf_Off actualPosition;       /* Real file position (no base offset) */
 
     baseOffset = segmentReader->baseOffset;

--- a/modules/c/nitf/source/SegmentSource.c
+++ b/modules/c/nitf/source/SegmentSource.c
@@ -61,7 +61,7 @@ NITFPRIV(NITF_BOOL) MemorySource_contigRead(
         nitf_Error * error)
 {
     memcpy(buf,
-           (const nitf_Uint8*)memorySource->data + memorySource->mark,
+           (const uint8_t*)memorySource->data + memorySource->mark,
            size);
     memorySource->mark += size;
     return NITF_SUCCESS;
@@ -75,8 +75,8 @@ NITFPRIV(NITF_BOOL) MemorySource_offsetRead(
         nitf_Error * error)
 {
     int i = 0;
-    const nitf_Uint8* src = (const nitf_Uint8*)memorySource->data;
-    nitf_Uint8* dest = (nitf_Uint8*)buf;
+    const uint8_t* src = (const uint8_t*)memorySource->data;
+    uint8_t* dest = (uint8_t*)buf;
 
     while (i < size)
     {
@@ -309,15 +309,15 @@ NITFPRIV(NITF_BOOL) FileSource_offsetRead(FileSourceImpl * fileSource,
 
     nitf_Off tsize = size * (fileSource->byteSkip + 1);
 
-    nitf_Uint8* tbuf;
-    nitf_Uint8* bufPtr = (nitf_Uint8*)buf;
+    uint8_t* tbuf;
+    uint8_t* bufPtr = (uint8_t*)buf;
 
     nitf_Off lmark = 0;
     int i = 0;
     if (tsize + fileSource->mark > fileSource->size)
         tsize = fileSource->size - fileSource->mark;
 
-    tbuf = (nitf_Uint8 *) NITF_MALLOC(tsize);
+    tbuf = (uint8_t *) NITF_MALLOC(tsize);
     if (!tbuf)
     {
         nitf_Error_init(error,

--- a/modules/c/nitf/source/StreamIOWriteHandler.c
+++ b/modules/c/nitf/source/StreamIOWriteHandler.c
@@ -26,8 +26,8 @@
 typedef struct _WriteHandlerImpl
 {
     nitf_IOInterface* ioHandle;
-    nitf_Uint64       offset;
-    nitf_Uint64       bytes;
+    uint64_t       offset;
+    uint64_t       bytes;
 } WriteHandlerImpl;
 
 
@@ -40,8 +40,8 @@ NITFPRIV(NITF_BOOL) WriteHandler_write
     (NITF_DATA * data, nitf_IOInterface* output, nitf_Error * error)
 {
     WriteHandlerImpl *impl = NULL;
-    nitf_Uint64 toWrite;
-    nitf_Uint32 bytesThisPass;
+    uint64_t toWrite;
+    uint32_t bytesThisPass;
     char *buf = NULL;
 
     /* cast it to the structure we know about */
@@ -70,7 +70,7 @@ NITFPRIV(NITF_BOOL) WriteHandler_write
     while (toWrite > 0)
     {
         bytesThisPass = toWrite >= _STREAM_CHUNK_SIZE ? _STREAM_CHUNK_SIZE :
-                (nitf_Uint32) toWrite;
+                (uint32_t) toWrite;
 
         /* read */
         if (!nitf_IOInterface_read(impl->ioHandle, buf, bytesThisPass, error))
@@ -107,8 +107,8 @@ NITFPRIV(void) WriteHandler_destruct(NITF_DATA * data)
 
 NITFAPI(nitf_WriteHandler*)
 nitf_StreamIOWriteHandler_construct(nitf_IOInterface *ioHandle,
-                                    nitf_Uint64 offset,
-                                    nitf_Uint64 bytes,
+                                    uint64_t offset,
+                                    uint64_t bytes,
                                     nitf_Error *error)
 {
     nitf_WriteHandler *writeHandler = NULL;

--- a/modules/c/nitf/source/TREUtils.c
+++ b/modules/c/nitf/source/TREUtils.c
@@ -80,8 +80,8 @@ NITFAPI(int) nitf_TREUtils_parse(nitf_TRE* tre, char* bufptr, nitf_Error* error)
             {
                 if (length == NITF_INT16_SZ)
                 {
-                    nitf_Int16 int16 = (nitf_Int16)NITF_NTOHS(
-                            *((nitf_Int16*)(bufptr + offset)));
+                    int16_t int16 = (int16_t)NITF_NTOHS(
+                            *((int16_t*)(bufptr + offset)));
                     status = nitf_Field_setRawData(field,
                                                    (NITF_DATA*)&int16,
                                                    length,
@@ -89,8 +89,8 @@ NITFAPI(int) nitf_TREUtils_parse(nitf_TRE* tre, char* bufptr, nitf_Error* error)
                 }
                 else if (length == NITF_INT32_SZ)
                 {
-                    nitf_Int32 int32 = (nitf_Int32)NITF_NTOHL(
-                            *((nitf_Int32*)(bufptr + offset)));
+                    int32_t int32 = (int32_t)NITF_NTOHL(
+                            *((int32_t*)(bufptr + offset)));
                     status = nitf_Field_setRawData(field,
                                                    (NITF_DATA*)&int32,
                                                    length,
@@ -156,12 +156,12 @@ CATCH_ERROR:
 
 NITFAPI(char*)
 nitf_TREUtils_getRawData(nitf_TRE* tre,
-                         nitf_Uint32* treLength,
+                         uint32_t* treLength,
                          nitf_Error* error)
 {
     int status = 1;
     int offset = 0;
-    nitf_Uint32 length;
+    uint32_t length;
     int tempLength;
 
     /* data buffer - Caller must free this */
@@ -242,14 +242,14 @@ nitf_TREUtils_getRawData(nitf_TRE* tre,
                 {
                     if (tempLength == NITF_INT16_SZ)
                     {
-                        nitf_Int16 int16 =
-                                (nitf_Int16)NITF_HTONS(*((nitf_Int16*)tempBuf));
+                        int16_t int16 =
+                                (int16_t)NITF_HTONS(*((int16_t*)tempBuf));
                         memcpy(tempBuf, (char*)&int16, tempLength);
                     }
                     else if (tempLength == NITF_INT32_SZ)
                     {
-                        nitf_Int32 int32 =
-                                (nitf_Int32)NITF_HTONL(*((nitf_Int32*)tempBuf));
+                        int32_t int32 =
+                                (int32_t)NITF_HTONL(*((int32_t*)tempBuf));
                         memcpy(tempBuf, (char*)&int32, tempLength);
                     }
                     else
@@ -462,7 +462,7 @@ nitf_TREUtils_setValue(nitf_TRE* tre,
 
 NITFAPI(NITF_BOOL)
 nitf_TREUtils_setDescription(nitf_TRE* tre,
-                             nitf_Uint32 length,
+                             uint32_t length,
                              nitf_Error* error)
 {
     nitf_TREDescriptionSet* descriptions = NULL;
@@ -759,7 +759,7 @@ NITFAPI(NITF_BOOL) nitf_TREUtils_isSane(nitf_TRE* tre)
 
 NITFAPI(NITF_BOOL)
 nitf_TREUtils_basicRead(nitf_IOInterface* io,
-                        nitf_Uint32 length,
+                        uint32_t length,
                         nitf_TRE* tre,
                         struct _nitf_Record* record,
                         nitf_Error* error)
@@ -931,7 +931,7 @@ nitf_TREUtils_basicWrite(nitf_IOInterface* io,
                          struct _nitf_Record* record,
                          nitf_Error* error)
 {
-    nitf_Uint32 length;
+    uint32_t length;
     char* data = NULL;
     NITF_BOOL ok = NITF_FAILURE;
 

--- a/modules/c/nitf/source/Writer.c
+++ b/modules/c/nitf/source/Writer.c
@@ -145,7 +145,7 @@
 /*  even an option.                                                   */
 NITFPRIV(NITF_BOOL) writeField(nitf_Writer * writer,
                                char *field,
-                               nitf_Uint32 length, nitf_Error * error);
+                               uint32_t length, nitf_Error * error);
 
 /*  Pads a string with a fill character                              */
 /*  field The input string                                             */
@@ -153,9 +153,9 @@ NITFPRIV(NITF_BOOL) writeField(nitf_Writer * writer,
 /*  fill The fill character                                          */
 /*  fillDir The fill direction (either FILL_LEFT or FILL_RIGHT)      */
 NITFPRIV(NITF_BOOL) padString(char *field,
-                              nitf_Uint32 length,
+                              uint32_t length,
                               char fill,
-                              const nitf_Uint32 fillDir,
+                              const uint32_t fillDir,
                               nitf_Error * error);
 
 /*  Writes the given TRE  */
@@ -176,9 +176,9 @@ NITFPRIV(void) resetIOInterface(nitf_Writer * writer)
 
 NITFPRIV(NITF_BOOL) writeStringField(nitf_Writer * writer,
                                      char *field,
-                                     nitf_Uint32 length,
+                                     uint32_t length,
                                      char fill,
-                                     const nitf_Uint32 fillDir,
+                                     const uint32_t fillDir,
                                      nitf_Error * error)
 {
     char *buf = (char *) NITF_MALLOC(length + 1);
@@ -209,9 +209,9 @@ CATCH_ERROR:
 
 NITFPRIV(NITF_BOOL) writeValue(nitf_Writer * writer,
                                nitf_Field * field,
-                               nitf_Uint32 length,
+                               uint32_t length,
                                char fill,
-                               const nitf_Uint32 fillDir,
+                               const uint32_t fillDir,
                                nitf_Error * error)
 {
     char *buf = (char *) NITF_MALLOC(length + 1);
@@ -229,14 +229,14 @@ NITFPRIV(NITF_BOOL) writeValue(nitf_Writer * writer,
     {
         if (length == NITF_INT16_SZ)
         {
-            nitf_Int16 int16 =
-                (nitf_Int16)NITF_HTONS(*((nitf_Int16 *) field->raw));
+            int16_t int16 =
+                (int16_t)NITF_HTONS(*((int16_t *) field->raw));
             memcpy(buf, (char*)&int16, length);
         }
         else if (length == NITF_INT32_SZ)
         {
-            nitf_Int32 int32 =
-                (nitf_Int32)NITF_HTONL(*((nitf_Int32 *) field->raw));
+            int32_t int32 =
+                (int32_t)NITF_HTONL(*((int32_t *) field->raw));
             memcpy(buf, (char*)&int32, length);
         }
         else
@@ -268,10 +268,10 @@ CATCH_ERROR:
 
 
 NITFPRIV(NITF_BOOL) writeIntField(nitf_Writer * writer,
-                                  nitf_Uint32 field,
-                                  nitf_Uint32 length,
+                                  uint32_t field,
+                                  uint32_t length,
                                   char fill,
-                                  const nitf_Uint32 fillDir,
+                                  const uint32_t fillDir,
                                   nitf_Error * error)
 {
     char buf[20];
@@ -291,12 +291,12 @@ NITFPRIV(NITF_BOOL) writeIntField(nitf_Writer * writer,
 }
 
 
-/* This function pads the given nitf_Uint64, and writes it to the IOHandle */
+/* This function pads the given uint64_t, and writes it to the IOHandle */
 NITFPROT(NITF_BOOL) nitf_Writer_writeInt64Field(nitf_Writer* writer,
-                                                nitf_Uint64 field,
-                                                nitf_Uint32 length,
+                                                uint64_t field,
+                                                uint32_t length,
                                                 char fill,
-                                                nitf_Uint32 fillDir,
+                                                uint32_t fillDir,
                                                 nitf_Error* error)
 {
     char buf[20];
@@ -318,7 +318,7 @@ NITFPROT(NITF_BOOL) nitf_Writer_writeInt64Field(nitf_Writer* writer,
 
 NITFPRIV(NITF_BOOL) writeField(nitf_Writer * writer,
                                char *field,
-                               nitf_Uint32 length,
+                               uint32_t length,
                                nitf_Error * error)
 {
     if (!nitf_IOInterface_write(writer->output, field, length, error))
@@ -397,9 +397,9 @@ CATCH_ERROR:
 
 /* This function pads the given string with the fill character */
 NITFPRIV(NITF_BOOL) padString(char *field,
-                              nitf_Uint32 length,
+                              uint32_t length,
                               char fill,
-                              const nitf_Uint32 fillDir,
+                              const uint32_t fillDir,
                               nitf_Error * error)
 {
     /*  size and remainder  */
@@ -412,7 +412,7 @@ NITFPRIV(NITF_BOOL) padString(char *field,
                 "Trying to use NULL field. padString failed.");
         return NITF_FAILURE;
     }
-    size = (nitf_Uint32)strlen(field);
+    size = (uint32_t)strlen(field);
     if (size >= length)
     {
         /* Dont need to pad at all */
@@ -439,12 +439,12 @@ NITFPRIV(NITF_BOOL) padString(char *field,
 /* This function writes the given ComponentInfo section */
 NITFPRIV(NITF_BOOL) writeComponentInfo(nitf_Writer * writer,
                                        nitf_ComponentInfo ** info,
-                                       nitf_Uint32 num,
-                                       nitf_Uint32 subHdrSize,
-                                       nitf_Uint32 segmentSize,
+                                       uint32_t num,
+                                       uint32_t subHdrSize,
+                                       uint32_t segmentSize,
                                        nitf_Error * error)
 {
-    nitf_Uint32 i;
+    uint32_t i;
 
     /*  First, write the num*  */
     if (!writeIntField(writer, num, NITF_IVAL_SZ, ZERO, FILL_LEFT, error))
@@ -472,10 +472,10 @@ CATCH_ERROR:
 /* This function writes the given Extensions */
 NITFPRIV(NITF_BOOL) writeExtras(nitf_Writer * writer,
                                 nitf_Extensions * section,
-                                nitf_Uint32 * dataLength,
-                                nitf_Uint32 * dataOverflow,
-                                const nitf_Uint32 hdlFieldSize,
-                                const nitf_Uint32 oflFieldSize,
+                                uint32_t * dataLength,
+                                uint32_t * dataOverflow,
+                                const uint32_t hdlFieldSize,
+                                const uint32_t oflFieldSize,
                                 nitf_Error * error)
 {
     nitf_ExtensionsIterator iter, end;
@@ -539,7 +539,7 @@ NITFPRIV(NITF_BOOL) writeExtension(nitf_Writer * writer,
                                    nitf_TRE * tre, nitf_Error * error)
 {
 
-    nitf_Uint32 length;
+    uint32_t length;
 
     /* write the cetag and cel */
     if (!writeStringField(writer, tre->tag,
@@ -593,10 +593,10 @@ CATCH_ERROR:
 /* This function writes the given BandInfo */
 NITFPRIV(NITF_BOOL) writeBandInfo(nitf_Writer * writer,
                                   nitf_BandInfo ** bandInfo,
-                                  nitf_Uint32 nbands, nitf_Error * error)
+                                  uint32_t nbands, nitf_Error * error)
 {
-    nitf_Uint32 i;
-    nitf_Uint32 numLuts, bandEntriesPerLut;
+    uint32_t i;
+    uint32_t numLuts, bandEntriesPerLut;
 
     for (i = 0; i < nbands; ++i)
     {
@@ -732,11 +732,11 @@ NITFAPI(NITF_BOOL) nitf_Writer_prepareIO(nitf_Writer* writer,
                                             nitf_IOInterface* io,
                                             nitf_Error* error)
 {
-    nitf_Int32 i;
-    nitf_Int32 numImages;
-    nitf_Int32 numTexts;
-    nitf_Int32 numGraphics;
-    nitf_Int32 numDEs;
+    int32_t i;
+    int32_t numImages;
+    int32_t numTexts;
+    int32_t numGraphics;
+    int32_t numDEs;
     nitf_ListIterator iter;
 
     if (!writer)
@@ -839,8 +839,8 @@ NITFAPI(NITF_BOOL) nitf_Writer_prepareIO(nitf_Writer* writer,
         {
             nitf_ImageSegment *segment = NULL;
             nitf_ImageSubheader *subheader = NULL;
-            nitf_Uint32 nbpp, nbands, xbands, nrows, ncols;
-            nitf_Uint64 length;
+            uint32_t nbpp, nbands, xbands, nrows, ncols;
+            uint64_t length;
 
             /* first, set the writer to NULL */
             writer->imageWriters[i] = NULL;
@@ -857,7 +857,7 @@ NITFAPI(NITF_BOOL) nitf_Writer_prepareIO(nitf_Writer* writer,
             NITF_TRY_GET_UINT32(subheader->numRows, &nrows, error);
             NITF_TRY_GET_UINT32(subheader->numCols, &ncols, error);
 
-            length = (nitf_Uint64)ncols * (nitf_Uint64)nrows *
+            length = (uint64_t)ncols * (uint64_t)nrows *
                     NITF_NBPP_TO_BYTES(nbpp) * (nbands + xbands);
 
             if (length > NITF_MAX_IMAGE_LENGTH)
@@ -972,12 +972,12 @@ NITFAPI(void) nitf_Writer_destruct(nitf_Writer ** writer)
 
 NITFPROT(NITF_BOOL) nitf_Writer_writeHeader(nitf_Writer* writer,
                                             nitf_Off* fileLenOff,
-                                            nitf_Uint32* hdrLen,
+                                            uint32_t* hdrLen,
                                             nitf_Error* error)
 {
-    nitf_Uint32 numImages, numGraphics, numLabels;
-    nitf_Uint32 numTexts, numDES, numRES;
-    nitf_Uint32 udhdl, udhofl, xhdl, xhdlofl;
+    uint32_t numImages, numGraphics, numLabels;
+    uint32_t numTexts, numDES, numRES;
+    uint32_t udhdl, udhofl, xhdl, xhdlofl;
     nitf_Version fver;
     char buf[256];              /* temp buf */
 
@@ -1124,10 +1124,10 @@ nitf_Writer_writeImageSubheader(nitf_Writer* writer,
                                 nitf_Off* comratOff,
                                 nitf_Error* error)
 {
-    nitf_Uint32 bands;
-    nitf_Uint32 i;
-    nitf_Uint32 numComments;
-    nitf_Uint32 udidl, udofl, ixshdl, ixsofl;
+    uint32_t bands;
+    uint32_t i;
+    uint32_t numComments;
+    uint32_t udidl, udofl, ixshdl, ixsofl;
     nitf_ListIterator iter, end;
 
     NITF_WRITE_VALUE(subhdr, NITF_IM, SPACE, FILL_RIGHT);
@@ -1250,7 +1250,7 @@ NITFPRIV(NITF_BOOL) writeGraphicSubheader(nitf_Writer * writer,
                                           nitf_Version fver,
                                           nitf_Error * error)
 {
-    nitf_Uint32 sxshdl, sxsofl;
+    uint32_t sxshdl, sxsofl;
 
     NITF_WRITE_VALUE(subhdr, NITF_SY, SPACE, FILL_RIGHT);
     NITF_WRITE_VALUE(subhdr, NITF_SID, SPACE, FILL_RIGHT);
@@ -1302,7 +1302,7 @@ NITFPRIV(NITF_BOOL) writeTextSubheader(nitf_Writer * writer,
                                        nitf_Version fver,
                                        nitf_Error * error)
 {
-    nitf_Uint32 txshdl, txsofl;
+    uint32_t txshdl, txsofl;
 
     NITF_WRITE_VALUE(subhdr, NITF_TE, SPACE, FILL_RIGHT);
     NITF_WRITE_VALUE(subhdr, NITF_TEXTID, SPACE, FILL_RIGHT);
@@ -1346,11 +1346,11 @@ CATCH_ERROR:
 
 NITFPROT(NITF_BOOL) nitf_Writer_writeDESubheader(nitf_Writer* writer,
                                                  const nitf_DESubheader* subhdr,
-                                                 nitf_Uint32* userSublen,
+                                                 uint32_t* userSublen,
                                                  nitf_Version fver,
                                                  nitf_Error* error)
 {
-    nitf_Uint32 subLen;
+    uint32_t subLen;
 
     char* des_data = NULL;
 
@@ -1435,7 +1435,7 @@ NITFPRIV(NITF_BOOL) writeRESubheader(nitf_Writer * writer,
                                      nitf_RESubheader * subhdr,
                                      nitf_Version fver, nitf_Error * error)
 {
-    nitf_Uint32 subLen;
+    uint32_t subLen;
 
     NITF_WRITE_VALUE(subhdr, NITF_RE, SPACE, FILL_RIGHT);
     NITF_WRITE_VALUE(subhdr, NITF_RESTAG, SPACE, FILL_RIGHT);
@@ -1601,13 +1601,13 @@ NITFAPI(NITF_BOOL) nitf_Writer_write(nitf_Writer * writer,
     nitf_Off fileLen;
 
     /* Length of teh file header */
-    nitf_Uint32 hdrLen;
-    nitf_Uint32 i = 0;
+    uint32_t hdrLen;
+    uint32_t i = 0;
     int skipBytes = 0;
     nitf_Version fver;
 
     /* Number of images */
-    nitf_Uint32 numImgs = 0;
+    uint32_t numImgs = 0;
 
     /* Lengths of image subheaders */
     nitf_Off *imageSubLens = NULL;
@@ -1616,7 +1616,7 @@ NITFAPI(NITF_BOOL) nitf_Writer_write(nitf_Writer * writer,
     nitf_Off *imageDataLens = NULL;
 
     /* Number of texts */
-    nitf_Uint32 numTexts = 0;
+    uint32_t numTexts = 0;
 
     /* Lengths of text subheaders */
     nitf_Off *textSubLens = NULL;
@@ -1625,7 +1625,7 @@ NITFAPI(NITF_BOOL) nitf_Writer_write(nitf_Writer * writer,
     nitf_Off *textDataLens = NULL;
 
     /* Number of graphics */
-    nitf_Uint32 numGraphics = 0;
+    uint32_t numGraphics = 0;
 
     /* Lengths of graphic subheaders */
     nitf_Off *graphicSubLens = NULL;
@@ -1634,7 +1634,7 @@ NITFAPI(NITF_BOOL) nitf_Writer_write(nitf_Writer * writer,
     nitf_Off *graphicDataLens = NULL;
 
     /* Number of data extensions */
-    nitf_Uint32 numDEs = 0;
+    uint32_t numDEs = 0;
 
     /* Lengths of data extension subheaders */
     nitf_Off *deSubLens = NULL;
@@ -1964,7 +1964,7 @@ NITFAPI(NITF_BOOL) nitf_Writer_write(nitf_Writer * writer,
     {
 
         /* Length of current user subheader */
-        nitf_Uint32 userSublen;
+        uint32_t userSublen;
 
         deSubLens = (nitf_Off *) NITF_MALLOC(numDEs * sizeof(nitf_Off));
         if (!deSubLens)

--- a/modules/c/nitf/tests/test_1band_rw_line.c
+++ b/modules/c/nitf/tests/test_1band_rw_line.c
@@ -30,15 +30,15 @@ void writeImage(nitf_ImageSegment* segment,
                 nitf_Error* error)
 {
 
-    nitf_Uint32 nBits, nBands, xBands, nRows, nColumns;
+    uint32_t nBits, nBands, xBands, nRows, nColumns;
     size_t subimageSize;
     nitf_SubWindow *subimage;
     unsigned int i;
 
     int padded;
-    nitf_Uint8** buffer;
-    nitf_Uint32 band;
-    nitf_Uint32 *bandList;
+    uint8_t** buffer;
+    uint32_t band;
+    uint32_t *bandList;
     char file[NITF_MAX_PATH];
 
     nitf_IOHandle toFile;
@@ -101,9 +101,9 @@ void writeImage(nitf_ImageSegment* segment,
         printf("This is a single band test case, but the image is multi-band.  Exiting...\n");
         exit(EXIT_FAILURE);
     }
-    buffer = (nitf_Uint8 **)malloc(sizeof(nitf_Uint8)); // Malloc one dimension
+    buffer = (uint8_t **)malloc(sizeof(uint8_t)); // Malloc one dimension
     band = 0;
-    bandList = (nitf_Uint32 *)malloc(sizeof(nitf_Uint32));
+    bandList = (uint32_t *)malloc(sizeof(uint32_t));
 
     subimage = nitf_SubWindow_construct(&error);
     assert(subimage);
@@ -123,7 +123,7 @@ void writeImage(nitf_ImageSegment* segment,
     subimage->numBands = nBands;
 
     assert(buffer);
-    buffer[0] = (nitf_Uint8*)malloc(subimageSize);
+    buffer[0] = (uint8_t*)malloc(subimageSize);
 
 
     /* find end slash */

--- a/modules/c/nitf/tests/test_ImageIO.h
+++ b/modules/c/nitf/tests/test_ImageIO.h
@@ -62,22 +62,22 @@ extern "C"
 
     typedef struct
     {
-        nitf_Uint32 nRows;          /*!< Number of rows in the image */
-        nitf_Uint32 nColumns;       /*!< Number of columns in the image */
-        nitf_Uint32 nBands;         /*!< Number of bands */
-        nitf_Uint32 nMultiBands;    /*!< Number of mutli-spectral bands */
+        uint32_t nRows;          /*!< Number of rows in the image */
+        uint32_t nColumns;       /*!< Number of columns in the image */
+        uint32_t nBands;         /*!< Number of bands */
+        uint32_t nMultiBands;    /*!< Number of mutli-spectral bands */
         char pixelType[TEST_NITF_IMAGE_IO_MAX_STRING+2];  /*!< Pixel type */
-        nitf_Uint32 nBits;          /*!< Number of bits per pixel */
-        nitf_Uint32 nBitsActual;    /*!< Actual number of bits per pixel */
+        uint32_t nBits;          /*!< Number of bits per pixel */
+        uint32_t nBitsActual;    /*!< Actual number of bits per pixel */
         char justify[TEST_NITF_IMAGE_IO_MAX_STRING+2];  /*!< ;Pixels justification */
-        nitf_Uint32 nBlksPerRow;    /*!< Number of blocks per row */
-        nitf_Uint32 nBlksPerColumn; /*!< Number of blocks per Columns */
-        nitf_Uint32 nRowsPerBlk;    /*!< Number of rows per block */
-        nitf_Uint32 nColumnsPerBlk; /*!< Number of columns per block */
+        uint32_t nBlksPerRow;    /*!< Number of blocks per row */
+        uint32_t nBlksPerColumn; /*!< Number of blocks per Columns */
+        uint32_t nRowsPerBlk;    /*!< Number of rows per block */
+        uint32_t nColumnsPerBlk; /*!< Number of columns per block */
         char mode[TEST_NITF_IMAGE_IO_MAX_STRING+2];  /*!< Blocking mode */
         char compression[TEST_NITF_IMAGE_IO_MAX_STRING+2];  /*!< Compression type */
-        nitf_Uint8 padValue[8];     /*!< Pad value */
-        nitf_Uint32 offset;         /*!< Byte offset in file to image data segment */
+        uint8_t padValue[8];     /*!< Pad value */
+        uint32_t offset;         /*!< Byte offset in file to image data segment */
         char dataPattern[TEST_NITF_IMAGE_IO_MAX_STRING+2]; /*!< Pattern gen method */
     }
     test_nitf_ImageIOConstructArgs;
@@ -95,16 +95,16 @@ extern "C"
     typedef struct
     {
         char name[TEST_NITF_IMAGE_IO_MAX_STRING+2]; /*!< File name to read */
-        nitf_Uint32 row;                            /*!< Start row */
-        nitf_Uint32 nRows;                          /*!< Number of rows to read */
-        nitf_Uint32 rowSkip;                        /*!< Row skip factor */
-        nitf_Uint32 column;                         /*!< Start column */
-        nitf_Uint32 nColumns;                       /*!< Number of columns to read */
-        nitf_Uint32 columnSkip;                     /*!< Column skip factor */
+        uint32_t row;                            /*!< Start row */
+        uint32_t nRows;                          /*!< Number of rows to read */
+        uint32_t rowSkip;                        /*!< Row skip factor */
+        uint32_t column;                         /*!< Start column */
+        uint32_t nColumns;                       /*!< Number of columns to read */
+        uint32_t columnSkip;                     /*!< Column skip factor */
         char
         downSample[TEST_NITF_IMAGE_IO_MAX_STRING+2];/*!< Down-sample method */
-        nitf_Uint32 nBands;                         /*!< Number of bands to read */
-        nitf_Uint32 bands[TEST_NITF_IMAGE_IO_MAX_BANDS]; /*!< Bands to read */
+        uint32_t nBands;                         /*!< Number of bands to read */
+        uint32_t bands[TEST_NITF_IMAGE_IO_MAX_BANDS]; /*!< Bands to read */
     }
     test_nitf_ImageIOReadArgs;
 
@@ -183,7 +183,7 @@ extern "C"
 
     NITFAPI(void) test_nitf_ImageIO_freeArray
     (
-        nitf_Uint8 ***data     /*!< The array to free */
+        uint8_t ***data     /*!< The array to free */
     );
 
     /*!

--- a/modules/c/nitf/tests/test_ImageIO_read_data.c
+++ b/modules/c/nitf/tests/test_ImageIO_read_data.c
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
 {
     nitf_ImageIO *nitf;                     /* The parent nitf_ImageIO object */
     char errorBuf[NITF_MAX_EMESSAGE];       /* Error buffer */
-    nitf_Uint8 **user;                      /* User buffer list */
+    uint8_t **user;                      /* User buffer list */
     int padded;                             /* Pad pixel present flag */
     nitf_IOHandle fileHandle;               /* I/O handle for reads */
     int ofd;                                /* File descriptor for writes */
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
 
     subWindowSize = (readArgs->nRows) * (readArgs->nColumns) * (newArgs->nBits / 8);
 
-    user = (nitf_Uint8 **) malloc(sizeof(nitf_Uint8 *) * (readArgs->nBands));
+    user = (uint8_t **) malloc(sizeof(uint8_t *) * (readArgs->nBands));
     if (user == NULL)
     {
         fprintf(stderr, "Error allocating user buffer\n");
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
 
     for (i = 0;i < readArgs->nBands;i++)
     {
-        user[i] = (nitf_Uint8 *) malloc(subWindowSize);
+        user[i] = (uint8_t *) malloc(subWindowSize);
         if (user[i] == NULL)
         {
             fprintf(stderr, "Error allocating user buffer\n");

--- a/modules/c/nitf/tests/test_ImageIO_support.c
+++ b/modules/c/nitf/tests/test_ImageIO_support.c
@@ -39,7 +39,7 @@ NITFAPI(test_nitf_ImageIOConstructArgs *) test_nitf_ImageIOReadConstructArgs(
     test_nitf_ImageIOConstructArgs *args;   /* The result */
     long padValues[8];                      /* Temp for pad value bytes */
     long tmpLong;                           /* Temp for longs */
-    nitf_Uint32 i;
+    uint32_t i;
 
     args = (test_nitf_ImageIOConstructArgs *)
            malloc(sizeof(test_nitf_ImageIOConstructArgs));
@@ -331,7 +331,7 @@ NITFAPI(test_nitf_ImageIOReadArgs *)test_nitf_ImageIOReadReadArgs(
     FILE *file, char **error)
 {
     test_nitf_ImageIOReadArgs *args;   /* The result */
-    nitf_Uint32 band;                  /* Current band */
+    uint32_t band;                  /* Current band */
     long tmpLong;                           /* Temp for longs */
 
     args = (test_nitf_ImageIOReadArgs *)
@@ -513,13 +513,13 @@ NITFAPI(test_nitf_ImageIOReadArgs *)test_nitf_ImageIOReadReadArgs(
 NITFAPI(void *) test_nitf_ImageIO_mkArray(
     test_nitf_ImageIOConstructArgs *args, char **error)
 {
-    nitf_Uint8 ***data;     /* The result */
-    nitf_Uint32 nBands;     /* Actual number of bands */
-    nitf_Uint32 band;       /* The current band */
-    nitf_Uint8 **rows;      /* The row dimension */
-    nitf_Uint32 row;        /* The current row */
-    nitf_Uint32 bytes;      /* Number of bytes per pixel */
-    nitf_Uint8 *cols;       /* The column dimension */
+    uint8_t ***data;     /* The result */
+    uint32_t nBands;     /* Actual number of bands */
+    uint32_t band;       /* The current band */
+    uint8_t **rows;      /* The row dimension */
+    uint32_t row;        /* The current row */
+    uint32_t bytes;      /* Number of bytes per pixel */
+    uint8_t *cols;       /* The column dimension */
 
     nBands = args->nBands;
     if (nBands == 0)
@@ -533,7 +533,7 @@ NITFAPI(void *) test_nitf_ImageIO_mkArray(
 
     /*    Band dimension */
 
-    data = (nitf_Uint8 ***) NITF_MALLOC(nBands * sizeof(nitf_Uint8 **));
+    data = (uint8_t ***) NITF_MALLOC(nBands * sizeof(uint8_t **));
     if (data == NULL)
     {
         snprintf(buffer, TEST_NITF_IMAGE_IO_MAX_STRING,
@@ -544,7 +544,7 @@ NITFAPI(void *) test_nitf_ImageIO_mkArray(
 
     /*    Row dimension */
 
-    rows = (nitf_Uint8 **) NITF_MALLOC(nBands * (args->nRows) * sizeof(nitf_Uint8 *));
+    rows = (uint8_t **) NITF_MALLOC(nBands * (args->nRows) * sizeof(uint8_t *));
     if (rows == NULL)
     {
         NITF_FREE(data);
@@ -562,7 +562,7 @@ NITFAPI(void *) test_nitf_ImageIO_mkArray(
     /*    Column dimension */
 
     bytes = NITF_NBPP_TO_BYTES(args->nBits);
-    cols = (nitf_Uint8 *) NITF_MALLOC(
+    cols = (uint8_t *) NITF_MALLOC(
                nBands * (args->nRows) * (args->nColumns) * bytes);
     if (data == NULL)
     {
@@ -586,7 +586,7 @@ NITFAPI(void *) test_nitf_ImageIO_mkArray(
 
 /*========================= test_nitf_ImageIO_freeArray ======================*/
 
-NITFAPI(void) test_nitf_ImageIO_freeArray(nitf_Uint8 ***data)
+NITFAPI(void) test_nitf_ImageIO_freeArray(uint8_t ***data)
 {
     NITF_FREE(data[0][0]);   /* Columns */
     NITF_FREE(data[0]);      /* Rows */
@@ -599,13 +599,13 @@ NITFAPI(void) test_nitf_ImageIO_freeArray(nitf_Uint8 ***data)
 NITFAPI(void *) test_nitf_ImageIO_brcI4(
     test_nitf_ImageIOConstructArgs *args, char **error)
 {
-    nitf_Uint32 ***data;    /* The result */
-    nitf_Uint32 nBands;     /* Number of bands */
-    nitf_Uint32 band;       /* The current band */
-    nitf_Uint32 row;        /* The current row */
-    nitf_Uint32 col;        /* The current column */
+    uint32_t ***data;    /* The result */
+    uint32_t nBands;     /* Number of bands */
+    uint32_t band;       /* The current band */
+    uint32_t row;        /* The current row */
+    uint32_t col;        /* The current column */
 
-    data = (nitf_Uint32 ***) test_nitf_ImageIO_mkArray(args, error);
+    data = (uint32_t ***) test_nitf_ImageIO_mkArray(args, error);
     if (data == NULL)
         return(NULL);
 
@@ -624,7 +624,7 @@ NITFAPI(void *) test_nitf_ImageIO_brcI4(
             for (col = 0;col < args->nColumns;col++)
                 data[band][row][col] = (band << 16) + (row << 8) + col;
 
-    return((nitf_Uint8 ***) data);
+    return((uint8_t ***) data);
 }
 
 /*========================= test_nitf_ImageIO_brcI4 ==========================*/
@@ -640,9 +640,9 @@ NITFAPI(void *) test_nitf_ImageIO_brcC8(
     double ***data;       /* The result */
     float *fdp;          /* Float pointer to current pixel */
     float nBands;        /* Number of bands */
-    nitf_Uint32 band;    /* The current band */
-    nitf_Uint32 row;     /* The current row */
-    nitf_Uint32 col;     /* The current column */
+    uint32_t band;    /* The current band */
+    uint32_t row;     /* The current row */
+    uint32_t col;     /* The current column */
 
     data = (double ***) test_nitf_ImageIO_mkArray(args, error);
     if (data == NULL)
@@ -667,17 +667,17 @@ NITFAPI(void *) test_nitf_ImageIO_brcC8(
                 *fdp = band * 100.0 + col;
             }
 
-    return((nitf_Uint8 ***) data);
+    return((uint8_t ***) data);
 }
 
 /*========================= test_nitf_ImageIO_bigEndian ======================*/
 
 NITFAPI(int) test_nitf_ImageIO_bigEndian(void)
 {
-    nitf_Uint8 p8[2] = {1, 2};    /* For big-endian test */
-    nitf_Uint16 *p16;            /* For big-endian test */
+    uint8_t p8[2] = {1, 2};    /* For big-endian test */
+    uint16_t *p16;            /* For big-endian test */
 
-    p16 = (nitf_Uint16 *) p8;
+    p16 = (uint16_t *) p8;
     return((*p16 == 0x102) ? 1 : 0); /* 0x102 => big-endian */
 }
 
@@ -750,10 +750,10 @@ char **makeBlockPattern(test_nitf_ImageIOConstructArgs *args,
                         char *spec, char **error)
 {
     char **array;             /* The result */
-    nitf_Uint32 nBlkRows;     /* Number of rows of blocks */
-    nitf_Uint32 nBlkCols;     /* Number of columns of blocks */
+    uint32_t nBlkRows;     /* Number of rows of blocks */
+    uint32_t nBlkCols;     /* Number of columns of blocks */
     size_t specLen;           /* Length of the spec string */
-    nitf_Uint32 i;
+    uint32_t i;
 
     specLen = strlen(spec);
     nBlkRows = args->nBlksPerColumn;
@@ -866,26 +866,26 @@ char **makeBlockPattern(test_nitf_ImageIOConstructArgs *args,
 NITFAPI(void *) test_nitf_ImageIO_block(
     test_nitf_ImageIOConstructArgs *args, char **error)
 {
-    nitf_Uint8 ***data;     /* The result */
+    uint8_t ***data;     /* The result */
     char **pattern;         /* Block mask pattern */
-    nitf_Uint32 nBands;     /* Number of bands */
-    nitf_Uint32 band;       /* The current band */
-    nitf_Uint32 bytes;      /* Number of bytes per pixel */
-    nitf_Uint32 blksPerRow; /* Number of blocks/row */
-    nitf_Uint32 rowsPerBlk; /* Number of rows/block */
-    nitf_Uint32 colsPerBlk; /* Number of columns/block */
-    nitf_Uint32 valueCode;  /* Output pixel value type code */
+    uint32_t nBands;     /* Number of bands */
+    uint32_t band;       /* The current band */
+    uint32_t bytes;      /* Number of bytes per pixel */
+    uint32_t blksPerRow; /* Number of blocks/row */
+    uint32_t rowsPerBlk; /* Number of rows/block */
+    uint32_t colsPerBlk; /* Number of columns/block */
+    uint32_t valueCode;  /* Output pixel value type code */
     char valueTypeStr[4];   /* Value type string from specification */
-    nitf_Uint32 rowsLeft;   /* Number of rows left in this block */
-    nitf_Uint32 colsLeft;   /* Number of columnsleft in this block */
-    nitf_Uint32 blkRow;     /* The current block row */
-    nitf_Uint32 blkCol;     /* The current block column */
+    uint32_t rowsLeft;   /* Number of rows left in this block */
+    uint32_t colsLeft;   /* Number of columnsleft in this block */
+    uint32_t blkRow;     /* The current block row */
+    uint32_t blkCol;     /* The current block column */
     int present;            /* Current block present if true */
     int transient;          /* Current block transient if true */
-    nitf_Uint32 row;        /* The current row */
-    nitf_Uint32 col;        /* The current column */
+    uint32_t row;        /* The current row */
+    uint32_t col;        /* The current column */
 
-    data = (nitf_Uint8 ***) test_nitf_ImageIO_mkArray(args, error);
+    data = (uint8_t ***) test_nitf_ImageIO_mkArray(args, error);
     if (data == NULL)
         return(NULL);
 
@@ -922,13 +922,13 @@ NITFAPI(void *) test_nitf_ImageIO_block(
     }
 
     if (bytes == 1)
-        PATTERN_PROCESS(nitf_Uint8)
+        PATTERN_PROCESS(uint8_t)
         else if (bytes == 2)
-            PATTERN_PROCESS(nitf_Uint16)
+            PATTERN_PROCESS(uint16_t)
             else if (bytes == 4)
-                PATTERN_PROCESS(nitf_Uint32)
+                PATTERN_PROCESS(uint32_t)
                 else if (bytes == 8)
-                    PATTERN_PROCESS(nitf_Uint64)
+                    PATTERN_PROCESS(uint64_t)
                     else
                     {
                         snprintf(buffer, TEST_NITF_IMAGE_IO_MAX_STRING, "Invalid byte count\n");

--- a/modules/c/nitf/tests/test_ImageIO_writePattern.c
+++ b/modules/c/nitf/tests/test_ImageIO_writePattern.c
@@ -60,11 +60,11 @@ int main(int argc, char *argv[])
     nitf_IOHandle io;                /* Handle for output */
     nitf_Error error;                /* Error object */
     nitf_ImageIO *image;             /* ImageIO for image */
-    nitf_Uint8 *user[NUM_BANDS_MAX]; /* User buffer for write rows */
-    nitf_Uint8 ***data;              /* Generated data [band][row][col] */
-    nitf_Uint32 band;                /* Current band */
-    nitf_Uint32 row;                 /* Current row */
-    nitf_Uint32 col;                 /* Current  column*/
+    uint8_t *user[NUM_BANDS_MAX]; /* User buffer for write rows */
+    uint8_t ***data;              /* Generated data [band][row][col] */
+    uint32_t band;                /* Current band */
+    uint32_t row;                 /* Current row */
+    uint32_t col;                 /* Current  column*/
 
     if (argc < 3)
     {
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
 
     if (strcmp(newArgs->dataPattern, "brcI4") == 0)
     {
-        data = (nitf_Uint8 ***) test_nitf_ImageIO_brcI4(newArgs, &errorStr);
+        data = (uint8_t ***) test_nitf_ImageIO_brcI4(newArgs, &errorStr);
         if (data == NULL)
         {
             fprintf(stderr, "%s\n", errorStr);
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
     }
     else if (strcmp(newArgs->dataPattern, "brcC8") == 0)
     {
-        data = (nitf_Uint8 ***) test_nitf_ImageIO_brcC8(newArgs, &errorStr);
+        data = (uint8_t ***) test_nitf_ImageIO_brcC8(newArgs, &errorStr);
         if (data == NULL)
         {
             fprintf(stderr, "%s\n", errorStr);
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
     for (row = 0;row < newArgs->nRows;row++)
     {
         for (band = 0;band < newArgs->nBands;band++)
-            user[band] = (nitf_Uint8 *) & (data[band][row][0]);
+            user[band] = (uint8_t *) & (data[band][row][0]);
         if (!nitf_ImageIO_writeRows(image, io, 1, user, &error))
         {
             nitf_Error_print(&error, stderr, "Writing rows");

--- a/modules/c/nitf/tests/test_add_masks.c
+++ b/modules/c/nitf/tests/test_add_masks.c
@@ -59,14 +59,14 @@
 
 typedef struct _imgInfo
 {
-    nitf_Uint32 index;               /* Segment index */
+    uint32_t index;               /* Segment index */
     nitf_ImageSegment *seg;          /* Image segment object */
     nitf_ImageSubheader *subhdr;     /* Image subheader object */
-    nitf_Uint32 nBands;              /* Number of bands */
-    nitf_Uint32 bytes;               /* Bytes/pixel */
+    uint32_t nBands;              /* Number of bands */
+    uint32_t bytes;               /* Bytes/pixel */
     size_t imgSize;                  /* Size of each band in bytes */
-    nitf_Uint8 padValue[MAX_PAD];    /* Pad value */
-    nitf_Uint8 **buffers;            /* Buffers containing the data */
+    uint8_t padValue[MAX_PAD];    /* Pad value */
+    uint8_t **buffers;            /* Buffers containing the data */
     nitf_ImageWriter *imgWriter;     /* Image writer for segment */
     nitf_ImageSource *imgSource;     /* Image source for segment */
 }
@@ -79,7 +79,7 @@ NITF_BOOL readImageSegment(imgInfo *img, nitf_Reader *reader, nitf_Error *error)
 NITF_BOOL makeImageSource(imgInfo *img, nitf_Writer *writer, nitf_Error *error);
 
 NITF_BOOL decodePadValue(imgInfo *info,
-                         char *string, nitf_Uint8 *value, nitf_Error *error);
+                         char *string, uint8_t *value, nitf_Error *error);
 
 int main(int argc, char *argv[])
 {
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
     nitf_Record *record;          /* Record used for input and output */
     imgInfo *imgs;                /* Image segment information */
     nitf_FileHeader *fileHdr;     /* File header */
-    nitf_Uint32 numImages;        /* Total number of image segments */
+    uint32_t numImages;        /* Total number of image segments */
     nitf_ListIterator imgIter;    /* Image segment list iterator */
     nitf_IOHandle in;             /* Input I/O handle */
     nitf_IOHandle out;            /* Output I/O handle */
@@ -283,17 +283,17 @@ int main(int argc, char *argv[])
 
 NITF_BOOL readImageSegment(imgInfo *img, nitf_Reader *reader, nitf_Error *error)
 {
-    nitf_Uint32 nBits;         /* Bits/pixel */
-    nitf_Uint32 nBands;        /* Number of bands */
-    nitf_Uint32 xBands;        /* Number of extended bands */
-    nitf_Uint32 nRows;         /* Number of rows */
-    nitf_Uint32 nColumns;      /* Number of columns */
+    uint32_t nBits;         /* Bits/pixel */
+    uint32_t nBands;        /* Number of bands */
+    uint32_t xBands;        /* Number of extended bands */
+    uint32_t nRows;         /* Number of rows */
+    uint32_t nColumns;      /* Number of columns */
     size_t subimageSize;       /* Image band size in bytes */
     nitf_SubWindow *subimage;  /* Sub-image object specifying full image */
     nitf_DownSampler *pixelSkip; /* Downsample for sub-window */
-    nitf_Uint32 *bandList;     /* List of bands for read */
-    nitf_Uint32 band;          /* Current band */
-    nitf_Uint8 **buffers;      /* Read buffer one/band */
+    uint32_t *bandList;     /* List of bands for read */
+    uint32_t band;          /* Current band */
+    uint8_t **buffers;      /* Read buffer one/band */
     /* Image reader */
     nitf_ImageReader *deserializer;
     int padded;                /* Argument for read */
@@ -324,7 +324,7 @@ NITF_BOOL readImageSegment(imgInfo *img, nitf_Reader *reader, nitf_Error *error)
     if (subimage == NULL)
         return(NITF_FAILURE);
 
-    bandList = (nitf_Uint32 *) NITF_MALLOC(sizeof(nitf_Uint32 *) * nBands);
+    bandList = (uint32_t *) NITF_MALLOC(sizeof(uint32_t *) * nBands);
     if (bandList == NULL)
         return(NITF_FAILURE);
 
@@ -346,13 +346,13 @@ NITF_BOOL readImageSegment(imgInfo *img, nitf_Reader *reader, nitf_Error *error)
 
     /*  Set-up buffers (one/band) */
 
-    buffers = (nitf_Uint8 **) NITF_MALLOC(nBands * sizeof(nitf_Uint8*));
+    buffers = (uint8_t **) NITF_MALLOC(nBands * sizeof(uint8_t*));
     if (buffers == NULL)
         return(NITF_FAILURE);
 
     for (i = 0;i < nBands;i++)
     {
-        buffers[i] = (nitf_Uint8 *) malloc(subimageSize);
+        buffers[i] = (uint8_t *) malloc(subimageSize);
         if (buffers[i] == NULL)
             return(NITF_FAILURE);
     }
@@ -403,12 +403,12 @@ NITF_BOOL makeImageSource(imgInfo *img, nitf_Writer *writer, nitf_Error *error)
 }
 
 NITF_BOOL decodePadValue(imgInfo *info,
-                         char *string, nitf_Uint8 *value, nitf_Error *error)
+                         char *string, uint8_t *value, nitf_Error *error)
 {
     char *str;           /* Pointer into the string */
     size_t len;          /* Current length of the value string */
-    nitf_Uint32 nValues; /* Number of byte values in pad value */
-    nitf_Uint32 i;
+    uint32_t nValues; /* Number of byte values in pad value */
+    uint32_t i;
 
     str = string;
     len = strlen(str);

--- a/modules/c/nitf/tests/test_atoi.c
+++ b/modules/c/nitf/tests/test_atoi.c
@@ -28,8 +28,8 @@
 
 int main(int argc, char *argv[])
 {
-    nitf_Int32  i32;
-    nitf_Uint32 u32;
+    int32_t  i32;
+    uint32_t u32;
 
     i32 = NITF_ATO32(BIG);
     u32 = NITF_ATO32(BIG);

--- a/modules/c/nitf/tests/test_clevel.c
+++ b/modules/c/nitf/tests/test_clevel.c
@@ -121,7 +121,7 @@ CLEVEL checkCCSExtent(nitf_Record* record, nitf_Error* error)
 
 CLEVEL checkFileSize(nitf_Record* record, nitf_Error* error)
 {
-    nitf_Int64 fl;
+    int64_t fl;
     TRY_IT( nitf_Field_get(record->header->fileLength,
                            &fl, NITF_CONV_INT, 8, error ));
     if (fl <= 52428799)

--- a/modules/c/nitf/tests/test_create_xmltre.c
+++ b/modules/c/nitf/tests/test_create_xmltre.c
@@ -45,7 +45,7 @@
 void printTRE(nitf_TRE* tre)
 {
     nitf_Error error;
-    nitf_Uint32 treLength;
+    uint32_t treLength;
     nitf_TREEnumerator* it = NULL;
     const char* treID = NULL;
 
@@ -536,14 +536,14 @@ void manuallyWriteImageBands(nitf_ImageSegment * segment,
                              int imageNumber, nitf_Error * error)
 {
     char *file;
-    nitf_Uint32 nBits, nBands, xBands, nRows, nColumns;
+    uint32_t nBits, nBands, xBands, nRows, nColumns;
     size_t subimageSize;
     nitf_SubWindow *subimage;
     unsigned int i;
     int padded;
-    nitf_Uint8 **buffer = NULL;
-    nitf_Uint32 band;
-    nitf_Uint32 *bandList = NULL;
+    uint8_t **buffer = NULL;
+    uint32_t band;
+    uint32_t *bandList = NULL;
 
     NITF_TRY_GET_UINT32(segment->subheader->numBitsPerPixel, &nBits,
                         error);
@@ -555,9 +555,9 @@ void manuallyWriteImageBands(nitf_ImageSegment * segment,
     NITF_TRY_GET_UINT32(segment->subheader->numCols, &nColumns, error);
     subimageSize = nRows * nColumns * NITF_NBPP_TO_BYTES(nBits);
 
-    buffer = (nitf_Uint8 **) malloc(8 * nBands);
+    buffer = (uint8_t **) malloc(8 * nBands);
     band = 0;
-    bandList = (nitf_Uint32 *) malloc(sizeof(nitf_Uint32 *) * nBands);
+    bandList = (uint32_t *) malloc(sizeof(uint32_t *) * nBands);
 
     subimage = nitf_SubWindow_construct(error);
     assert(subimage);
@@ -575,7 +575,7 @@ void manuallyWriteImageBands(nitf_ImageSegment * segment,
     assert(buffer);
     for (i = 0; i < nBands; i++)
     {
-        buffer[i] = (nitf_Uint8 *) malloc(subimageSize);
+        buffer[i] = (uint8_t *) malloc(subimageSize);
         assert(buffer[i]);
     }
     if (!nitf_ImageReader_read

--- a/modules/c/nitf/tests/test_des_create.c
+++ b/modules/c/nitf/tests/test_des_create.c
@@ -87,14 +87,14 @@ void manuallyWriteImageBands(nitf_ImageSegment * segment,
                              int imageNumber, nitf_Error * error)
 {
     char *file;
-    nitf_Uint32 nBits, nBands, xBands, nRows, nColumns;
+    uint32_t nBits, nBands, xBands, nRows, nColumns;
     size_t subimageSize;
     nitf_SubWindow *subimage;
     unsigned int i;
     int padded;
-    nitf_Uint8 **buffer;
-    nitf_Uint32 band;
-    nitf_Uint32 *bandList;
+    uint8_t **buffer;
+    uint32_t band;
+    uint32_t *bandList;
 
     NITF_TRY_GET_UINT32(segment->subheader->numBitsPerPixel, &nBits,
                         error);
@@ -150,9 +150,9 @@ void manuallyWriteImageBands(nitf_ImageSegment * segment,
            segment->subheader->compressionRate->raw);
 
 
-    buffer = (nitf_Uint8 **) malloc(8 * nBands);
+    buffer = (uint8_t **) malloc(8 * nBands);
     band = 0;
-    bandList = (nitf_Uint32 *) malloc(sizeof(nitf_Uint32 *) * nBands);
+    bandList = (uint32_t *) malloc(sizeof(uint32_t *) * nBands);
 
     subimage = nitf_SubWindow_construct(error);
     assert(subimage);
@@ -170,7 +170,7 @@ void manuallyWriteImageBands(nitf_ImageSegment * segment,
     assert(buffer);
     for (i = 0; i < nBands; i++)
     {
-        buffer[i] = (nitf_Uint8 *) malloc(subimageSize);
+        buffer[i] = (uint8_t *) malloc(subimageSize);
         assert(buffer[i]);
     }
     if (!nitf_ImageReader_read

--- a/modules/c/nitf/tests/test_dump_masks.c
+++ b/modules/c/nitf/tests/test_dump_masks.c
@@ -33,12 +33,12 @@
 #include <import/nitf.h>
 
 NITF_BOOL nitf_ImageIO_getMaskInfo(nitf_ImageIO *nitf,
-                                   nitf_Uint32 *imageDataOffset, nitf_Uint32 *blockRecordLength,
-                                   nitf_Uint32 *padRecordLength, nitf_Uint32 *padPixelValueLength,
-                                   nitf_Uint8 **padValue, nitf_Uint64 **blockMask, nitf_Uint64 **padMask);
+                                   uint32_t *imageDataOffset, uint32_t *blockRecordLength,
+                                   uint32_t *padRecordLength, uint32_t *padPixelValueLength,
+                                   uint8_t **padValue, uint64_t **blockMask, uint64_t **padMask);
 
 void dumpMask(const char* maskType,
-              const nitf_Uint64* mask,
+              const uint64_t* mask,
               size_t numRows,
               size_t numCols)
 {
@@ -94,13 +94,13 @@ int main(int argc, char *argv[])
 
     /*  Mask structure and mask components */
 
-    nitf_Uint32 imageDataOffset;    /* Offset to actual image data past masks */
-    nitf_Uint32 blockRecordLength;  /* Block mask record length */
-    nitf_Uint32 padRecordLength;    /* Pad mask record length */
-    nitf_Uint32 padPixelValueLength; /* Pad pixel value length in bytes */
-    nitf_Uint8 *padValue;           /* Pad value */
-    nitf_Uint64 *blockMask;         /* Block mask array */
-    nitf_Uint64 *padMask;           /* Pad mask array */
+    uint32_t imageDataOffset;    /* Offset to actual image data past masks */
+    uint32_t blockRecordLength;  /* Block mask record length */
+    uint32_t padRecordLength;    /* Pad mask record length */
+    uint32_t padPixelValueLength; /* Pad pixel value length in bytes */
+    uint8_t *padValue;           /* Pad value */
+    uint64_t *blockMask;         /* Block mask array */
+    uint64_t *padMask;           /* Pad mask array */
     size_t imgCtr = 0;
     const char* pathname;
 
@@ -200,7 +200,7 @@ int main(int argc, char *argv[])
                                      &padRecordLength, &padPixelValueLength,
                                      &padValue, &blockMask, &padMask))
         {
-            nitf_Uint32 i;
+            uint32_t i;
 
             printf("  Masked image:\n");
             printf("    Image data offset = %d\n", imageDataOffset);

--- a/modules/c/nitf/tests/test_fhdr_clone.c
+++ b/modules/c/nitf/tests/test_fhdr_clone.c
@@ -31,10 +31,10 @@
 void printHdr(nitf_FileHeader* header)
 {
     unsigned int i;
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_Error error;
-    nitf_Uint32 len;
-    nitf_Uint64 dataLen;
+    uint32_t len;
+    uint64_t dataLen;
 
     SHOW_VAL( header->fileHeader );
     SHOW_VAL( header->fileVersion );

--- a/modules/c/nitf/tests/test_field_set.c
+++ b/modules/c/nitf/tests/test_field_set.c
@@ -36,14 +36,14 @@ int main(int argc, char *argv[])
 {
     nitf_FileHeader *fhdr;          /* File header supplying fields */
     nitf_ImageSubheader *subhdr;    /* Subheader supplying fields */
-    nitf_Uint32 valueU32Before;     /* Value buffer */
-    nitf_Uint32 valueU32After;      /* Value buffer */
-    nitf_Uint64 valueU64Before;     /* Value buffer */
-    nitf_Uint64 valueU64After;      /* Value buffer */
+    uint32_t valueU32Before;     /* Value buffer */
+    uint32_t valueU32After;      /* Value buffer */
+    uint64_t valueU64Before;     /* Value buffer */
+    uint64_t valueU64After;      /* Value buffer */
     char *valueStrBefore;           /* Value buffer */
     /* Value buffer */
     static char valueStrAfter[STR_LEN + 2];
-    nitf_Uint32 valueStrLen;        /* Value buffer */
+    uint32_t valueStrLen;        /* Value buffer */
     static nitf_Error errorObj;     /* Error object for messages */
     nitf_Error *error;              /* Pointer to the error object */
 

--- a/modules/c/nitf/tests/test_image_loading.c
+++ b/modules/c/nitf/tests/test_image_loading.c
@@ -38,20 +38,20 @@ void writeImage(nitf_ImageSegment * segment,
                 char *imageName,
                 nitf_ImageReader * deserializer,
                 int imageNumber,
-                nitf_Uint32 rowSkipFactor,
-                nitf_Uint32 columnSkipFactor,
+                uint32_t rowSkipFactor,
+                uint32_t columnSkipFactor,
                 NITF_BOOL optz,
                 nitf_Error * error)
 {
 
-    nitf_Uint32 nBits, nBands, xBands, nRows, nColumns;
+    uint32_t nBits, nBands, xBands, nRows, nColumns;
     size_t subimageSize;
     nitf_SubWindow *subimage;
     unsigned int i;
     int padded;
-    nitf_Uint8 **buffer = NULL;
-    nitf_Uint32 band;
-    nitf_Uint32 *bandList = NULL;
+    uint8_t **buffer = NULL;
+    uint32_t band;
+    uint32_t *bandList = NULL;
 
     nitf_DownSampler *pixelSkip;
 
@@ -158,7 +158,7 @@ void writeImage(nitf_ImageSegment * segment,
      *  can set the number of bands to 1, and size your buffer
      *  accordingly to receive band-interleaved by pixel data)
      */
-    buffer = (nitf_Uint8 **) NITF_MALLOC(nBands * sizeof(nitf_Uint8*));
+    buffer = (uint8_t **) NITF_MALLOC(nBands * sizeof(uint8_t*));
 
     /* An iterator for bands */
     band = 0;
@@ -170,7 +170,7 @@ void writeImage(nitf_ImageSegment * segment,
      *  have a band of magnitude and a band of phase.  If you order the
      *  bandList backwards, the phase buffer comes first in the output
      */
-    bandList = (nitf_Uint32 *) NITF_MALLOC(sizeof(nitf_Uint32 *) * nBands);
+    bandList = (uint32_t *) NITF_MALLOC(sizeof(uint32_t *) * nBands);
 
     /* This example reads all rows and cols starting at 0, 0 */
     subimage->startCol = 0;
@@ -205,7 +205,7 @@ void writeImage(nitf_ImageSegment * segment,
     assert(buffer);
     for (i = 0; i < nBands; i++)
     {
-        buffer[i] = (nitf_Uint8 *) NITF_MALLOC(subimageSize);
+        buffer[i] = (uint8_t *) NITF_MALLOC(subimageSize);
         assert(buffer[i]);
     }
     if (!nitf_ImageReader_read
@@ -283,8 +283,8 @@ int main(int argc, char **argv)
     nitf_Error e;
 
     /* Skip factors */
-    nitf_Uint32 rowSkipFactor = 1;
-    nitf_Uint32 columnSkipFactor = 1;
+    uint32_t rowSkipFactor = 1;
+    uint32_t columnSkipFactor = 1;
 
     /*  This is the reader  */
     nitf_Reader *reader;

--- a/modules/c/nitf/tests/test_imsub_clone.c
+++ b/modules/c/nitf/tests/test_imsub_clone.c
@@ -32,10 +32,10 @@
 void showFileHeader(nitf_FileHeader* header)
 {
     unsigned int i;
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_Error error;
-    nitf_Uint32 len;
-    nitf_Uint64 dataLen;
+    uint32_t len;
+    uint64_t dataLen;
 
     SHOW_VAL( header->fileHeader );
     SHOW_VAL( header->fileVersion );

--- a/modules/c/nitf/tests/test_insert_raw_xmltre.c
+++ b/modules/c/nitf/tests/test_insert_raw_xmltre.c
@@ -435,14 +435,14 @@ void manuallyWriteImageBands(nitf_ImageSegment * segment,
                              int imageNumber, nitf_Error * error)
 {
     char *file;
-    nitf_Uint32 nBits, nBands, xBands, nRows, nColumns;
+    uint32_t nBits, nBands, xBands, nRows, nColumns;
     size_t subimageSize;
     nitf_SubWindow *subimage;
     unsigned int i;
     int padded;
-    nitf_Uint8 **buffer = NULL;
-    nitf_Uint32 band;
-    nitf_Uint32 *bandList = NULL;
+    uint8_t **buffer = NULL;
+    uint32_t band;
+    uint32_t *bandList = NULL;
 
     NITF_TRY_GET_UINT32(segment->subheader->numBitsPerPixel, &nBits,
                         error);
@@ -454,9 +454,9 @@ void manuallyWriteImageBands(nitf_ImageSegment * segment,
     NITF_TRY_GET_UINT32(segment->subheader->numCols, &nColumns, error);
     subimageSize = nRows * nColumns * NITF_NBPP_TO_BYTES(nBits);
 
-    buffer = (nitf_Uint8 **) malloc(8 * nBands);
+    buffer = (uint8_t **) malloc(8 * nBands);
     band = 0;
-    bandList = (nitf_Uint32 *) malloc(sizeof(nitf_Uint32 *) * nBands);
+    bandList = (uint32_t *) malloc(sizeof(uint32_t *) * nBands);
 
     subimage = nitf_SubWindow_construct(error);
     assert(subimage);
@@ -474,7 +474,7 @@ void manuallyWriteImageBands(nitf_ImageSegment * segment,
     assert(buffer);
     for (i = 0; i < nBands; i++)
     {
-        buffer[i] = (nitf_Uint8 *) malloc(subimageSize);
+        buffer[i] = (uint8_t *) malloc(subimageSize);
         assert(buffer[i]);
     }
     if (!nitf_ImageReader_read

--- a/modules/c/nitf/tests/test_make_pattern.c
+++ b/modules/c/nitf/tests/test_make_pattern.c
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
 
     nitf_IOHandle out;               /* Handle for output */
     nitf_Error error;                /* Error object */
-    nitf_Uint8 ***data;              /* Generated data [band][row][col] */
+    uint8_t ***data;              /* Generated data [band][row][col] */
 
     if (argc < 4)
     {
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
 
     if (strcmp(newArgs->dataPattern, "brcI4") == 0)
     {
-        data = (nitf_Uint8 ***) test_nitf_ImageIO_brcI4(newArgs, &errorStr);
+        data = (uint8_t ***) test_nitf_ImageIO_brcI4(newArgs, &errorStr);
         if (data == NULL)
         {
             fprintf(stderr, "%s\n", errorStr);
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
     }
     else if (strcmp(newArgs->dataPattern, "brcC8") == 0)
     {
-        data = (nitf_Uint8 ***) test_nitf_ImageIO_brcC8(newArgs, &errorStr);
+        data = (uint8_t ***) test_nitf_ImageIO_brcC8(newArgs, &errorStr);
         if (data == NULL)
         {
             fprintf(stderr, "%s\n", errorStr);
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
     }
     else if (strncmp(newArgs->dataPattern, "blocks_", 7) == 0)
     {
-        data = (nitf_Uint8 ***) test_nitf_ImageIO_block(newArgs, &errorStr);
+        data = (uint8_t ***) test_nitf_ImageIO_block(newArgs, &errorStr);
         if (data == NULL)
         {
             fprintf(stderr, "%s\n", errorStr);
@@ -253,10 +253,10 @@ void setupImageSubheader(
     nitf_Record *record, nitf_ImageSegment *seg)
 {
     nitf_ImageSubheader *subheader;   /* Subheader from segment */
-    nitf_Uint32 nBands;               /* Number of bands */
+    uint32_t nBands;               /* Number of bands */
     nitf_BandInfo **bands;            /* BandInfo array */
     nitf_Error errorObj;              /* Error object argument */
-    nitf_Uint32 i;
+    uint32_t i;
 
     subheader = seg->subheader;
     nitf_Field_setUint32(subheader->numRows, args->nRows, &errorObj);
@@ -342,10 +342,10 @@ nitf_ImageSource *makeImageSource(
     test_nitf_ImageIOConstructArgs *args, char ***data)
 {
     nitf_ImageSource *imgSource;  /* The result */
-    nitf_Uint32 nBands;           /* Number of bands */
+    uint32_t nBands;           /* Number of bands */
     nitf_Off bandSize;               /* Size of individual bands */
     nitf_Error error;             /* Error object argument */
-    nitf_Uint32 i;
+    uint32_t i;
 
     bandSize = (args->nRows) * (args->nColumns) * (NITF_NBPP_TO_BYTES(args->nBits));
 

--- a/modules/c/nitf/tests/test_setReal.c
+++ b/modules/c/nitf/tests/test_setReal.c
@@ -29,7 +29,7 @@
 #include <import/nitf.h>
 
 void testField(nitf_Field *field, char *type, NITF_BOOL plus,
-               nitf_Uint32 length, double value);
+               uint32_t length, double value);
 
 int main(int argc, char *argv[])
 {
@@ -72,12 +72,12 @@ int main(int argc, char *argv[])
 }
 
 void testField(nitf_Field *field, char *type, NITF_BOOL plus,
-               nitf_Uint32 length, double value)
+               uint32_t length, double value)
 {
     NITF_BOOL ret;        /* Return from function */
     nitf_Error errorObj;  /* Error object */
     nitf_Error *error;    /* Pointer to error object */
-    nitf_Uint32 i;
+    uint32_t i;
 
     error = &errorObj;
 

--- a/modules/c/nitf/tests/test_writer_3.c
+++ b/modules/c/nitf/tests/test_writer_3.c
@@ -87,10 +87,10 @@ void freeBandName(char **rootFile)
 void showFileHeader(nitf_FileHeader * header)
 {
     unsigned int i;
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_Error error;
-    nitf_Uint32 len;
-    nitf_Uint64 dataLen;
+    uint32_t len;
+    uint64_t dataLen;
     NITF_BOOL success;
 
     SHOW_VAL(header->fileHeader);
@@ -469,9 +469,9 @@ void writeDEData(nitf_DESegment * segment,
         size_t leftToRead;
         size_t amtToRead;
     */
-    nitf_Uint64 toRead = DE_READ_SIZE;
-    nitf_Uint64 leftToRead;
-    nitf_Uint64 amtToRead;
+    uint64_t toRead = DE_READ_SIZE;
+    uint64_t leftToRead;
+    uint64_t amtToRead;
     char * buf = NULL;
     char * outName = NULL;
 
@@ -536,14 +536,14 @@ void manuallyWriteImageBands(nitf_ImageSegment * segment,
                              int imageNumber, nitf_Error * error)
 {
     char *file;
-    nitf_Uint32 nBits, nBands, xBands, nRows, nColumns;
+    uint32_t nBits, nBands, xBands, nRows, nColumns;
     size_t subimageSize;
     nitf_SubWindow *subimage;
     unsigned int i;
     int padded;
-    nitf_Uint8 **buffer = NULL;
-    nitf_Uint32 band;
-    nitf_Uint32 *bandList = NULL;
+    uint8_t **buffer = NULL;
+    uint32_t band;
+    uint32_t *bandList = NULL;
 
     NITF_TRY_GET_UINT32(segment->subheader->numBitsPerPixel, &nBits,
                         error);
@@ -599,9 +599,9 @@ void manuallyWriteImageBands(nitf_ImageSegment * segment,
            segment->subheader->compressionRate->raw);
 
 
-    buffer = (nitf_Uint8 **) malloc(sizeof(nitf_Uint8*) * nBands);
+    buffer = (uint8_t **) malloc(sizeof(uint8_t*) * nBands);
     band = 0;
-    bandList = (nitf_Uint32 *) malloc(sizeof(nitf_Uint32 *) * nBands);
+    bandList = (uint32_t *) malloc(sizeof(uint32_t *) * nBands);
 
     subimage = nitf_SubWindow_construct(error);
     assert(subimage);
@@ -619,7 +619,7 @@ void manuallyWriteImageBands(nitf_ImageSegment * segment,
     assert(buffer);
     for (i = 0; i < nBands; i++)
     {
-        buffer[i] = (nitf_Uint8 *) malloc(subimageSize);
+        buffer[i] = (uint8_t *) malloc(subimageSize);
         assert(buffer[i]);
     }
     /*  This should change to returning failures!  */

--- a/modules/c/nitf/tests/test_writer_s.c
+++ b/modules/c/nitf/tests/test_writer_s.c
@@ -51,10 +51,10 @@
 void showFileHeader(nitf_FileHeader* header)
 {
     unsigned int i;
-    nitf_Uint32 num;
+    uint32_t num;
     nitf_Error error;
-    nitf_Uint32 len;
-    nitf_Uint64 dataLen;
+    uint32_t len;
+    uint64_t dataLen;
     NITF_BOOL success;
 
     SHOW_VAL(header->fileHeader);
@@ -124,12 +124,12 @@ NITF_BOOL writeImage(nitf_ImageSegment* segment, nitf_IOHandle input_io, nitf_IO
 
     nitf_ImageIO* ioClone;
 
-    nitf_Uint8** buffer;
-    nitf_Uint32 nBits, nBands, xBands, nRows, nColumns;
+    uint8_t** buffer;
+    uint32_t nBits, nBands, xBands, nRows, nColumns;
     nitf_SubWindow *subimage;
     size_t subimageSize;
-    nitf_Uint32 band;
-    nitf_Uint32 *bandList;
+    uint32_t band;
+    uint32_t *bandList;
     NITF_BOOL success;
     int padded;
 
@@ -166,18 +166,18 @@ NITF_BOOL writeImage(nitf_ImageSegment* segment, nitf_IOHandle input_io, nitf_IO
 
 
     /* Allcoate buffers */
-    buffer = (nitf_Uint8 **)malloc(8 * nBands);
+    buffer = (uint8_t **)malloc(8 * nBands);
     assert(buffer);
 
     for (band = 0; band < nBands; band++)
     {
-        buffer[band] = (nitf_Uint8*)malloc(subimageSize);
+        buffer[band] = (uint8_t*)malloc(subimageSize);
         assert(buffer[band]);
     }
 
     /*  Set-up band array and subimage */
 
-    bandList = (nitf_Uint32 *)malloc(sizeof(nitf_Uint32 *) * nBands);
+    bandList = (uint32_t *)malloc(sizeof(uint32_t *) * nBands);
 
     subimage = nitf_SubWindow_construct(&error);
     assert(subimage);
@@ -242,8 +242,8 @@ int doWrite(nitf_ImageSegment* segment, nitf_ImageSource *imgSrc,
             nitf_IOHandle output_io, nitf_ImageIO* ioClone)
 {
     nitf_Error error;
-    nitf_Uint8** user;
-    nitf_Uint32 nBits, nBands, xBands, nRows, nColumns, row;
+    uint8_t** user;
+    uint32_t nBits, nBands, xBands, nRows, nColumns, row;
     size_t rowSize;
     int band;
     NITF_BOOL success; /* Used in GET macros */
@@ -261,11 +261,11 @@ int doWrite(nitf_ImageSegment* segment, nitf_ImageSource *imgSrc,
 
     /*    Allocate buffers */
 
-    user = (nitf_Uint8 **)malloc(8 * nBands);
+    user = (uint8_t **)malloc(8 * nBands);
     assert(user);
     for (band = 0; band < nBands; band++)
     {
-        user[band] = (nitf_Uint8*)malloc(rowSize);
+        user[band] = (uint8_t*)malloc(rowSize);
         assert(user[band]);
     }
 

--- a/modules/c/nitf/unittests/test_create_nitf.c
+++ b/modules/c/nitf/unittests/test_create_nitf.c
@@ -1148,7 +1148,7 @@ NITF_BOOL writeNITF(nitf_Record *record, const char* filename, nitf_Error *error
     nitf_Writer *writer = NULL;
     nitf_ImageWriter *imageWriter = NULL;
     nitf_ImageSource *imageSource;
-    nitf_Uint32 i;
+    uint32_t i;
 
     /* create the IOHandle */
     out = nitf_IOHandle_create(filename, NITF_ACCESS_WRITEONLY,

--- a/modules/c/nitf/unittests/test_field.c
+++ b/modules/c/nitf/unittests/test_field.c
@@ -33,7 +33,7 @@ TEST_CASE( testField)
     nitf_Field *fhdr = NULL, *ubin = NULL, *hl = NULL, *realField = NULL;
 
     nitf_Error error;
-    nitf_Int32 int32 = 16801;
+    int32_t int32 = 16801;
     fhdr = nitf_Field_construct(NITF_FHDR_SZ, NITF_BCS_A, &error);
     ubin = nitf_Field_construct(4, NITF_BINARY, &error);
     hl = nitf_Field_construct(NITF_HL_SZ, NITF_BCS_N, &error);

--- a/modules/c/nitf/unittests/test_image_io.c
+++ b/modules/c/nitf/unittests/test_image_io.c
@@ -27,16 +27,16 @@ typedef struct TestSpec
 {
     // Image spec
     const char* imageMode;
-    nitf_Uint32 bitsPerPixel;
+    uint32_t bitsPerPixel;
     char* pixels;
-    nitf_Uint64 imageSize;
-    nitf_Uint32 numBands;
+    uint64_t imageSize;
+    uint32_t numBands;
 
     // Read request
-    nitf_Uint32 startRow;
-    nitf_Uint32 numRows;
-    nitf_Uint32 startCol;
-    nitf_Uint32 numCols;
+    uint32_t startRow;
+    uint32_t numRows;
+    uint32_t startCol;
+    uint32_t numCols;
 
     const char* expectedRead;
 } TestSpec;
@@ -50,8 +50,8 @@ typedef struct TestState
     nitf_ImageIO* imageIO;
     nitf_IOInterface* interface;
     nitf_SubWindow* subwindow;
-    nitf_Uint32 numBands;
-    nitf_Uint32* bandList;
+    uint32_t numBands;
+    uint32_t* bandList;
     nitf_BandInfo** band;
 } TestState;
 
@@ -79,7 +79,7 @@ TestState* constructTestSubheader(TestSpec* spec)
     state->band = malloc(sizeof(nitf_BandInfo) * spec->numBands);
     assert(state->band);
 
-    nitf_Uint32 band;
+    uint32_t band;
     for (band = 0; band < spec->numBands; ++band)
     {
         state->band[band] = nitf_BandInfo_construct(&error);
@@ -125,7 +125,7 @@ TestState* constructTestSubheader(TestSpec* spec)
     state->interface = io;
     state->subwindow = subwindow;
     state->numBands = spec->numBands;
-    state->bandList = malloc(state->numBands * sizeof(nitf_Uint32));
+    state->bandList = malloc(state->numBands * sizeof(uint32_t));
     for (band = 0; band < state->numBands; ++band)
     {
         state->bandList[band] = band;
@@ -146,7 +146,7 @@ void freeTestState(TestState* state)
     free(state);
 }
 
-void freeBands(nitf_Uint8** bands, size_t numBands)
+void freeBands(uint8_t** bands, size_t numBands)
 {
     size_t bandIndex;
     for (bandIndex = 0; bandIndex < numBands; ++bandIndex)
@@ -159,12 +159,12 @@ void freeBands(nitf_Uint8** bands, size_t numBands)
     free(bands);
 }
 
-static nitf_Uint8** allocateBands(size_t numBands, size_t bytesPerBand)
+static uint8_t** allocateBands(size_t numBands, size_t bytesPerBand)
 {
     size_t bandIndex;
     int success = 1;
 
-    nitf_Uint8** bands = (nitf_Uint8**)calloc(numBands, sizeof(nitf_Uint8 *));
+    uint8_t** bands = (uint8_t**)calloc(numBands, sizeof(uint8_t *));
     if (bands == NULL)
     {
         return NULL;
@@ -172,7 +172,7 @@ static nitf_Uint8** allocateBands(size_t numBands, size_t bytesPerBand)
 
     for (bandIndex = 0; bandIndex < numBands; ++bandIndex)
     {
-        bands[bandIndex] = (nitf_Uint8*)calloc(sizeof(nitf_Uint8), bytesPerBand + 1);
+        bands[bandIndex] = (uint8_t*)calloc(sizeof(uint8_t), bytesPerBand + 1);
         if (bands[bandIndex] == NULL)
         {
             success = 0;
@@ -193,9 +193,9 @@ static NITF_BOOL doReadTest(TestSpec* spec, TestState* test)
 {
     NITF_BOOL result = NITF_SUCCESS;
 
-    const nitf_Uint32 numBands = test->subwindow->numBands;
+    const uint32_t numBands = test->subwindow->numBands;
     const size_t bandSize = strlen(spec->expectedRead) / numBands;
-    nitf_Uint8** bands = allocateBands(numBands, bandSize);
+    uint8_t** bands = allocateBands(numBands, bandSize);
     if (bands == NULL)
     {
         return NITF_FAILURE;
@@ -211,7 +211,7 @@ static NITF_BOOL doReadTest(TestSpec* spec, TestState* test)
     if (joinedBands)
     {
         strcpy(joinedBands, (const char*) bands[0]);
-        nitf_Uint32 bandIdx;
+        uint32_t bandIdx;
         for (bandIdx = 1; bandIdx < numBands; ++bandIdx)
         {
             strcat(joinedBands, (const char*) bands[bandIdx]);
@@ -235,11 +235,11 @@ static NITF_BOOL roundTripTest(TestSpec* spec, TestState* test, char* pixels)
 {
     NITF_BOOL result = NITF_SUCCESS;
     nitf_Error error;
-    const nitf_Uint32 numBands = test->subwindow->numBands;
+    const uint32_t numBands = test->subwindow->numBands;
     nitf_IOInterface* writeIO = NULL;
 
     const size_t bandSize = strlen(spec->expectedRead) / numBands;
-    nitf_Uint8** bands = allocateBands(numBands, bandSize);
+    uint8_t** bands = allocateBands(numBands, bandSize);
     if (bands == NULL)
     {
         return NITF_FAILURE;
@@ -832,7 +832,7 @@ TEST_CASE(testInvalidReadOrderFailsGracefully)
     test->subwindow->bandList[1] = 0;
 
     int padded;
-    nitf_Uint8* user[2] = { 0, 0 };
+    uint8_t* user[2] = { 0, 0 };
     TEST_ASSERT(!nitf_ImageIO_read(test->imageIO, test->interface, test->subwindow,
                 user, &padded, &error));
     freeTestState(test);

--- a/modules/c/nitf/unittests/test_tre_mods.c
+++ b/modules/c/nitf/unittests/test_tre_mods.c
@@ -60,7 +60,7 @@ TEST_CASE(testIncompleteCondMod)
 {
     nitf_Error error;
     NITF_BOOL exists;
-    nitf_Uint32 treLength = 0;
+    uint32_t treLength = 0;
     nitf_TRE* tre = nitf_TRE_construct("ACCPOB", NULL, &error);
     TEST_ASSERT(tre);
     treLength = tre->handler->getCurrentSize(tre, &error);
@@ -156,7 +156,7 @@ TEST_CASE(iterateUnfilled)
     nitf_Error error;
     nitf_TRECursor cursor;
     nitf_TRE* tre = nitf_TRE_construct("ACCPOB", NULL, &error);
-    nitf_Uint32 numFields = 0;
+    uint32_t numFields = 0;
     TEST_ASSERT(tre);
     cursor = nitf_TRECursor_begin(tre);
 
@@ -177,7 +177,7 @@ TEST_CASE(populateThenIterate)
     nitf_Error error;
     nitf_TRECursor cursor;
     nitf_TRE* tre = nitf_TRE_construct("ACCPOB", NULL, &error);
-    nitf_Uint32 numFields = 0;
+    uint32_t numFields = 0;
     TEST_ASSERT(tre);
 
     nitf_TRE_setField(tre, "NUMACPO", "2", 1, &error);
@@ -203,7 +203,7 @@ TEST_CASE(populateWhileIterating)
     nitf_Error error;
     nitf_TRECursor cursor;
     nitf_TRE* tre = nitf_TRE_construct("ACCPOB", NULL, &error);
-    nitf_Uint32 numFields = 0;
+    uint32_t numFields = 0;
     TEST_ASSERT(tre);
 
     cursor = nitf_TRECursor_begin(tre);

--- a/modules/c/nrt/include/nrt/List.h
+++ b/modules/c/nrt/include/nrt/List.h
@@ -277,8 +277,8 @@ NRTAPI(NRT_DATA *) nrt_List_remove(nrt_List * chain, nrt_ListIterator * where);
  *  \param newIndex the index where the data item will be moved to
  *  \return NRT_SUCCESS on success, or NRT_FAILURE
  */
-NRTAPI(NRT_BOOL) nrt_List_move(nrt_List * chain, nrt_Uint32 oldIndex,
-                               nrt_Uint32 newIndex, nrt_Error * error);
+NRTAPI(NRT_BOOL) nrt_List_move(nrt_List * chain, uint32_t oldIndex,
+                               uint32_t newIndex, nrt_Error * error);
 
 /*!
  *  Return the size of the list
@@ -286,7 +286,7 @@ NRTAPI(NRT_BOOL) nrt_List_move(nrt_List * chain, nrt_Uint32 oldIndex,
  *  \param list The list to check
  *  \return size of the list
  */
-NRTAPI(nrt_Uint32) nrt_List_size(nrt_List * list);
+NRTAPI(uint32_t) nrt_List_size(nrt_List * list);
 
 /*!
  *  Return the element at the specified position in the list

--- a/modules/c/nrt/include/nrt/System.h
+++ b/modules/c/nrt/include/nrt/System.h
@@ -32,9 +32,9 @@
 #include "nrt/Directory.h"
 #include "nrt/IOHandle.h"
 
-NRTPROT(nrt_Uint16) nrt_System_swap16(nrt_Uint16 ins);
-NRTPROT(nrt_Uint32) nrt_System_swap32(nrt_Uint32 inl);
-NRTPROT(nrt_Uint64) nrt_System_swap64c(nrt_Uint64 inl);
-NRTPROT(nrt_Uint64) nrt_System_swap64(nrt_Uint64 inl);
+NRTPROT(uint16_t) nrt_System_swap16(uint16_t ins);
+NRTPROT(uint32_t) nrt_System_swap32(uint32_t inl);
+NRTPROT(uint64_t) nrt_System_swap64c(uint64_t inl);
+NRTPROT(uint64_t) nrt_System_swap64(uint64_t inl);
 
 #endif

--- a/modules/c/nrt/include/nrt/Types.h
+++ b/modules/c/nrt/include/nrt/Types.h
@@ -22,6 +22,7 @@
 
 #ifndef __NRT_TYPES_H__
 #define __NRT_TYPES_H__
+#pragma once
 
 #include "nrt/nrt_config.h"
 
@@ -35,6 +36,18 @@
 #   include <sys/types.h>
 #   include <ctype.h>
 #   include <time.h>
+
+ // Keeping these here so that code using "nrt_Uint8" still compiles;
+ // we can't make others change to "uint8_t".
+typedef uint8_t nrt_Uint8;
+typedef uint16_t nrt_Uint16;
+typedef uint32_t nrt_Uint32;
+typedef uint64_t nrt_Uint64;
+
+typedef int8_t nrt_Int8;
+typedef int16_t nrt_Int16;
+typedef int32_t nrt_Int32;
+typedef int64_t nrt_Int64;
 
 #ifdef WIN32
 #      include <windows.h>

--- a/modules/c/nrt/include/nrt/Types.h
+++ b/modules/c/nrt/include/nrt/Types.h
@@ -27,6 +27,7 @@
 
 #   include <assert.h>
 #   include <stdlib.h>
+#   include <stdint.h>
 #   include <string.h>
 #   include <stdio.h>
 #   include <math.h>
@@ -39,15 +40,6 @@
 #      include <windows.h>
 
 /*  Types are defined for windows here  */
-typedef unsigned char nrt_Uint8;
-typedef unsigned __int16 nrt_Uint16;
-typedef unsigned __int32 nrt_Uint32;
-typedef unsigned __int64 nrt_Uint64;
-
-typedef signed char nrt_Int8;
-typedef __int16 nrt_Int16;
-typedef __int32 nrt_Int32;
-typedef __int64 nrt_Int64;
 typedef HANDLE nrt_IOHandle;
 typedef HINSTANCE NRT_NATIVE_DLL;
 typedef FARPROC NRT_DLL_FUNCTION_PTR;
@@ -56,8 +48,8 @@ typedef DWORD nrt_CreationFlags;
 /*  Determine the maximum file path length  */
 #      define  NRT_MAX_PATH     MAX_PATH
 
-/* use nrt_Off instead of off_t, since on Windows we want nrt_Int64 used */
-typedef nrt_Int64 nrt_Off;
+/* use nrt_Off instead of off_t, since on Windows we want int64_t used */
+typedef int64_t nrt_Off;
 
 /*  IO macros  */
 #      define  NRT_INVALID_HANDLE_VALUE INVALID_HANDLE_VALUE
@@ -104,15 +96,6 @@ typedef nrt_Int64 nrt_Off;
 #      include <sys/param.h>
 
 /*  Typedefs on Unix are a different ball game */
-typedef uint8_t nrt_Uint8;
-typedef uint16_t nrt_Uint16;
-typedef uint32_t nrt_Uint32;
-typedef uint64_t nrt_Uint64;
-
-typedef int8_t nrt_Int8;
-typedef int16_t nrt_Int16;
-typedef int32_t nrt_Int32;
-typedef int64_t nrt_Int64;
 typedef int nrt_IOHandle;
 typedef off_t nrt_Off;
 
@@ -187,10 +170,10 @@ typedef enum _nrt_CornersType
 /* these functions are accessed if needed via the nrt_ntohs
    and nrt_ntohl macros defined in System.h                 */
 
-NRTPROT(nrt_Uint16) nrt_System_swap16(nrt_Uint16 ins);
-NRTPROT(nrt_Uint32) nrt_System_swap32(nrt_Uint32 inl);
-NRTPROT(nrt_Uint64) nrt_System_swap64(nrt_Uint64 inl);
-NRTPROT(nrt_Uint64) nrt_System_swap64c(nrt_Uint64 inl);
+NRTPROT(uint16_t) nrt_System_swap16(uint16_t ins);
+NRTPROT(uint32_t) nrt_System_swap32(uint32_t inl);
+NRTPROT(uint64_t) nrt_System_swap64(uint64_t inl);
+NRTPROT(uint64_t) nrt_System_swap64c(uint64_t inl);
 
 /* Configure says we are big-endian */
 #if defined(__LITTLE_ENDIAN__) || !defined(WORDS_BIGENDIAN)

--- a/modules/c/nrt/include/nrt/Utils.h
+++ b/modules/c/nrt/include/nrt/Utils.h
@@ -203,10 +203,10 @@ __inline
 #else
 inline
 #endif
-nrt_Utils_swap(nrt_Uint8* value, size_t indexOne,
+nrt_Utils_swap(uint8_t* value, size_t indexOne,
         size_t indexTwo)
 {
-    nrt_Uint8 temp;
+    uint8_t temp;
     temp = value[indexOne];
     value[indexOne] = value[indexTwo];
     value[indexTwo] = temp;
@@ -219,7 +219,7 @@ nrt_Utils_swap(nrt_Uint8* value, size_t indexOne,
  *  \param value Pointer to value to be swapped
  *  \param size The size, in bytes, of each buffer element
  */
-NRTAPI(void) nrt_Utils_byteSwap(nrt_Uint8* value, size_t size);
+NRTAPI(void) nrt_Utils_byteSwap(uint8_t* value, size_t size);
 
 NRT_CXX_ENDGUARD
 #endif

--- a/modules/c/nrt/source/IOHandleUnix.c
+++ b/modules/c/nrt/source/IOHandleUnix.c
@@ -59,7 +59,7 @@ NRTAPI(NRT_BOOL) nrt_IOHandle_read(nrt_IOHandle handle, void* buf, size_t size,
     {
         /* Make the next read */
         bytesRead = read(handle,
-                         (nrt_Uint8*)buf + totalBytesRead,
+                         (uint8_t*)buf + totalBytesRead,
                          size - totalBytesRead);
 
         switch (bytesRead)
@@ -112,7 +112,7 @@ NRTAPI(NRT_BOOL) nrt_IOHandle_write(nrt_IOHandle handle, const void *buf,
     do
     {
         const ssize_t bytesThisWrite =
-            write(handle, (const nrt_Uint8*)buf + bytesActuallyWritten, size);
+            write(handle, (const uint8_t*)buf + bytesActuallyWritten, size);
         if (bytesThisWrite == -1)
         {
             nrt_Error_init(error, strerror(errno), NRT_CTXT,

--- a/modules/c/nrt/source/IOHandleWin32.c
+++ b/modules/c/nrt/source/IOHandleWin32.c
@@ -70,7 +70,7 @@ NRTAPI(NRT_BOOL) nrt_IOHandle_read(nrt_IOHandle handle, void* buf, size_t size,
         /* Read from file */
         DWORD bytesThisRead = 0;
         if (!ReadFile(handle,
-                      (nrt_Uint8*)buf + bytesRead,
+                      (uint8_t*)buf + bytesRead,
                       bytesToRead,
                       &bytesThisRead,
                       NULL))
@@ -113,7 +113,7 @@ NRTAPI(NRT_BOOL) nrt_IOHandle_write(nrt_IOHandle handle, const void *buf,
         DWORD bytesThisWrite = 0;
 
         if (!WriteFile(handle,
-                       (const nrt_Uint8*)buf + bytesWritten,
+                       (const uint8_t*)buf + bytesWritten,
                        bytesToWrite,
                        &bytesThisWrite,
                        NULL))
@@ -162,7 +162,7 @@ NRTAPI(nrt_Off) nrt_IOHandle_getSize(nrt_IOHandle handle, nrt_Error * error)
 {
     DWORD ret;
     DWORD highOff;
-    nrt_Uint64 off;
+    uint64_t off;
     ret = GetFileSize(handle, &highOff);
     if ((ret == -1))
     {
@@ -171,7 +171,7 @@ NRTAPI(nrt_Off) nrt_IOHandle_getSize(nrt_IOHandle handle, nrt_Error * error)
         return (nrt_Off) - 1;
     }
 
-    off = (nrt_Uint64)highOff;
+    off = (uint64_t)highOff;
     return (nrt_Off)((off << 32) + ret);
 }
 

--- a/modules/c/nrt/source/List.c
+++ b/modules/c/nrt/source/List.c
@@ -362,10 +362,10 @@ NRTAPI(NRT_DATA *) nrt_List_remove(nrt_List * list, nrt_ListIterator * where)
     return data;
 }
 
-NRTAPI(NRT_BOOL) nrt_List_move(nrt_List * chain, nrt_Uint32 oldIndex,
-                               nrt_Uint32 newIndex, nrt_Error * error)
+NRTAPI(NRT_BOOL) nrt_List_move(nrt_List * chain, uint32_t oldIndex,
+                               uint32_t newIndex, nrt_Error * error)
 {
-    nrt_Uint32 listSize = nrt_List_size(chain);
+    uint32_t listSize = nrt_List_size(chain);
     nrt_ListIterator iter;
     NRT_DATA *data = NULL;
 
@@ -448,9 +448,9 @@ NRTAPI(NRT_DATA *) nrt_ListIterator_get(nrt_ListIterator * this_iter)
     return this_iter->current->data;
 }
 
-NRTAPI(nrt_Uint32) nrt_List_size(nrt_List * list)
+NRTAPI(uint32_t) nrt_List_size(nrt_List * list)
 {
-    nrt_Uint32 size = 0;
+    uint32_t size = 0;
 
     if (list)
     {

--- a/modules/c/nrt/source/System.c
+++ b/modules/c/nrt/source/System.c
@@ -22,9 +22,9 @@
 
 #include "nrt/System.h"
 
-NRTPROT(nrt_Uint16) nrt_System_swap16(nrt_Uint16 ins)
+NRTPROT(uint16_t) nrt_System_swap16(uint16_t ins)
 {
-    nrt_Uint16 outs;
+    uint16_t outs;
     unsigned char *ibytep = (unsigned char *) &ins;
     unsigned char *obytep = (unsigned char *) &outs;
     obytep[1] = ibytep[0];
@@ -32,9 +32,9 @@ NRTPROT(nrt_Uint16) nrt_System_swap16(nrt_Uint16 ins)
     return outs;
 }
 
-NRTPROT(nrt_Uint32) nrt_System_swap32(nrt_Uint32 inl)
+NRTPROT(uint32_t) nrt_System_swap32(uint32_t inl)
 {
-    nrt_Uint32 outl;
+    uint32_t outl;
     unsigned char *ibytep = (unsigned char *) &inl;
     unsigned char *obytep = (unsigned char *) &outl;
     obytep[3] = ibytep[0];
@@ -44,9 +44,9 @@ NRTPROT(nrt_Uint32) nrt_System_swap32(nrt_Uint32 inl)
     return outl;
 }
 
-NRTPROT(nrt_Uint64) nrt_System_swap64c(nrt_Uint64 inl)
+NRTPROT(uint64_t) nrt_System_swap64c(uint64_t inl)
 {
-    nrt_Uint64 outl;
+    uint64_t outl;
     const unsigned char* const ibytep = (const unsigned char* )&inl;
     unsigned char* const obytep = (unsigned char* )&outl;
 
@@ -64,9 +64,9 @@ NRTPROT(nrt_Uint64) nrt_System_swap64c(nrt_Uint64 inl)
     return outl;
 }
 
-NRTPROT(nrt_Uint64) nrt_System_swap64(nrt_Uint64 inl)
+NRTPROT(uint64_t) nrt_System_swap64(uint64_t inl)
 {
-    nrt_Uint64 outl;
+    uint64_t outl;
     unsigned char *ibytep = (unsigned char *) &inl;
     unsigned char *obytep = (unsigned char *) &outl;
 

--- a/modules/c/nrt/source/Utils.c
+++ b/modules/c/nrt/source/Utils.c
@@ -563,7 +563,7 @@ NRTPROT(void) nrt_Utils_decimalLonToGeoCharArray(double decimal, char *buffer8)
     nrt_Utils_geographicLonToCharArray(d, m, s, buffer8);
 }
 
-NRTAPI(void) nrt_Utils_byteSwap(nrt_Uint8 *value, size_t size)
+NRTAPI(void) nrt_Utils_byteSwap(uint8_t *value, size_t size)
 {
     switch(size)
     {

--- a/modules/c/nrt/unittests/test_core_values.c
+++ b/modules/c/nrt/unittests/test_core_values.c
@@ -25,15 +25,15 @@
 
 TEST_CASE(testCoreValues)
 {
-    TEST_ASSERT(sizeof(nrt_Uint8) == 1);
-    TEST_ASSERT(sizeof(nrt_Uint16) == 2);
-    TEST_ASSERT(sizeof(nrt_Uint32) == 4);
-    TEST_ASSERT(sizeof(nrt_Uint64) == 8);
+    TEST_ASSERT(sizeof(uint8_t) == 1);
+    TEST_ASSERT(sizeof(uint16_t) == 2);
+    TEST_ASSERT(sizeof(uint32_t) == 4);
+    TEST_ASSERT(sizeof(uint64_t) == 8);
 
-    TEST_ASSERT(sizeof(nrt_Int8) == 1);
-    TEST_ASSERT(sizeof(nrt_Int16) == 2);
-    TEST_ASSERT(sizeof(nrt_Int32) == 4);
-    TEST_ASSERT(sizeof(nrt_Int64) == 8);
+    TEST_ASSERT(sizeof(int8_t) == 1);
+    TEST_ASSERT(sizeof(int16_t) == 2);
+    TEST_ASSERT(sizeof(int32_t) == 4);
+    TEST_ASSERT(sizeof(int64_t) == 8);
 
     if (sizeof(long) == 4)
     {

--- a/modules/c/nrt/unittests/test_list.c
+++ b/modules/c/nrt/unittests/test_list.c
@@ -82,7 +82,7 @@ char *cloneString(char *data, nrt_Error * error)
 
 TEST_CASE(testClone)
 {
-    nrt_Uint32 i;
+    uint32_t i;
     nrt_Error e;
     nrt_List *l = nrt_List_construct(&e), *dolly = NULL;
     TEST_ASSERT(l);
@@ -114,7 +114,7 @@ TEST_CASE(testClone)
 
 TEST_CASE(testIterate)
 {
-    nrt_Uint32 i;
+    uint32_t i;
     nrt_Error e;
     nrt_List *l = nrt_List_construct(&e), *dolly = NULL;
     nrt_ListIterator it, end;

--- a/modules/c/nrt/unittests/test_nrt_byte_swap.c
+++ b/modules/c/nrt/unittests/test_nrt_byte_swap.c
@@ -26,34 +26,34 @@
 
 TEST_CASE(testFourBytes)
 {
-    nrt_Uint32 value;
-    nrt_Uint32 swappedValue;
+    uint32_t value;
+    uint32_t swappedValue;
 
     value = 0x12345678;
     swappedValue = 0x78563412;
-    nrt_Utils_byteSwap((nrt_Uint8*)&value, 4);
+    nrt_Utils_byteSwap((uint8_t*)&value, 4);
     TEST_ASSERT(value == swappedValue);
 }
 
 TEST_CASE(testTwoBytes)
 {
-    nrt_Uint16 value;
-    nrt_Uint16 swappedValue;
+    uint16_t value;
+    uint16_t swappedValue;
 
     value = 0x0304;
     swappedValue = 0x0403;
-    nrt_Utils_byteSwap((nrt_Uint8*)&value, 2);
+    nrt_Utils_byteSwap((uint8_t*)&value, 2);
     TEST_ASSERT(value == swappedValue);
 }
 
 TEST_CASE(testEightBytes)
 {
-    nrt_Uint64 value;
-    nrt_Uint64 swappedValue;
+    uint64_t value;
+    uint64_t swappedValue;
 
     value = 0x0123456789ABCDEF;
     swappedValue = 0xEFCDAB8967452301;
-    nrt_Utils_byteSwap((nrt_Uint8*)&value, 8);
+    nrt_Utils_byteSwap((uint8_t*)&value, 8);
     TEST_ASSERT(value == swappedValue);
 }
 

--- a/modules/java/nitf/src/jni/source/nitf_FileHeader.c
+++ b/modules/java/nitf/src/jni/source/nitf_FileHeader.c
@@ -403,7 +403,7 @@ JNIEXPORT jobjectArray JNICALL Java_nitf_FileHeader_getImageInfo
     jobjectArray info;
     jobject element;
     jint i;
-    nitf_Uint32 num;
+    uint32_t num;
     jmethodID methodID;
 
     NITF_TRY_GET_UINT32(header->numImages, &num, &error);

--- a/modules/java/nitf/src/jni/source/nitf_ImageReader.c
+++ b/modules/java/nitf/src/jni/source/nitf_ImageReader.c
@@ -125,8 +125,8 @@ JNIEXPORT jboolean JNICALL Java_nitf_ImageReader_read(JNIEnv *env,
         }
     }
     /* TODO: remove later */
-    assert(sizeof(nitf_Uint8) == sizeof(jbyte));
-    if (!nitf_ImageReader_read(imReader, nitfSubWindow, (nitf_Uint8 **) data,
+    assert(sizeof(uint8_t) == sizeof(jbyte));
+    if (!nitf_ImageReader_read(imReader, nitfSubWindow, (uint8_t **) data,
                                &padded, &error))
     {
         free(data);

--- a/modules/java/nitf/src/jni/source/nitf_ImageSubheader.c
+++ b/modules/java/nitf/src/jni/source/nitf_ImageSubheader.c
@@ -192,7 +192,7 @@ JNIEXPORT jobjectArray JNICALL Java_nitf_ImageSubheader_getImageComments
     (JNIEnv * env, jobject self)
 {
     nitf_ImageSubheader *header = _GetObj(env, self);
-    nitf_Uint32 numComments;
+    uint32_t numComments;
     nitf_Error error;
     jint i;
     jobjectArray array;
@@ -768,7 +768,7 @@ JNIEXPORT jboolean JNICALL Java_nitf_ImageSubheader_createBands
     nitf_Error error;
 
     if (!nitf_ImageSubheader_createBands
-        (header, (nitf_Uint32) numBands, &error))
+        (header, (uint32_t) numBands, &error))
     {
         _ThrowNITFException(env, error.message);
         return JNI_FALSE;
@@ -787,7 +787,7 @@ JNIEXPORT void JNICALL Java_nitf_ImageSubheader_removeBand
     nitf_ImageSubheader *header = _GetObj(env, self);
     nitf_Error error;
 
-    if (!nitf_ImageSubheader_removeBand(header, (nitf_Uint32) index, &error))
+    if (!nitf_ImageSubheader_removeBand(header, (uint32_t) index, &error))
     {
         _ThrowNITFException(env, error.message);
     }

--- a/modules/java/nitf/src/jni/source/nitf_LookupTable.c
+++ b/modules/java/nitf/src/jni/source/nitf_LookupTable.c
@@ -40,8 +40,8 @@ JNIEXPORT void JNICALL Java_nitf_LookupTable_construct
     char *dataBuf = NULL;
 
     /* construct the LUT */
-    lut = nitf_LookupTable_construct((nitf_Uint32) numTables,
-            (nitf_Uint32) numEntries, &error);
+    lut = nitf_LookupTable_construct((uint32_t) numTables,
+            (uint32_t) numEntries, &error);
 
     if (!lut)
     {
@@ -58,8 +58,8 @@ JNIEXPORT void JNICALL Java_nitf_LookupTable_construct
     }
 
     /* initialize the data */
-    nitf_LookupTable_init(lut, (nitf_Uint32) numTables,
-            (nitf_Uint32) numEntries, (NITF_DATA *) dataBuf,
+    nitf_LookupTable_init(lut, (uint32_t) numTables,
+            (uint32_t) numEntries, (NITF_DATA *) dataBuf,
             &error);
 
     (*env)->ReleaseByteArrayElements(env, lutData, dataBuf, 0);

--- a/modules/java/nitf/src/jni/source/nitf_Record.c
+++ b/modules/java/nitf/src/jni/source/nitf_Record.c
@@ -609,7 +609,7 @@ JNIEXPORT void JNICALL Java_nitf_Record_removeImageSegment
 	nitf_Record *record = _GetObj(env, self);
 	nitf_Error error;
 
-	if (!nitf_Record_removeImageSegment(record, (nitf_Uint32)segmentNumber, &error))
+	if (!nitf_Record_removeImageSegment(record, (uint32_t)segmentNumber, &error))
 	{
 		_ThrowNITFException(env, error.message);
 	}
@@ -627,7 +627,7 @@ JNIEXPORT void JNICALL Java_nitf_Record_removeGraphicSegment
 	nitf_Record *record = _GetObj(env, self);
 	nitf_Error error;
 
-	if (!nitf_Record_removeGraphicSegment(record, (nitf_Uint32)segmentNumber, &error))
+	if (!nitf_Record_removeGraphicSegment(record, (uint32_t)segmentNumber, &error))
 	{
 		_ThrowNITFException(env, error.message);
 	}
@@ -645,7 +645,7 @@ JNIEXPORT void JNICALL Java_nitf_Record_removeLabelSegment
 	nitf_Record *record = _GetObj(env, self);
 	nitf_Error error;
 
-	if (!nitf_Record_removeLabelSegment(record, (nitf_Uint32)segmentNumber, &error))
+	if (!nitf_Record_removeLabelSegment(record, (uint32_t)segmentNumber, &error))
 	{
 		_ThrowNITFException(env, error.message);
 	}
@@ -663,7 +663,7 @@ JNIEXPORT void JNICALL Java_nitf_Record_removeTextSegment
 	nitf_Record *record = _GetObj(env, self);
 	nitf_Error error;
 
-	if (!nitf_Record_removeTextSegment(record, (nitf_Uint32)segmentNumber, &error))
+	if (!nitf_Record_removeTextSegment(record, (uint32_t)segmentNumber, &error))
 	{
 		_ThrowNITFException(env, error.message);
 	}
@@ -681,7 +681,7 @@ JNIEXPORT void JNICALL Java_nitf_Record_removeDataExtensionSegment
 	nitf_Record *record = _GetObj(env, self);
 	nitf_Error error;
 
-	if (!nitf_Record_removeDataExtensionSegment(record, (nitf_Uint32)segmentNumber, &error))
+	if (!nitf_Record_removeDataExtensionSegment(record, (uint32_t)segmentNumber, &error))
 	{
 		_ThrowNITFException(env, error.message);
 	}
@@ -699,7 +699,7 @@ JNIEXPORT void JNICALL Java_nitf_Record_removeReservedExtensionSegment
 	nitf_Record *record = _GetObj(env, self);
 	nitf_Error error;
 
-	if (!nitf_Record_removeReservedExtensionSegment(record, (nitf_Uint32)segmentNumber, &error))
+	if (!nitf_Record_removeReservedExtensionSegment(record, (uint32_t)segmentNumber, &error))
 	{
 		_ThrowNITFException(env, error.message);
 	}
@@ -713,7 +713,7 @@ JNIEXPORT void JNICALL Java_nitf_Record_moveImageSegment
     nitf_Error error;
 
     if (!nitf_Record_moveImageSegment(record,
-            (nitf_Uint32)oldIndex, (nitf_Uint32)newIndex, &error))
+            (uint32_t)oldIndex, (uint32_t)newIndex, &error))
     {
         _ThrowNITFException(env, error.message);
     }
@@ -727,7 +727,7 @@ JNIEXPORT void JNICALL Java_nitf_Record_moveGraphicSegment
     nitf_Error error;
 
     if (!nitf_Record_moveGraphicSegment(record,
-                    (nitf_Uint32)oldIndex, (nitf_Uint32)newIndex, &error))
+                    (uint32_t)oldIndex, (uint32_t)newIndex, &error))
     {
         _ThrowNITFException(env, error.message);
     }
@@ -741,7 +741,7 @@ JNIEXPORT void JNICALL Java_nitf_Record_moveTextSegment
     nitf_Error error;
 
     if (!nitf_Record_moveTextSegment(record,
-                    (nitf_Uint32)oldIndex, (nitf_Uint32)newIndex, &error))
+                    (uint32_t)oldIndex, (uint32_t)newIndex, &error))
     {
         _ThrowNITFException(env, error.message);
     }
@@ -755,7 +755,7 @@ JNIEXPORT void JNICALL Java_nitf_Record_moveLabelSegment
     nitf_Error error;
 
     if (!nitf_Record_moveLabelSegment(record,
-                    (nitf_Uint32)oldIndex, (nitf_Uint32)newIndex, &error))
+                    (uint32_t)oldIndex, (uint32_t)newIndex, &error))
     {
         _ThrowNITFException(env, error.message);
     }
@@ -769,7 +769,7 @@ JNIEXPORT void JNICALL Java_nitf_Record_moveDataExtensionSegment
     nitf_Error error;
 
     if (!nitf_Record_moveDataExtensionSegment(record,
-                    (nitf_Uint32)oldIndex, (nitf_Uint32)newIndex, &error))
+                    (uint32_t)oldIndex, (uint32_t)newIndex, &error))
     {
         _ThrowNITFException(env, error.message);
     }
@@ -783,7 +783,7 @@ JNIEXPORT void JNICALL Java_nitf_Record_moveReservedExtensionSegment
     nitf_Error error;
 
     if (!nitf_Record_moveReservedExtensionSegment(record,
-                    (nitf_Uint32)oldIndex, (nitf_Uint32)newIndex, &error))
+                    (uint32_t)oldIndex, (uint32_t)newIndex, &error))
     {
         _ThrowNITFException(env, error.message);
     }

--- a/modules/java/nitf/src/jni/source/nitf_TRE.c
+++ b/modules/java/nitf/src/jni/source/nitf_TRE.c
@@ -187,7 +187,7 @@ JNIEXPORT jobject JNICALL Java_nitf_TRE_find
         jfieldID nameFieldID, fieldFieldID;
         jobject vector, jField, jFieldPair;
         jstring jFieldName;
-        nitf_Uint32 listSize;
+        uint32_t listSize;
         
         vectorClass = (*env)->FindClass(env, "java/util/Vector");
         fieldClass = (*env)->FindClass(env, "nitf/Field");

--- a/modules/mex/nitf/nitf_image.c
+++ b/modules/mex/nitf/nitf_image.c
@@ -104,10 +104,10 @@ nitf_SubWindow* createSubWindow(long startRow,
     nitf_SubWindow* subWindow;
 
     /* Band ordering list */
-    nitf_Uint32* bandList = NULL;
+    uint32_t* bandList = NULL;
 
     /* Starting bandID is always 1 for now */
-    nitf_Uint32 bandID = 0;
+    uint32_t bandID = 0;
 
     /* Error handler */
     nitf_Error error;
@@ -125,14 +125,14 @@ nitf_SubWindow* createSubWindow(long startRow,
      *  have a band of magnitude and a band of phase.  If you order the
      *  bandList backwards, the phase buffer comes first in the output
      */
-    bandList = (nitf_Uint32 *) malloc(sizeof(nitf_Uint32 *) * numBands);
+    bandList = (uint32_t *) malloc(sizeof(uint32_t *) * numBands);
     if(bandList == NULL)
     {
         nitf_SubWindow_destruct(&subWindow);
         return(NULL);
     }
 
-    for (bandID = 0; bandID < (nitf_Uint32)numBands; ++bandID)
+    for (bandID = 0; bandID < (uint32_t)numBands; ++bandID)
         bandList[bandID] = bandID;
 
     subWindow->numBands = numBands;
@@ -164,9 +164,9 @@ mxArray* read32BitFloatPixelArray(nitf_Reader* reader,
     nitf_ImageReader* imageReader = NULL;
 
     /* Buffer array ptr */
-    nitf_Uint8* buffers[1];
+    uint8_t* buffers[1];
 
-    nitf_Uint8* buffer = NULL;
+    uint8_t* buffer = NULL;
 
     int numBands = 1;
 
@@ -180,7 +180,7 @@ mxArray* read32BitFloatPixelArray(nitf_Reader* reader,
                                 numRows, numCols, numBands);
 
     /* Now attach the buffer up to the mxImageArray */
-    buffer = (nitf_Uint8*)mxGetData(mxImageArray);
+    buffer = (uint8_t*)mxGetData(mxImageArray);
 
     /* Only works with one band */
     buffers[0] = buffer;
@@ -240,9 +240,9 @@ mxArray* readSingleBandPixelArray(nitf_Reader* reader,
     nitf_ImageReader* imageReader = NULL;
 
     /* Buffer array ptr */
-    nitf_Uint8** buffers = NULL;
+    uint8_t** buffers = NULL;
 
-    nitf_Uint8* buffer = NULL;
+    uint8_t* buffer = NULL;
 
     int numBands = 1;
 
@@ -251,13 +251,13 @@ mxArray* readSingleBandPixelArray(nitf_Reader* reader,
                                 numRows, numCols, numBands);
 
     /* Create the image buffer - will fail internally if error */
-    buffers = (nitf_Uint8**)malloc( sizeof(nitf_Uint8*) * numBands);
+    buffers = (uint8_t**)malloc( sizeof(uint8_t*) * numBands);
 
     mxImageArray = 
         mxCreateNumericMatrix(numCols, numRows, matlabClassType, mxREAL);
 
     /* Now attach the buffer up to the mxImageArray */
-    buffer = (nitf_Uint8*)mxGetData(mxImageArray);
+    buffer = (uint8_t*)mxGetData(mxImageArray);
 
     /* Only works with one band */
     buffers[0] = buffer;
@@ -361,7 +361,7 @@ mxArray* read2BandComplexPixelArray(nitf_Reader* reader,
     nitf_ImageReader* imageReader = NULL;
 
     /* Buffer array ptr */
-    nitf_Uint8* buffers[2];
+    uint8_t* buffers[2];
 
     int numBands = 2;
 
@@ -378,8 +378,8 @@ mxArray* read2BandComplexPixelArray(nitf_Reader* reader,
 
 
     /* Now attach the buffer up to the mxImageArray */
-    buffers[0] = (nitf_Uint8*)mxGetData(mxImageArray);
-    buffers[1] = (nitf_Uint8*)mxGetImagData(mxImageArray);
+    buffers[0] = (uint8_t*)mxGetData(mxImageArray);
+    buffers[1] = (uint8_t*)mxGetImagData(mxImageArray);
 
     /* Image reader (could fail) */
     imageReader = nitf_Reader_newImageReader(reader, idx, NULL, error);
@@ -466,7 +466,7 @@ mxArray* read24BitPixelArray(nitf_Reader* reader,
     nitf_ImageReader* imageReader = NULL;
 
     /* Buffer array ptr */
-    nitf_Uint8* buffers[3];
+    uint8_t* buffers[3];
 
     const mwSize dims[] = { numCols, numRows, 3 };
     const int numBands = 3;
@@ -482,9 +482,9 @@ mxArray* read24BitPixelArray(nitf_Reader* reader,
     subWindow = createSubWindow(startRow, startCol,
                                 numRows, numCols, numBands);
 
-    buffers[0] = ((nitf_Uint8*)mxGetData(mxImageArray));
-    buffers[1] = ((nitf_Uint8*)mxGetData(mxImageArray)) + frame;
-    buffers[2] = ((nitf_Uint8*)mxGetData(mxImageArray)) + 2 * frame;
+    buffers[0] = ((uint8_t*)mxGetData(mxImageArray));
+    buffers[1] = ((uint8_t*)mxGetData(mxImageArray)) + frame;
+    buffers[2] = ((uint8_t*)mxGetData(mxImageArray)) + 2 * frame;
     /* Image reader (could fail) */
     imageReader = nitf_Reader_newImageReader(reader, idx, NULL, error);
     if (!imageReader)

--- a/modules/mex/nitf/xml_metadata.cpp
+++ b/modules/mex/nitf/xml_metadata.cpp
@@ -297,10 +297,10 @@ void mexFunction(int nlhs, mxArray *plhs[],
 	    nitf::IOHandle io(inputFile);
 	    nitf::Record record = reader.read(io);
             nitf::List des = record.getDataExtensions();
-	    nitf::Uint32 numDES = des.getSize();
+	    uint32_t numDES = des.getSize();
             std::vector<mxArray*> structs;
 
-            for (nitf::Uint32 i = 0; i < numDES; i++)
+            for (uint32_t i = 0; i < numDES; i++)
             {
                 nitf::DESegment seg = des[i];
                 nitf::DESubheader subheader = seg.getSubheader();

--- a/modules/python/nitf/source/generated/nitropy.py
+++ b/modules/python/nitf/source/generated/nitropy.py
@@ -110,19 +110,19 @@ NRT_CORNERS_UTM_UPS_N = _nitropy.NRT_CORNERS_UTM_UPS_N
 NRT_CORNERS_GEO = _nitropy.NRT_CORNERS_GEO
 NRT_CORNERS_DECIMAL = _nitropy.NRT_CORNERS_DECIMAL
 
-def nrt_System_swap16(ins: 'nrt_Uint16') -> "nrt_Uint16":
+def nrt_System_swap16(ins: 'uint16_t') -> "uint16_t":
     return _nitropy.nrt_System_swap16(ins)
 nrt_System_swap16 = _nitropy.nrt_System_swap16
 
-def nrt_System_swap32(inl: 'nrt_Uint32') -> "nrt_Uint32":
+def nrt_System_swap32(inl: 'uint32_t') -> "uint32_t":
     return _nitropy.nrt_System_swap32(inl)
 nrt_System_swap32 = _nitropy.nrt_System_swap32
 
-def nrt_System_swap64(inl: 'nrt_Uint64') -> "nrt_Uint64":
+def nrt_System_swap64(inl: 'uint64_t') -> "uint64_t":
     return _nitropy.nrt_System_swap64(inl)
 nrt_System_swap64 = _nitropy.nrt_System_swap64
 
-def nrt_System_swap64c(inl: 'nrt_Uint64') -> "nrt_Uint64":
+def nrt_System_swap64c(inl: 'uint64_t') -> "uint64_t":
     return _nitropy.nrt_System_swap64c(inl)
 nrt_System_swap64c = _nitropy.nrt_System_swap64c
 NITF_VER_20 = _nitropy.NITF_VER_20

--- a/modules/python/nitf/source/generated/nitropy.py
+++ b/modules/python/nitf/source/generated/nitropy.py
@@ -660,7 +660,7 @@ def nitf_Writer_write(writer: 'nitf_Writer', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Writer_write(writer, error)
 nitf_Writer_write = _nitropy.nitf_Writer_write
 
-def nitf_Writer_writeHeader(writer: 'nitf_Writer', fileLenOff: 'nitf_Off *', hdrLen: 'nitf_Uint32 *', error: 'nrt_Error') -> "bool":
+def nitf_Writer_writeHeader(writer: 'nitf_Writer', fileLenOff: 'nitf_Off *', hdrLen: 'uint32_t *', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Writer_writeHeader(writer, fileLenOff, hdrLen, error)
 nitf_Writer_writeHeader = _nitropy.nitf_Writer_writeHeader
 
@@ -668,11 +668,11 @@ def nitf_Writer_writeImageSubheader(writer: 'nitf_Writer', subhdr: 'nitf_ImageSu
     return _nitropy.nitf_Writer_writeImageSubheader(writer, subhdr, fver, comratOff, error)
 nitf_Writer_writeImageSubheader = _nitropy.nitf_Writer_writeImageSubheader
 
-def nitf_Writer_writeDESubheader(writer: 'nitf_Writer', subhdr: 'nitf_DESubheader', userSublen: 'nitf_Uint32 *', fver: 'nitf_Version', error: 'nrt_Error') -> "bool":
+def nitf_Writer_writeDESubheader(writer: 'nitf_Writer', subhdr: 'nitf_DESubheader', userSublen: 'uint32_t *', fver: 'nitf_Version', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Writer_writeDESubheader(writer, subhdr, userSublen, fver, error)
 nitf_Writer_writeDESubheader = _nitropy.nitf_Writer_writeDESubheader
 
-def nitf_Writer_writeInt64Field(writer: 'nitf_Writer', field: 'nitf_Uint64', length: 'nitf_Uint32', fill: 'char', fillDir: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Writer_writeInt64Field(writer: 'nitf_Writer', field: 'uint64_t', length: 'uint32_t', fill: 'char', fillDir: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Writer_writeInt64Field(writer, field, length, fill, fillDir, error)
 nitf_Writer_writeInt64Field = _nitropy.nitf_Writer_writeInt64Field
 class nitf_Record(_object):
@@ -734,7 +734,7 @@ def nitf_Record_getVersion(record: 'nitf_Record') -> "nitf_Version":
     return _nitropy.nitf_Record_getVersion(record)
 nitf_Record_getVersion = _nitropy.nitf_Record_getVersion
 
-def nitf_Record_getNumImages(record: 'nitf_Record', error: 'nrt_Error') -> "nitf_Uint32":
+def nitf_Record_getNumImages(record: 'nitf_Record', error: 'nrt_Error') -> "uint32_t":
     return _nitropy.nitf_Record_getNumImages(record, error)
 nitf_Record_getNumImages = _nitropy.nitf_Record_getNumImages
 
@@ -742,7 +742,7 @@ def nitf_Record_newImageSegment(record: 'nitf_Record', error: 'nrt_Error') -> "n
     return _nitropy.nitf_Record_newImageSegment(record, error)
 nitf_Record_newImageSegment = _nitropy.nitf_Record_newImageSegment
 
-def nitf_Record_getNumGraphics(record: 'nitf_Record', error: 'nrt_Error') -> "nitf_Uint32":
+def nitf_Record_getNumGraphics(record: 'nitf_Record', error: 'nrt_Error') -> "uint32_t":
     return _nitropy.nitf_Record_getNumGraphics(record, error)
 nitf_Record_getNumGraphics = _nitropy.nitf_Record_getNumGraphics
 
@@ -750,7 +750,7 @@ def nitf_Record_newGraphicSegment(record: 'nitf_Record', error: 'nrt_Error') -> 
     return _nitropy.nitf_Record_newGraphicSegment(record, error)
 nitf_Record_newGraphicSegment = _nitropy.nitf_Record_newGraphicSegment
 
-def nitf_Record_getNumTexts(record: 'nitf_Record', error: 'nrt_Error') -> "nitf_Uint32":
+def nitf_Record_getNumTexts(record: 'nitf_Record', error: 'nrt_Error') -> "uint32_t":
     return _nitropy.nitf_Record_getNumTexts(record, error)
 nitf_Record_getNumTexts = _nitropy.nitf_Record_getNumTexts
 
@@ -758,7 +758,7 @@ def nitf_Record_newTextSegment(record: 'nitf_Record', error: 'nrt_Error') -> "ni
     return _nitropy.nitf_Record_newTextSegment(record, error)
 nitf_Record_newTextSegment = _nitropy.nitf_Record_newTextSegment
 
-def nitf_Record_getNumDataExtensions(record: 'nitf_Record', error: 'nrt_Error') -> "nitf_Uint32":
+def nitf_Record_getNumDataExtensions(record: 'nitf_Record', error: 'nrt_Error') -> "uint32_t":
     return _nitropy.nitf_Record_getNumDataExtensions(record, error)
 nitf_Record_getNumDataExtensions = _nitropy.nitf_Record_getNumDataExtensions
 
@@ -766,59 +766,59 @@ def nitf_Record_newDataExtensionSegment(record: 'nitf_Record', error: 'nrt_Error
     return _nitropy.nitf_Record_newDataExtensionSegment(record, error)
 nitf_Record_newDataExtensionSegment = _nitropy.nitf_Record_newDataExtensionSegment
 
-def nitf_Record_removeImageSegment(record: 'nitf_Record', segmentNumber: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Record_removeImageSegment(record: 'nitf_Record', segmentNumber: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Record_removeImageSegment(record, segmentNumber, error)
 nitf_Record_removeImageSegment = _nitropy.nitf_Record_removeImageSegment
 
-def nitf_Record_removeGraphicSegment(record: 'nitf_Record', segmentNumber: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Record_removeGraphicSegment(record: 'nitf_Record', segmentNumber: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Record_removeGraphicSegment(record, segmentNumber, error)
 nitf_Record_removeGraphicSegment = _nitropy.nitf_Record_removeGraphicSegment
 
-def nitf_Record_getNumLabels(record: 'nitf_Record', error: 'nrt_Error') -> "nitf_Uint32":
+def nitf_Record_getNumLabels(record: 'nitf_Record', error: 'nrt_Error') -> "uint32_t":
     return _nitropy.nitf_Record_getNumLabels(record, error)
 nitf_Record_getNumLabels = _nitropy.nitf_Record_getNumLabels
 
-def nitf_Record_removeLabelSegment(record: 'nitf_Record', segmentNumber: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Record_removeLabelSegment(record: 'nitf_Record', segmentNumber: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Record_removeLabelSegment(record, segmentNumber, error)
 nitf_Record_removeLabelSegment = _nitropy.nitf_Record_removeLabelSegment
 
-def nitf_Record_removeTextSegment(record: 'nitf_Record', segmentNumber: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Record_removeTextSegment(record: 'nitf_Record', segmentNumber: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Record_removeTextSegment(record, segmentNumber, error)
 nitf_Record_removeTextSegment = _nitropy.nitf_Record_removeTextSegment
 
-def nitf_Record_removeDataExtensionSegment(record: 'nitf_Record', segmentNumber: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Record_removeDataExtensionSegment(record: 'nitf_Record', segmentNumber: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Record_removeDataExtensionSegment(record, segmentNumber, error)
 nitf_Record_removeDataExtensionSegment = _nitropy.nitf_Record_removeDataExtensionSegment
 
-def nitf_Record_getNumReservedExtensions(record: 'nitf_Record', error: 'nrt_Error') -> "nitf_Uint32":
+def nitf_Record_getNumReservedExtensions(record: 'nitf_Record', error: 'nrt_Error') -> "uint32_t":
     return _nitropy.nitf_Record_getNumReservedExtensions(record, error)
 nitf_Record_getNumReservedExtensions = _nitropy.nitf_Record_getNumReservedExtensions
 
-def nitf_Record_removeReservedExtensionSegment(record: 'nitf_Record', segmentNumber: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Record_removeReservedExtensionSegment(record: 'nitf_Record', segmentNumber: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Record_removeReservedExtensionSegment(record, segmentNumber, error)
 nitf_Record_removeReservedExtensionSegment = _nitropy.nitf_Record_removeReservedExtensionSegment
 
-def nitf_Record_moveImageSegment(record: 'nitf_Record', oldIndex: 'nitf_Uint32', newIndex: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Record_moveImageSegment(record: 'nitf_Record', oldIndex: 'uint32_t', newIndex: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Record_moveImageSegment(record, oldIndex, newIndex, error)
 nitf_Record_moveImageSegment = _nitropy.nitf_Record_moveImageSegment
 
-def nitf_Record_moveGraphicSegment(record: 'nitf_Record', oldIndex: 'nitf_Uint32', newIndex: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Record_moveGraphicSegment(record: 'nitf_Record', oldIndex: 'uint32_t', newIndex: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Record_moveGraphicSegment(record, oldIndex, newIndex, error)
 nitf_Record_moveGraphicSegment = _nitropy.nitf_Record_moveGraphicSegment
 
-def nitf_Record_moveLabelSegment(record: 'nitf_Record', oldIndex: 'nitf_Uint32', newIndex: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Record_moveLabelSegment(record: 'nitf_Record', oldIndex: 'uint32_t', newIndex: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Record_moveLabelSegment(record, oldIndex, newIndex, error)
 nitf_Record_moveLabelSegment = _nitropy.nitf_Record_moveLabelSegment
 
-def nitf_Record_moveTextSegment(record: 'nitf_Record', oldIndex: 'nitf_Uint32', newIndex: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Record_moveTextSegment(record: 'nitf_Record', oldIndex: 'uint32_t', newIndex: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Record_moveTextSegment(record, oldIndex, newIndex, error)
 nitf_Record_moveTextSegment = _nitropy.nitf_Record_moveTextSegment
 
-def nitf_Record_moveDataExtensionSegment(record: 'nitf_Record', oldIndex: 'nitf_Uint32', newIndex: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Record_moveDataExtensionSegment(record: 'nitf_Record', oldIndex: 'uint32_t', newIndex: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Record_moveDataExtensionSegment(record, oldIndex, newIndex, error)
 nitf_Record_moveDataExtensionSegment = _nitropy.nitf_Record_moveDataExtensionSegment
 
-def nitf_Record_moveReservedExtensionSegment(record: 'nitf_Record', oldIndex: 'nitf_Uint32', newIndex: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Record_moveReservedExtensionSegment(record: 'nitf_Record', oldIndex: 'uint32_t', newIndex: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Record_moveReservedExtensionSegment(record, oldIndex, newIndex, error)
 nitf_Record_moveReservedExtensionSegment = _nitropy.nitf_Record_moveReservedExtensionSegment
 
@@ -880,19 +880,19 @@ def nitf_Field_setRawData(field: 'nitf_Field', data: 'NITF_DATA *', dataLength: 
     return _nitropy.nitf_Field_setRawData(field, data, dataLength, error)
 nitf_Field_setRawData = _nitropy.nitf_Field_setRawData
 
-def nitf_Field_setUint32(field: 'nitf_Field', number: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_Field_setUint32(field: 'nitf_Field', number: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Field_setUint32(field, number, error)
 nitf_Field_setUint32 = _nitropy.nitf_Field_setUint32
 
-def nitf_Field_setUint64(field: 'nitf_Field', number: 'nitf_Uint64', error: 'nrt_Error') -> "bool":
+def nitf_Field_setUint64(field: 'nitf_Field', number: 'uint64_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Field_setUint64(field, number, error)
 nitf_Field_setUint64 = _nitropy.nitf_Field_setUint64
 
-def nitf_Field_setInt32(field: 'nitf_Field', number: 'nitf_Int32', error: 'nrt_Error') -> "bool":
+def nitf_Field_setInt32(field: 'nitf_Field', number: 'int32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Field_setInt32(field, number, error)
 nitf_Field_setInt32 = _nitropy.nitf_Field_setInt32
 
-def nitf_Field_setInt64(field: 'nitf_Field', number: 'nitf_Int64', error: 'nrt_Error') -> "bool":
+def nitf_Field_setInt64(field: 'nitf_Field', number: 'int64_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_Field_setInt64(field, number, error)
 nitf_Field_setInt64 = _nitropy.nitf_Field_setInt64
 
@@ -1330,7 +1330,7 @@ def nitf_ExtensionsIterator_notEqualTo(it1: 'nitf_ExtensionsIterator', it2: 'nit
     return _nitropy.nitf_ExtensionsIterator_notEqualTo(it1, it2)
 nitf_ExtensionsIterator_notEqualTo = _nitropy.nitf_ExtensionsIterator_notEqualTo
 
-def nitf_Extensions_computeLength(ext: 'nitf_Extensions', fver: 'nitf_Version', error: 'nrt_Error') -> "nitf_Uint32":
+def nitf_Extensions_computeLength(ext: 'nitf_Extensions', fver: 'nitf_Version', error: 'nrt_Error') -> "uint32_t":
     return _nitropy.nitf_Extensions_computeLength(ext, fver, error)
 nitf_Extensions_computeLength = _nitropy.nitf_Extensions_computeLength
 NRT_DATA_RETAIN_OWNER = _nitropy.NRT_DATA_RETAIN_OWNER
@@ -1620,7 +1620,7 @@ def nitf_ImageWriter_setDirectBlockWrite(iWriter: 'nitf_ImageWriter *', enable: 
     return _nitropy.nitf_ImageWriter_setDirectBlockWrite(iWriter, enable, error)
 nitf_ImageWriter_setDirectBlockWrite = _nitropy.nitf_ImageWriter_setDirectBlockWrite
 
-def nitf_ImageWriter_setPadPixel(imageWriter: 'nitf_ImageWriter *', value: 'nitf_Uint8 *', length: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_ImageWriter_setPadPixel(imageWriter: 'nitf_ImageWriter *', value: 'uint8_t *', length: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_ImageWriter_setPadPixel(imageWriter, value, length, error)
 nitf_ImageWriter_setPadPixel = _nitropy.nitf_ImageWriter_setPadPixel
 NITF_FHDR_SZ = _nitropy.NITF_FHDR_SZ
@@ -2098,31 +2098,31 @@ def nitf_ImageSubheader_destruct(subhdr: 'nitf_ImageSubheader **') -> "void":
     return _nitropy.nitf_ImageSubheader_destruct(subhdr)
 nitf_ImageSubheader_destruct = _nitropy.nitf_ImageSubheader_destruct
 
-def nitf_ImageSubheader_setPixelInformation(subhdr: 'nitf_ImageSubheader', pvtype: 'char const *', nbpp: 'nitf_Uint32', abpp: 'nitf_Uint32', justification: 'char const *', irep: 'char const *', icat: 'char const *', bandCount: 'nitf_Uint32', bands: 'nitf_BandInfo **', error: 'nrt_Error') -> "bool":
+def nitf_ImageSubheader_setPixelInformation(subhdr: 'nitf_ImageSubheader', pvtype: 'char const *', nbpp: 'uint32_t', abpp: 'uint32_t', justification: 'char const *', irep: 'char const *', icat: 'char const *', bandCount: 'uint32_t', bands: 'nitf_BandInfo **', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_ImageSubheader_setPixelInformation(subhdr, pvtype, nbpp, abpp, justification, irep, icat, bandCount, bands, error)
 nitf_ImageSubheader_setPixelInformation = _nitropy.nitf_ImageSubheader_setPixelInformation
 
-def nitf_ImageSubheader_getBandCount(subhdr: 'nitf_ImageSubheader', error: 'nrt_Error') -> "nitf_Uint32":
+def nitf_ImageSubheader_getBandCount(subhdr: 'nitf_ImageSubheader', error: 'nrt_Error') -> "uint32_t":
     return _nitropy.nitf_ImageSubheader_getBandCount(subhdr, error)
 nitf_ImageSubheader_getBandCount = _nitropy.nitf_ImageSubheader_getBandCount
 
-def nitf_ImageSubheader_getBandInfo(subhdr: 'nitf_ImageSubheader', band: 'nitf_Uint32', error: 'nrt_Error') -> "nitf_BandInfo *":
+def nitf_ImageSubheader_getBandInfo(subhdr: 'nitf_ImageSubheader', band: 'uint32_t', error: 'nrt_Error') -> "nitf_BandInfo *":
     return _nitropy.nitf_ImageSubheader_getBandInfo(subhdr, band, error)
 nitf_ImageSubheader_getBandInfo = _nitropy.nitf_ImageSubheader_getBandInfo
 
-def nitf_ImageSubheader_createBands(subhdr: 'nitf_ImageSubheader', numBands: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_ImageSubheader_createBands(subhdr: 'nitf_ImageSubheader', numBands: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_ImageSubheader_createBands(subhdr, numBands, error)
 nitf_ImageSubheader_createBands = _nitropy.nitf_ImageSubheader_createBands
 
-def nitf_ImageSubheader_removeBand(subhdr: 'nitf_ImageSubheader', index: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_ImageSubheader_removeBand(subhdr: 'nitf_ImageSubheader', index: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_ImageSubheader_removeBand(subhdr, index, error)
 nitf_ImageSubheader_removeBand = _nitropy.nitf_ImageSubheader_removeBand
 
-def nitf_ImageSubheader_getDimensions(subhdr: 'nitf_ImageSubheader', numRows: 'nitf_Uint32 *', numCols: 'nitf_Uint32 *', error: 'nrt_Error') -> "bool":
+def nitf_ImageSubheader_getDimensions(subhdr: 'nitf_ImageSubheader', numRows: 'uint32_t *', numCols: 'uint32_t *', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_ImageSubheader_getDimensions(subhdr, numRows, numCols, error)
 nitf_ImageSubheader_getDimensions = _nitropy.nitf_ImageSubheader_getDimensions
 
-def nitf_ImageSubheader_getBlocking(subhdr: 'nitf_ImageSubheader', numRows: 'nitf_Uint32 *', numCols: 'nitf_Uint32 *', numRowsPerBlock: 'nitf_Uint32 *', numColsPerBlock: 'nitf_Uint32 *', numBlocksPerRow: 'nitf_Uint32 *', numBlocksPerCol: 'nitf_Uint32 *', imode: 'char *', error: 'nrt_Error') -> "bool":
+def nitf_ImageSubheader_getBlocking(subhdr: 'nitf_ImageSubheader', numRows: 'uint32_t *', numCols: 'uint32_t *', numRowsPerBlock: 'uint32_t *', numColsPerBlock: 'uint32_t *', numBlocksPerRow: 'uint32_t *', numBlocksPerCol: 'uint32_t *', imode: 'char *', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_ImageSubheader_getBlocking(subhdr, numRows, numCols, numRowsPerBlock, numColsPerBlock, numBlocksPerRow, numBlocksPerCol, imode, error)
 nitf_ImageSubheader_getBlocking = _nitropy.nitf_ImageSubheader_getBlocking
 
@@ -2130,7 +2130,7 @@ def nitf_ImageSubheader_getCompression(subhdr: 'nitf_ImageSubheader', imageCompr
     return _nitropy.nitf_ImageSubheader_getCompression(subhdr, imageCompression, compressionRate, error)
 nitf_ImageSubheader_getCompression = _nitropy.nitf_ImageSubheader_getCompression
 
-def nitf_ImageSubheader_setDimensions(subhdr: 'nitf_ImageSubheader', numRows: 'nitf_Uint32', numCols: 'nitf_Uint32', error: 'nrt_Error') -> "bool":
+def nitf_ImageSubheader_setDimensions(subhdr: 'nitf_ImageSubheader', numRows: 'uint32_t', numCols: 'uint32_t', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_ImageSubheader_setDimensions(subhdr, numRows, numCols, error)
 nitf_ImageSubheader_setDimensions = _nitropy.nitf_ImageSubheader_setDimensions
 
@@ -2146,11 +2146,11 @@ def nitf_ImageSubheader_getCornersAsLatLons(subheader: 'nitf_ImageSubheader', co
     return _nitropy.nitf_ImageSubheader_getCornersAsLatLons(subheader, corners, error)
 nitf_ImageSubheader_getCornersAsLatLons = _nitropy.nitf_ImageSubheader_getCornersAsLatLons
 
-def nitf_ImageSubheader_computeBlocking(numRows: 'nitf_Uint32', numCols: 'nitf_Uint32', numRowsPerBlock: 'nitf_Uint32 *', numColsPerBlock: 'nitf_Uint32 *', numBlocksPerCol: 'nitf_Uint32 *', numBlocksPerRow: 'nitf_Uint32 *') -> "void":
+def nitf_ImageSubheader_computeBlocking(numRows: 'uint32_t', numCols: 'uint32_t', numRowsPerBlock: 'uint32_t *', numColsPerBlock: 'uint32_t *', numBlocksPerCol: 'uint32_t *', numBlocksPerRow: 'uint32_t *') -> "void":
     return _nitropy.nitf_ImageSubheader_computeBlocking(numRows, numCols, numRowsPerBlock, numColsPerBlock, numBlocksPerCol, numBlocksPerRow)
 nitf_ImageSubheader_computeBlocking = _nitropy.nitf_ImageSubheader_computeBlocking
 
-def nitf_ImageSubheader_setBlocking(subhdr: 'nitf_ImageSubheader', numRows: 'nitf_Uint32', numCols: 'nitf_Uint32', numRowsPerBlock: 'nitf_Uint32', numColsPerBlock: 'nitf_Uint32', imode: 'char const *', error: 'nrt_Error') -> "bool":
+def nitf_ImageSubheader_setBlocking(subhdr: 'nitf_ImageSubheader', numRows: 'uint32_t', numCols: 'uint32_t', numRowsPerBlock: 'uint32_t', numColsPerBlock: 'uint32_t', imode: 'char const *', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_ImageSubheader_setBlocking(subhdr, numRows, numCols, numRowsPerBlock, numColsPerBlock, imode, error)
 nitf_ImageSubheader_setBlocking = _nitropy.nitf_ImageSubheader_setBlocking
 
@@ -2834,7 +2834,7 @@ nitf_ComponentInfo_swigregister = _nitropy.nitf_ComponentInfo_swigregister
 nitf_ComponentInfo_swigregister(nitf_ComponentInfo)
 
 
-def nitf_ComponentInfo_construct(subheaderFieldWidth: 'nitf_Uint32', dataFieldWidth: 'nitf_Uint32', error: 'nrt_Error') -> "nitf_ComponentInfo *":
+def nitf_ComponentInfo_construct(subheaderFieldWidth: 'uint32_t', dataFieldWidth: 'uint32_t', error: 'nrt_Error') -> "nitf_ComponentInfo *":
     return _nitropy.nitf_ComponentInfo_construct(subheaderFieldWidth, dataFieldWidth, error)
 nitf_ComponentInfo_construct = _nitropy.nitf_ComponentInfo_construct
 
@@ -2876,11 +2876,11 @@ def nitf_ImageReader_getBlockingInfo(imageReader: 'nitf_ImageReader', error: 'nr
     return _nitropy.nitf_ImageReader_getBlockingInfo(imageReader, error)
 nitf_ImageReader_getBlockingInfo = _nitropy.nitf_ImageReader_getBlockingInfo
 
-def nitf_ImageReader_read(imageReader: 'nitf_ImageReader', subWindow: 'nitf_SubWindow', user: 'nitf_Uint8 **', padded: 'int *', error: 'nrt_Error') -> "bool":
+def nitf_ImageReader_read(imageReader: 'nitf_ImageReader', subWindow: 'nitf_SubWindow', user: 'uint8_t **', padded: 'int *', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_ImageReader_read(imageReader, subWindow, user, padded, error)
 nitf_ImageReader_read = _nitropy.nitf_ImageReader_read
 
-def nitf_ImageReader_readBlock(imageReader: 'nitf_ImageReader', blockNumber: 'nitf_Uint32', blockSize: 'nitf_Uint64 *', error: 'nrt_Error') -> "nitf_Uint8 *":
+def nitf_ImageReader_readBlock(imageReader: 'nitf_ImageReader', blockNumber: 'uint32_t', blockSize: 'uint64_t *', error: 'nrt_Error') -> "uint8_t *":
     return _nitropy.nitf_ImageReader_readBlock(imageReader, blockNumber, blockSize, error)
 nitf_ImageReader_readBlock = _nitropy.nitf_ImageReader_readBlock
 
@@ -3072,19 +3072,19 @@ nitf_DownSampler_swigregister = _nitropy.nitf_DownSampler_swigregister
 nitf_DownSampler_swigregister(nitf_DownSampler)
 
 
-def nitf_PixelSkip_construct(rowSkip: 'nitf_Uint32', colSkip: 'nitf_Uint32', error: 'nrt_Error') -> "nitf_DownSampler *":
+def nitf_PixelSkip_construct(rowSkip: 'uint32_t', colSkip: 'uint32_t', error: 'nrt_Error') -> "nitf_DownSampler *":
     return _nitropy.nitf_PixelSkip_construct(rowSkip, colSkip, error)
 nitf_PixelSkip_construct = _nitropy.nitf_PixelSkip_construct
 
-def nitf_MaxDownSample_construct(rowSkip: 'nitf_Uint32', colSkip: 'nitf_Uint32', error: 'nrt_Error') -> "nitf_DownSampler *":
+def nitf_MaxDownSample_construct(rowSkip: 'uint32_t', colSkip: 'uint32_t', error: 'nrt_Error') -> "nitf_DownSampler *":
     return _nitropy.nitf_MaxDownSample_construct(rowSkip, colSkip, error)
 nitf_MaxDownSample_construct = _nitropy.nitf_MaxDownSample_construct
 
-def nitf_SumSq2DownSample_construct(rowSkip: 'nitf_Uint32', colSkip: 'nitf_Uint32', error: 'nrt_Error') -> "nitf_DownSampler *":
+def nitf_SumSq2DownSample_construct(rowSkip: 'uint32_t', colSkip: 'uint32_t', error: 'nrt_Error') -> "nitf_DownSampler *":
     return _nitropy.nitf_SumSq2DownSample_construct(rowSkip, colSkip, error)
 nitf_SumSq2DownSample_construct = _nitropy.nitf_SumSq2DownSample_construct
 
-def nitf_Select2DownSample_construct(rowSkip: 'nitf_Uint32', colSkip: 'nitf_Uint32', error: 'nrt_Error') -> "nitf_DownSampler *":
+def nitf_Select2DownSample_construct(rowSkip: 'uint32_t', colSkip: 'uint32_t', error: 'nrt_Error') -> "nitf_DownSampler *":
     return _nitropy.nitf_Select2DownSample_construct(rowSkip, colSkip, error)
 nitf_Select2DownSample_construct = _nitropy.nitf_Select2DownSample_construct
 
@@ -3168,7 +3168,7 @@ def nitf_BandInfo_clone(source: 'nitf_BandInfo', error: 'nrt_Error') -> "nitf_Ba
     return _nitropy.nitf_BandInfo_clone(source, error)
 nitf_BandInfo_clone = _nitropy.nitf_BandInfo_clone
 
-def nitf_BandInfo_init(bandInfo: 'nitf_BandInfo', representation: 'char const *', subcategory: 'char const *', imageFilterCondition: 'char const *', imageFilterCode: 'char const *', numLUTs: 'nitf_Uint32', bandEntriesPerLUT: 'nitf_Uint32', lut: 'nitf_LookupTable *', error: 'nrt_Error') -> "bool":
+def nitf_BandInfo_init(bandInfo: 'nitf_BandInfo', representation: 'char const *', subcategory: 'char const *', imageFilterCondition: 'char const *', imageFilterCode: 'char const *', numLUTs: 'uint32_t', bandEntriesPerLUT: 'uint32_t', lut: 'nitf_LookupTable *', error: 'nrt_Error') -> "bool":
     return _nitropy.nitf_BandInfo_init(bandInfo, representation, subcategory, imageFilterCondition, imageFilterCode, numLUTs, bandEntriesPerLUT, lut, error)
 nitf_BandInfo_init = _nitropy.nitf_BandInfo_init
 PY_NITF_CREATE = _nitropy.PY_NITF_CREATE
@@ -3197,7 +3197,7 @@ def py_Field_getString(field: 'nitf_Field', error: 'nrt_Error') -> "char *":
     return _nitropy.py_Field_getString(field, error)
 py_Field_getString = _nitropy.py_Field_getString
 
-def py_Field_getInt(field: 'nitf_Field', error: 'nrt_Error') -> "nitf_Uint32":
+def py_Field_getInt(field: 'nitf_Field', error: 'nrt_Error') -> "uint32_t":
     return _nitropy.py_Field_getInt(field, error)
 py_Field_getInt = _nitropy.py_Field_getInt
 

--- a/modules/python/nitf/source/generated/nitropy_wrap.cxx
+++ b/modules/python/nitf/source/generated/nitropy_wrap.cxx
@@ -4356,28 +4356,28 @@ extern "C" {
 #endif
 SWIGINTERN PyObject *_wrap_nrt_System_swap16(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  nrt_Uint16 arg1 ;
+  uint16_t arg1 ;
   void *argp1 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nrt_Uint16 result;
+  uint16_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nrt_System_swap16",&obj0)) SWIG_fail;
   {
     res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_uint16_t,  0  | 0);
     if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "nrt_System_swap16" "', argument " "1"" of type '" "nrt_Uint16""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "nrt_System_swap16" "', argument " "1"" of type '" "uint16_t""'"); 
     }  
     if (!argp1) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nrt_System_swap16" "', argument " "1"" of type '" "nrt_Uint16""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nrt_System_swap16" "', argument " "1"" of type '" "uint16_t""'");
     } else {
-      nrt_Uint16 * temp = reinterpret_cast< nrt_Uint16 * >(argp1);
+      uint16_t * temp = reinterpret_cast< uint16_t * >(argp1);
       arg1 = *temp;
       if (SWIG_IsNewObj(res1)) delete temp;
     }
   }
   result = nrt_System_swap16(arg1);
-  resultobj = SWIG_NewPointerObj((new nrt_Uint16(static_cast< const nrt_Uint16& >(result))), SWIGTYPE_p_uint16_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint16_t(static_cast< const uint16_t& >(result))), SWIGTYPE_p_uint16_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -4386,28 +4386,28 @@ fail:
 
 SWIGINTERN PyObject *_wrap_nrt_System_swap32(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  nrt_Uint32 arg1 ;
+  uint32_t arg1 ;
   void *argp1 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nrt_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nrt_System_swap32",&obj0)) SWIG_fail;
   {
     res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_uint32_t,  0  | 0);
     if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "nrt_System_swap32" "', argument " "1"" of type '" "nrt_Uint32""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "nrt_System_swap32" "', argument " "1"" of type '" "uint32_t""'"); 
     }  
     if (!argp1) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nrt_System_swap32" "', argument " "1"" of type '" "nrt_Uint32""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nrt_System_swap32" "', argument " "1"" of type '" "uint32_t""'");
     } else {
-      nrt_Uint32 * temp = reinterpret_cast< nrt_Uint32 * >(argp1);
+      uint32_t * temp = reinterpret_cast< uint32_t * >(argp1);
       arg1 = *temp;
       if (SWIG_IsNewObj(res1)) delete temp;
     }
   }
   result = nrt_System_swap32(arg1);
-  resultobj = SWIG_NewPointerObj((new nrt_Uint32(static_cast< const nrt_Uint32& >(result))), SWIGTYPE_p_uint32_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint32_t(static_cast< const uint32_t& >(result))), SWIGTYPE_p_uint32_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -4416,28 +4416,28 @@ fail:
 
 SWIGINTERN PyObject *_wrap_nrt_System_swap64(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  nrt_Uint64 arg1 ;
+  uint64_t arg1 ;
   void *argp1 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nrt_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nrt_System_swap64",&obj0)) SWIG_fail;
   {
     res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "nrt_System_swap64" "', argument " "1"" of type '" "nrt_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "nrt_System_swap64" "', argument " "1"" of type '" "uint64_t""'"); 
     }  
     if (!argp1) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nrt_System_swap64" "', argument " "1"" of type '" "nrt_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nrt_System_swap64" "', argument " "1"" of type '" "uint64_t""'");
     } else {
-      nrt_Uint64 * temp = reinterpret_cast< nrt_Uint64 * >(argp1);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp1);
       arg1 = *temp;
       if (SWIG_IsNewObj(res1)) delete temp;
     }
   }
   result = nrt_System_swap64(arg1);
-  resultobj = SWIG_NewPointerObj((new nrt_Uint64(static_cast< const nrt_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -4446,28 +4446,28 @@ fail:
 
 SWIGINTERN PyObject *_wrap_nrt_System_swap64c(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  nrt_Uint64 arg1 ;
+  uint64_t arg1 ;
   void *argp1 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nrt_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nrt_System_swap64c",&obj0)) SWIG_fail;
   {
     res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "nrt_System_swap64c" "', argument " "1"" of type '" "nrt_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "nrt_System_swap64c" "', argument " "1"" of type '" "uint64_t""'"); 
     }  
     if (!argp1) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nrt_System_swap64c" "', argument " "1"" of type '" "nrt_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nrt_System_swap64c" "', argument " "1"" of type '" "uint64_t""'");
     } else {
-      nrt_Uint64 * temp = reinterpret_cast< nrt_Uint64 * >(argp1);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp1);
       arg1 = *temp;
       if (SWIG_IsNewObj(res1)) delete temp;
     }
   }
   result = nrt_System_swap64c(arg1);
-  resultobj = SWIG_NewPointerObj((new nrt_Uint64(static_cast< const nrt_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -33429,10 +33429,10 @@ static swig_type_info _swigt__p_f_p_void_p_q_const__void_size_t_p__NRT_Error__bo
 static swig_type_info _swigt__p_f_p_void_p_void_off_t_p__NRT_Error__bool = {"_p_f_p_void_p_void_off_t_p__NRT_Error__bool", "bool (*)(void *,void *,off_t,_NRT_Error *)|NITF_IDATASOURCE_READ", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_f_p_void_p_void_size_t_p__NRT_Error__bool = {"_p_f_p_void_p_void_size_t_p__NRT_Error__bool", "bool (*)(void *,void *,size_t,_NRT_Error *)|NRT_IO_INTERFACE_READ", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_int = {"_p_int", "int *|nrt_IOHandle *|nitf_IOHandle *|nrt_CreationFlags *|nitf_CreationFlags *|nrt_AccessFlags *|nitf_AccessFlags *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_int16_t = {"_p_int16_t", "nrt_Int16 *|nitf_Int16 *|int16_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_int32_t = {"_p_int32_t", "int32_t *|nrt_Int32 *|nitf_Int32 *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_int64_t = {"_p_int64_t", "int64_t *|nrt_Int64 *|nitf_Int64 *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_int8_t = {"_p_int8_t", "nrt_Int8 *|nitf_Int8 *|int8_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_int16_t = {"_p_int16_t", "int16_t *|nitf_Int16 *|int16_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_int32_t = {"_p_int32_t", "int32_t *|int32_t *|nitf_Int32 *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_int64_t = {"_p_int64_t", "int64_t *|int64_t *|nitf_Int64 *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_int8_t = {"_p_int8_t", "int8_t *|nitf_Int8 *|int8_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_nitf_BlockingInfo = {"_p_nitf_BlockingInfo", "nitf_BlockingInfo *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_nitf_CompressionInterface = {"_p_nitf_CompressionInterface", "nitf_CompressionInterface *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_nitf_FieldWarning = {"_p_nitf_FieldWarning", "nitf_FieldWarning *", 0, 0, (void*)0, 0};
@@ -33494,10 +33494,10 @@ static swig_type_info _swigt__p_p_nitf_WriteHandler = {"_p_p_nitf_WriteHandler",
 static swig_type_info _swigt__p_p_nrt_List = {"_p_p_nrt_List", "nrt_List **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_uint8_t = {"_p_p_uint8_t", "uint8_t **|nitf_Uint8 **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_void = {"_p_p_void", "NITF_DLL_FUNCTION_PTR *|NITF_NATIVE_DLL *|void **", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_uint16_t = {"_p_uint16_t", "nrt_Uint16 *|nitf_Uint16 *|uint16_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_uint32_t = {"_p_uint32_t", "uint32_t *|nrt_Uint32 *|nitf_Uint32 *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_uint64_t = {"_p_uint64_t", "uint64_t *|nrt_Uint64 *|nitf_Uint64 *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_uint8_t = {"_p_uint8_t", "nrt_Uint8 *|nitf_Uint8 *|uint8_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_uint16_t = {"_p_uint16_t", "uint16_t *|nitf_Uint16 *|uint16_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_uint32_t = {"_p_uint32_t", "uint32_t *|uint32_t *|nitf_Uint32 *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_uint64_t = {"_p_uint64_t", "uint64_t *|uint64_t *|nitf_Uint64 *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_uint8_t = {"_p_uint8_t", "uint8_t *|nitf_Uint8 *|uint8_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_void = {"_p_void", "NRT_DATA *|NITF_DATA *|void *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {

--- a/modules/python/nitf/source/generated/nitropy_wrap.cxx
+++ b/modules/python/nitf/source/generated/nitropy_wrap.cxx
@@ -3946,9 +3946,9 @@ SWIG_AsVal_long_SS_long (PyObject *obj, long long *val)
         return buf;
     }
 
-    nitf_Uint32 py_Field_getInt(nitf_Field *field, nitf_Error *error)
+    uint32_t py_Field_getInt(nitf_Field *field, nitf_Error *error)
     {
-        nitf_Uint32 intVal;
+        uint32_t intVal;
         NITF_TRY_GET_UINT32(field, &intVal, error);
         return intVal;
 
@@ -4054,7 +4054,7 @@ SWIG_AsVal_long_SS_long (PyObject *obj, long long *val)
 
     nitf_ComponentInfo* py_FileHeader_getComponentInfo(nitf_FileHeader* header, int index, char* type, nitf_Error* error)
     {
-        nitf_Uint32 num;
+        uint32_t num;
 
         if (!type)
         	goto CATCH_ERROR;
@@ -4152,7 +4152,7 @@ SWIG_AsVal_long_SS_long (PyObject *obj, long long *val)
 
         window->numBands = PySequence_Length(bandList);
         if (window->numBands < 0) window->numBands = 0;
-        window->bandList = (nitf_Uint32*)NITF_MALLOC(sizeof(nitf_Uint32) * window->numBands);
+        window->bandList = (uint32_t*)NITF_MALLOC(sizeof(uint32_t) * window->numBands);
         if (!window->bandList)
         {
             PyErr_NoMemory();
@@ -4178,17 +4178,17 @@ SWIG_AsVal_long_SS_long (PyObject *obj, long long *val)
     PyObject* py_ImageReader_read(nitf_ImageReader* reader, nitf_SubWindow* window, int nbpp, nitf_Error* error)
     {
         /* TODO somehow get the NUMBITSPERPIXEL in the future */
-        nitf_Uint8 **buf = NULL;
-        nitf_Uint8 *pyArrayBuffer = NULL;
+        uint8_t **buf = NULL;
+        uint8_t *pyArrayBuffer = NULL;
         PyObject* result = Py_None;
         int padded, rowSkip, colSkip;
-        nitf_Uint64 subimageSize;
-        nitf_Uint32 i;
+        uint64_t subimageSize;
+        uint32_t i;
         types::RowCol<size_t> dims;
 
         rowSkip = window->downsampler ? window->downsampler->rowSkip : 1;
         colSkip = window->downsampler ? window->downsampler->colSkip : 1;
-        subimageSize = static_cast<nitf_Uint64>(window->numRows/rowSkip) *
+        subimageSize = static_cast<uint64_t>(window->numRows/rowSkip) *
                 (window->numCols/colSkip) *
                 nitf_ImageIO_pixelSize(reader->imageDeblocker);
         if (subimageSize > std::numeric_limits<size_t>::max())
@@ -4204,18 +4204,18 @@ SWIG_AsVal_long_SS_long (PyObject *obj, long long *val)
 
         numpyutils::createOrVerify(result, NPY_UINT8, dims);
 
-        buf = (nitf_Uint8**) NITF_MALLOC(sizeof(nitf_Uint8*) * window->numBands);
+        buf = (uint8_t**) NITF_MALLOC(sizeof(uint8_t*) * window->numBands);
         if (!buf)
         {
             PyErr_NoMemory();
             goto CATCH_ERROR;
         }
 
-        memset(buf, 0, sizeof(nitf_Uint8*) * window->numBands);
+        memset(buf, 0, sizeof(uint8_t*) * window->numBands);
 
         for (i = 0; i < window->numBands; ++i)
         {
-            buf[i] = (nitf_Uint8*) NITF_MALLOC(sizeof(nitf_Uint8) * subimageSize);
+            buf[i] = (uint8_t*) NITF_MALLOC(sizeof(uint8_t) * subimageSize);
             if (!buf[i])
             {
                 PyErr_NoMemory();
@@ -4232,11 +4232,11 @@ SWIG_AsVal_long_SS_long (PyObject *obj, long long *val)
         }
 
         // Copy to output numpy array
-        pyArrayBuffer = numpyutils::getBuffer<nitf_Uint8>(result);
+        pyArrayBuffer = numpyutils::getBuffer<uint8_t>(result);
         for (i = 0; i < window->numBands; ++i)
         {
             memcpy(pyArrayBuffer + i * subimageSize,
-                   buf[i], sizeof(nitf_Uint8) * subimageSize);
+                   buf[i], sizeof(uint8_t) * subimageSize);
         }
 
         for (i = 0; i < window->numBands; ++i)
@@ -9221,7 +9221,7 @@ SWIGINTERN PyObject *_wrap_nitf_Writer_writeHeader(PyObject *SWIGUNUSEDPARM(self
   PyObject *resultobj = 0;
   nitf_Writer *arg1 = (nitf_Writer *) 0 ;
   nitf_Off *arg2 = (nitf_Off *) 0 ;
-  nitf_Uint32 *arg3 = (nitf_Uint32 *) 0 ;
+  uint32_t *arg3 = (uint32_t *) 0 ;
   nitf_Error *arg4 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -9250,9 +9250,9 @@ SWIGINTERN PyObject *_wrap_nitf_Writer_writeHeader(PyObject *SWIGUNUSEDPARM(self
   arg2 = reinterpret_cast< nitf_Off * >(argp2);
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_Writer_writeHeader" "', argument " "3"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_Writer_writeHeader" "', argument " "3"" of type '" "uint32_t *""'"); 
   }
-  arg3 = reinterpret_cast< nitf_Uint32 * >(argp3);
+  arg3 = reinterpret_cast< uint32_t * >(argp3);
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
     SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "nitf_Writer_writeHeader" "', argument " "4"" of type '" "nitf_Error *""'"); 
@@ -9328,7 +9328,7 @@ SWIGINTERN PyObject *_wrap_nitf_Writer_writeDESubheader(PyObject *SWIGUNUSEDPARM
   PyObject *resultobj = 0;
   nitf_Writer *arg1 = (nitf_Writer *) 0 ;
   nitf_DESubheader *arg2 = (nitf_DESubheader *) 0 ;
-  nitf_Uint32 *arg3 = (nitf_Uint32 *) 0 ;
+  uint32_t *arg3 = (uint32_t *) 0 ;
   nitf_Version arg4 ;
   nitf_Error *arg5 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
@@ -9361,9 +9361,9 @@ SWIGINTERN PyObject *_wrap_nitf_Writer_writeDESubheader(PyObject *SWIGUNUSEDPARM
   arg2 = reinterpret_cast< nitf_DESubheader * >(argp2);
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_Writer_writeDESubheader" "', argument " "3"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_Writer_writeDESubheader" "', argument " "3"" of type '" "uint32_t *""'"); 
   }
-  arg3 = reinterpret_cast< nitf_Uint32 * >(argp3);
+  arg3 = reinterpret_cast< uint32_t * >(argp3);
   ecode4 = SWIG_AsVal_int(obj3, &val4);
   if (!SWIG_IsOK(ecode4)) {
     SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "nitf_Writer_writeDESubheader" "', argument " "4"" of type '" "nitf_Version""'");
@@ -9385,10 +9385,10 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Writer_writeInt64Field(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Writer *arg1 = (nitf_Writer *) 0 ;
-  nitf_Uint64 arg2 ;
-  nitf_Uint32 arg3 ;
+  uint64_t arg2 ;
+  uint32_t arg3 ;
   char arg4 ;
-  nitf_Uint32 arg5 ;
+  uint32_t arg5 ;
   nitf_Error *arg6 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -9415,18 +9415,18 @@ SWIGINTERN PyObject *_wrap_nitf_Writer_writeInt64Field(PyObject *SWIGUNUSEDPARM(
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_Writer_writeInt64Field" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_Writer_writeInt64Field" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_Writer_writeInt64Field" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_Writer_writeInt64Field" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
   }
   {
-    arg3 = (nitf_Uint32)PyInt_AsLong(obj2);
+    arg3 = (uint32_t)PyInt_AsLong(obj2);
   }
   ecode4 = SWIG_AsVal_char(obj3, &val4);
   if (!SWIG_IsOK(ecode4)) {
@@ -9434,7 +9434,7 @@ SWIGINTERN PyObject *_wrap_nitf_Writer_writeInt64Field(PyObject *SWIGUNUSEDPARM(
   } 
   arg4 = static_cast< char >(val4);
   {
-    arg5 = (nitf_Uint32)PyInt_AsLong(obj4);
+    arg5 = (uint32_t)PyInt_AsLong(obj4);
   }
   res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res6)) {
@@ -9993,7 +9993,7 @@ SWIGINTERN PyObject *_wrap_nitf_Record_getNumImages(PyObject *SWIGUNUSEDPARM(sel
   int res2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"OO:nitf_Record_getNumImages",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_Record, 0 |  0 );
@@ -10057,7 +10057,7 @@ SWIGINTERN PyObject *_wrap_nitf_Record_getNumGraphics(PyObject *SWIGUNUSEDPARM(s
   int res2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"OO:nitf_Record_getNumGraphics",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_Record, 0 |  0 );
@@ -10121,7 +10121,7 @@ SWIGINTERN PyObject *_wrap_nitf_Record_getNumTexts(PyObject *SWIGUNUSEDPARM(self
   int res2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"OO:nitf_Record_getNumTexts",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_Record, 0 |  0 );
@@ -10185,7 +10185,7 @@ SWIGINTERN PyObject *_wrap_nitf_Record_getNumDataExtensions(PyObject *SWIGUNUSED
   int res2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"OO:nitf_Record_getNumDataExtensions",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_Record, 0 |  0 );
@@ -10242,7 +10242,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Record_removeImageSegment(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Record *arg1 = (nitf_Record *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -10260,7 +10260,7 @@ SWIGINTERN PyObject *_wrap_nitf_Record_removeImageSegment(PyObject *SWIGUNUSEDPA
   }
   arg1 = reinterpret_cast< nitf_Record * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -10278,7 +10278,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Record_removeGraphicSegment(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Record *arg1 = (nitf_Record *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -10296,7 +10296,7 @@ SWIGINTERN PyObject *_wrap_nitf_Record_removeGraphicSegment(PyObject *SWIGUNUSED
   }
   arg1 = reinterpret_cast< nitf_Record * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -10321,7 +10321,7 @@ SWIGINTERN PyObject *_wrap_nitf_Record_getNumLabels(PyObject *SWIGUNUSEDPARM(sel
   int res2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"OO:nitf_Record_getNumLabels",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_Record, 0 |  0 );
@@ -10347,7 +10347,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Record_removeLabelSegment(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Record *arg1 = (nitf_Record *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -10365,7 +10365,7 @@ SWIGINTERN PyObject *_wrap_nitf_Record_removeLabelSegment(PyObject *SWIGUNUSEDPA
   }
   arg1 = reinterpret_cast< nitf_Record * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -10383,7 +10383,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Record_removeTextSegment(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Record *arg1 = (nitf_Record *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -10401,7 +10401,7 @@ SWIGINTERN PyObject *_wrap_nitf_Record_removeTextSegment(PyObject *SWIGUNUSEDPAR
   }
   arg1 = reinterpret_cast< nitf_Record * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -10419,7 +10419,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Record_removeDataExtensionSegment(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Record *arg1 = (nitf_Record *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -10437,7 +10437,7 @@ SWIGINTERN PyObject *_wrap_nitf_Record_removeDataExtensionSegment(PyObject *SWIG
   }
   arg1 = reinterpret_cast< nitf_Record * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -10462,7 +10462,7 @@ SWIGINTERN PyObject *_wrap_nitf_Record_getNumReservedExtensions(PyObject *SWIGUN
   int res2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"OO:nitf_Record_getNumReservedExtensions",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_Record, 0 |  0 );
@@ -10488,7 +10488,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Record_removeReservedExtensionSegment(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Record *arg1 = (nitf_Record *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -10506,7 +10506,7 @@ SWIGINTERN PyObject *_wrap_nitf_Record_removeReservedExtensionSegment(PyObject *
   }
   arg1 = reinterpret_cast< nitf_Record * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -10524,8 +10524,8 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Record_moveImageSegment(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Record *arg1 = (nitf_Record *) 0 ;
-  nitf_Uint32 arg2 ;
-  nitf_Uint32 arg3 ;
+  uint32_t arg2 ;
+  uint32_t arg3 ;
   nitf_Error *arg4 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -10544,10 +10544,10 @@ SWIGINTERN PyObject *_wrap_nitf_Record_moveImageSegment(PyObject *SWIGUNUSEDPARM
   }
   arg1 = reinterpret_cast< nitf_Record * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   {
-    arg3 = (nitf_Uint32)PyInt_AsLong(obj2);
+    arg3 = (uint32_t)PyInt_AsLong(obj2);
   }
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
@@ -10565,8 +10565,8 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Record_moveGraphicSegment(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Record *arg1 = (nitf_Record *) 0 ;
-  nitf_Uint32 arg2 ;
-  nitf_Uint32 arg3 ;
+  uint32_t arg2 ;
+  uint32_t arg3 ;
   nitf_Error *arg4 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -10585,10 +10585,10 @@ SWIGINTERN PyObject *_wrap_nitf_Record_moveGraphicSegment(PyObject *SWIGUNUSEDPA
   }
   arg1 = reinterpret_cast< nitf_Record * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   {
-    arg3 = (nitf_Uint32)PyInt_AsLong(obj2);
+    arg3 = (uint32_t)PyInt_AsLong(obj2);
   }
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
@@ -10606,8 +10606,8 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Record_moveLabelSegment(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Record *arg1 = (nitf_Record *) 0 ;
-  nitf_Uint32 arg2 ;
-  nitf_Uint32 arg3 ;
+  uint32_t arg2 ;
+  uint32_t arg3 ;
   nitf_Error *arg4 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -10626,10 +10626,10 @@ SWIGINTERN PyObject *_wrap_nitf_Record_moveLabelSegment(PyObject *SWIGUNUSEDPARM
   }
   arg1 = reinterpret_cast< nitf_Record * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   {
-    arg3 = (nitf_Uint32)PyInt_AsLong(obj2);
+    arg3 = (uint32_t)PyInt_AsLong(obj2);
   }
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
@@ -10647,8 +10647,8 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Record_moveTextSegment(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Record *arg1 = (nitf_Record *) 0 ;
-  nitf_Uint32 arg2 ;
-  nitf_Uint32 arg3 ;
+  uint32_t arg2 ;
+  uint32_t arg3 ;
   nitf_Error *arg4 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -10667,10 +10667,10 @@ SWIGINTERN PyObject *_wrap_nitf_Record_moveTextSegment(PyObject *SWIGUNUSEDPARM(
   }
   arg1 = reinterpret_cast< nitf_Record * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   {
-    arg3 = (nitf_Uint32)PyInt_AsLong(obj2);
+    arg3 = (uint32_t)PyInt_AsLong(obj2);
   }
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
@@ -10688,8 +10688,8 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Record_moveDataExtensionSegment(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Record *arg1 = (nitf_Record *) 0 ;
-  nitf_Uint32 arg2 ;
-  nitf_Uint32 arg3 ;
+  uint32_t arg2 ;
+  uint32_t arg3 ;
   nitf_Error *arg4 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -10708,10 +10708,10 @@ SWIGINTERN PyObject *_wrap_nitf_Record_moveDataExtensionSegment(PyObject *SWIGUN
   }
   arg1 = reinterpret_cast< nitf_Record * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   {
-    arg3 = (nitf_Uint32)PyInt_AsLong(obj2);
+    arg3 = (uint32_t)PyInt_AsLong(obj2);
   }
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
@@ -10729,8 +10729,8 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Record_moveReservedExtensionSegment(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Record *arg1 = (nitf_Record *) 0 ;
-  nitf_Uint32 arg2 ;
-  nitf_Uint32 arg3 ;
+  uint32_t arg2 ;
+  uint32_t arg3 ;
   nitf_Error *arg4 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -10749,10 +10749,10 @@ SWIGINTERN PyObject *_wrap_nitf_Record_moveReservedExtensionSegment(PyObject *SW
   }
   arg1 = reinterpret_cast< nitf_Record * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   {
-    arg3 = (nitf_Uint32)PyInt_AsLong(obj2);
+    arg3 = (uint32_t)PyInt_AsLong(obj2);
   }
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
@@ -11164,7 +11164,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Field_setUint32(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Field *arg1 = (nitf_Field *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -11182,7 +11182,7 @@ SWIGINTERN PyObject *_wrap_nitf_Field_setUint32(PyObject *SWIGUNUSEDPARM(self), 
   }
   arg1 = reinterpret_cast< nitf_Field * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -11200,7 +11200,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Field_setUint64(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Field *arg1 = (nitf_Field *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -11222,12 +11222,12 @@ SWIGINTERN PyObject *_wrap_nitf_Field_setUint64(PyObject *SWIGUNUSEDPARM(self), 
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_Field_setUint64" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_Field_setUint64" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_Field_setUint64" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_Field_setUint64" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -11248,7 +11248,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Field_setInt32(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Field *arg1 = (nitf_Field *) 0 ;
-  nitf_Int32 arg2 ;
+  int32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -11270,12 +11270,12 @@ SWIGINTERN PyObject *_wrap_nitf_Field_setInt32(PyObject *SWIGUNUSEDPARM(self), P
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_int32_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_Field_setInt32" "', argument " "2"" of type '" "nitf_Int32""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_Field_setInt32" "', argument " "2"" of type '" "int32_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_Field_setInt32" "', argument " "2"" of type '" "nitf_Int32""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_Field_setInt32" "', argument " "2"" of type '" "int32_t""'");
     } else {
-      nitf_Int32 * temp = reinterpret_cast< nitf_Int32 * >(argp2);
+      int32_t * temp = reinterpret_cast< int32_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -11296,7 +11296,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_Field_setInt64(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_Field *arg1 = (nitf_Field *) 0 ;
-  nitf_Int64 arg2 ;
+  int64_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -11318,12 +11318,12 @@ SWIGINTERN PyObject *_wrap_nitf_Field_setInt64(PyObject *SWIGUNUSEDPARM(self), P
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_int64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_Field_setInt64" "', argument " "2"" of type '" "nitf_Int64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_Field_setInt64" "', argument " "2"" of type '" "int64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_Field_setInt64" "', argument " "2"" of type '" "nitf_Int64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_Field_setInt64" "', argument " "2"" of type '" "int64_t""'");
     } else {
-      nitf_Int64 * temp = reinterpret_cast< nitf_Int64 * >(argp2);
+      int64_t * temp = reinterpret_cast< int64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -14854,7 +14854,7 @@ SWIGINTERN PyObject *_wrap_nitf_Extensions_computeLength(PyObject *SWIGUNUSEDPAR
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"OOO:nitf_Extensions_computeLength",&obj0,&obj1,&obj2)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_Extensions, 0 |  0 );
@@ -17096,8 +17096,8 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_ImageWriter_setPadPixel(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_ImageWriter *arg1 = (nitf_ImageWriter *) 0 ;
-  nitf_Uint8 *arg2 = (nitf_Uint8 *) 0 ;
-  nitf_Uint32 arg3 ;
+  uint8_t *arg2 = (uint8_t *) 0 ;
+  uint32_t arg3 ;
   nitf_Error *arg4 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -17119,11 +17119,11 @@ SWIGINTERN PyObject *_wrap_nitf_ImageWriter_setPadPixel(PyObject *SWIGUNUSEDPARM
   arg1 = reinterpret_cast< nitf_ImageWriter * >(argp1);
   res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint8_t, 0 |  0 );
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_ImageWriter_setPadPixel" "', argument " "2"" of type '" "nitf_Uint8 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_ImageWriter_setPadPixel" "', argument " "2"" of type '" "uint8_t *""'"); 
   }
-  arg2 = reinterpret_cast< nitf_Uint8 * >(argp2);
+  arg2 = reinterpret_cast< uint8_t * >(argp2);
   {
-    arg3 = (nitf_Uint32)PyInt_AsLong(obj2);
+    arg3 = (uint32_t)PyInt_AsLong(obj2);
   }
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
@@ -19115,7 +19115,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_ImageSegment_imageOffset_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_ImageSegment *arg1 = (_nitf_ImageSegment *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -19132,12 +19132,12 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSegment_imageOffset_set(PyObject *SWIGUNUSE
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_ImageSegment_imageOffset_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_ImageSegment_imageOffset_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_ImageSegment_imageOffset_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_ImageSegment_imageOffset_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -19156,7 +19156,7 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSegment_imageOffset_get(PyObject *SWIGUNUSE
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_ImageSegment_imageOffset_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_ImageSegment, 0 |  0 );
@@ -19165,7 +19165,7 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSegment_imageOffset_get(PyObject *SWIGUNUSE
   }
   arg1 = reinterpret_cast< _nitf_ImageSegment * >(argp1);
   result =  ((arg1)->imageOffset);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -19175,7 +19175,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_ImageSegment_imageEnd_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_ImageSegment *arg1 = (_nitf_ImageSegment *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -19192,12 +19192,12 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSegment_imageEnd_set(PyObject *SWIGUNUSEDPA
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_ImageSegment_imageEnd_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_ImageSegment_imageEnd_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_ImageSegment_imageEnd_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_ImageSegment_imageEnd_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -19216,7 +19216,7 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSegment_imageEnd_get(PyObject *SWIGUNUSEDPA
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_ImageSegment_imageEnd_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_ImageSegment, 0 |  0 );
@@ -19225,7 +19225,7 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSegment_imageEnd_get(PyObject *SWIGUNUSEDPA
   }
   arg1 = reinterpret_cast< _nitf_ImageSegment * >(argp1);
   result =  ((arg1)->imageEnd);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -21630,12 +21630,12 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_setPixelInformation(PyObject *SWI
   PyObject *resultobj = 0;
   nitf_ImageSubheader *arg1 = (nitf_ImageSubheader *) 0 ;
   char *arg2 = (char *) 0 ;
-  nitf_Uint32 arg3 ;
-  nitf_Uint32 arg4 ;
+  uint32_t arg3 ;
+  uint32_t arg4 ;
   char *arg5 = (char *) 0 ;
   char *arg6 = (char *) 0 ;
   char *arg7 = (char *) 0 ;
-  nitf_Uint32 arg8 ;
+  uint32_t arg8 ;
   nitf_BandInfo **arg9 = (nitf_BandInfo **) 0 ;
   nitf_Error *arg10 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
@@ -21680,10 +21680,10 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_setPixelInformation(PyObject *SWI
   }
   arg2 = reinterpret_cast< char * >(buf2);
   {
-    arg3 = (nitf_Uint32)PyInt_AsLong(obj2);
+    arg3 = (uint32_t)PyInt_AsLong(obj2);
   }
   {
-    arg4 = (nitf_Uint32)PyInt_AsLong(obj3);
+    arg4 = (uint32_t)PyInt_AsLong(obj3);
   }
   res5 = SWIG_AsCharPtrAndSize(obj4, &buf5, NULL, &alloc5);
   if (!SWIG_IsOK(res5)) {
@@ -21701,7 +21701,7 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_setPixelInformation(PyObject *SWI
   }
   arg7 = reinterpret_cast< char * >(buf7);
   {
-    arg8 = (nitf_Uint32)PyInt_AsLong(obj7);
+    arg8 = (uint32_t)PyInt_AsLong(obj7);
   }
   res9 = SWIG_ConvertPtr(obj8, &argp9,SWIGTYPE_p_p__nitf_BandInfo, 0 |  0 );
   if (!SWIG_IsOK(res9)) {
@@ -21739,7 +21739,7 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_getBandCount(PyObject *SWIGUNUSED
   int res2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"OO:nitf_ImageSubheader_getBandCount",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_ImageSubheader, 0 |  0 );
@@ -21765,7 +21765,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_getBandInfo(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_ImageSubheader *arg1 = (nitf_ImageSubheader *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -21783,7 +21783,7 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_getBandInfo(PyObject *SWIGUNUSEDP
   }
   arg1 = reinterpret_cast< nitf_ImageSubheader * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -21801,7 +21801,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_createBands(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_ImageSubheader *arg1 = (nitf_ImageSubheader *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -21819,7 +21819,7 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_createBands(PyObject *SWIGUNUSEDP
   }
   arg1 = reinterpret_cast< nitf_ImageSubheader * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -21837,7 +21837,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_removeBand(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_ImageSubheader *arg1 = (nitf_ImageSubheader *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -21855,7 +21855,7 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_removeBand(PyObject *SWIGUNUSEDPA
   }
   arg1 = reinterpret_cast< nitf_ImageSubheader * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -21873,8 +21873,8 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_getDimensions(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_ImageSubheader *arg1 = (nitf_ImageSubheader *) 0 ;
-  nitf_Uint32 *arg2 = (nitf_Uint32 *) 0 ;
-  nitf_Uint32 *arg3 = (nitf_Uint32 *) 0 ;
+  uint32_t *arg2 = (uint32_t *) 0 ;
+  uint32_t *arg3 = (uint32_t *) 0 ;
   nitf_Error *arg4 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -21898,14 +21898,14 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_getDimensions(PyObject *SWIGUNUSE
   arg1 = reinterpret_cast< nitf_ImageSubheader * >(argp1);
   res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_ImageSubheader_getDimensions" "', argument " "2"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_ImageSubheader_getDimensions" "', argument " "2"" of type '" "uint32_t *""'"); 
   }
-  arg2 = reinterpret_cast< nitf_Uint32 * >(argp2);
+  arg2 = reinterpret_cast< uint32_t * >(argp2);
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_ImageSubheader_getDimensions" "', argument " "3"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_ImageSubheader_getDimensions" "', argument " "3"" of type '" "uint32_t *""'"); 
   }
-  arg3 = reinterpret_cast< nitf_Uint32 * >(argp3);
+  arg3 = reinterpret_cast< uint32_t * >(argp3);
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
     SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "nitf_ImageSubheader_getDimensions" "', argument " "4"" of type '" "nitf_Error *""'"); 
@@ -21922,12 +21922,12 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_getBlocking(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_ImageSubheader *arg1 = (nitf_ImageSubheader *) 0 ;
-  nitf_Uint32 *arg2 = (nitf_Uint32 *) 0 ;
-  nitf_Uint32 *arg3 = (nitf_Uint32 *) 0 ;
-  nitf_Uint32 *arg4 = (nitf_Uint32 *) 0 ;
-  nitf_Uint32 *arg5 = (nitf_Uint32 *) 0 ;
-  nitf_Uint32 *arg6 = (nitf_Uint32 *) 0 ;
-  nitf_Uint32 *arg7 = (nitf_Uint32 *) 0 ;
+  uint32_t *arg2 = (uint32_t *) 0 ;
+  uint32_t *arg3 = (uint32_t *) 0 ;
+  uint32_t *arg4 = (uint32_t *) 0 ;
+  uint32_t *arg5 = (uint32_t *) 0 ;
+  uint32_t *arg6 = (uint32_t *) 0 ;
+  uint32_t *arg7 = (uint32_t *) 0 ;
   char *arg8 = (char *) 0 ;
   nitf_Error *arg9 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
@@ -21968,34 +21968,34 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_getBlocking(PyObject *SWIGUNUSEDP
   arg1 = reinterpret_cast< nitf_ImageSubheader * >(argp1);
   res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_ImageSubheader_getBlocking" "', argument " "2"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_ImageSubheader_getBlocking" "', argument " "2"" of type '" "uint32_t *""'"); 
   }
-  arg2 = reinterpret_cast< nitf_Uint32 * >(argp2);
+  arg2 = reinterpret_cast< uint32_t * >(argp2);
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_ImageSubheader_getBlocking" "', argument " "3"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_ImageSubheader_getBlocking" "', argument " "3"" of type '" "uint32_t *""'"); 
   }
-  arg3 = reinterpret_cast< nitf_Uint32 * >(argp3);
+  arg3 = reinterpret_cast< uint32_t * >(argp3);
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
-    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "nitf_ImageSubheader_getBlocking" "', argument " "4"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "nitf_ImageSubheader_getBlocking" "', argument " "4"" of type '" "uint32_t *""'"); 
   }
-  arg4 = reinterpret_cast< nitf_Uint32 * >(argp4);
+  arg4 = reinterpret_cast< uint32_t * >(argp4);
   res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res5)) {
-    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "nitf_ImageSubheader_getBlocking" "', argument " "5"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "nitf_ImageSubheader_getBlocking" "', argument " "5"" of type '" "uint32_t *""'"); 
   }
-  arg5 = reinterpret_cast< nitf_Uint32 * >(argp5);
+  arg5 = reinterpret_cast< uint32_t * >(argp5);
   res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res6)) {
-    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "nitf_ImageSubheader_getBlocking" "', argument " "6"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "nitf_ImageSubheader_getBlocking" "', argument " "6"" of type '" "uint32_t *""'"); 
   }
-  arg6 = reinterpret_cast< nitf_Uint32 * >(argp6);
+  arg6 = reinterpret_cast< uint32_t * >(argp6);
   res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res7)) {
-    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "nitf_ImageSubheader_getBlocking" "', argument " "7"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "nitf_ImageSubheader_getBlocking" "', argument " "7"" of type '" "uint32_t *""'"); 
   }
-  arg7 = reinterpret_cast< nitf_Uint32 * >(argp7);
+  arg7 = reinterpret_cast< uint32_t * >(argp7);
   res8 = SWIG_AsCharPtrAndSize(obj7, &buf8, NULL, &alloc8);
   if (!SWIG_IsOK(res8)) {
     SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "nitf_ImageSubheader_getBlocking" "', argument " "8"" of type '" "char *""'");
@@ -22074,8 +22074,8 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_setDimensions(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_ImageSubheader *arg1 = (nitf_ImageSubheader *) 0 ;
-  nitf_Uint32 arg2 ;
-  nitf_Uint32 arg3 ;
+  uint32_t arg2 ;
+  uint32_t arg3 ;
   nitf_Error *arg4 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -22094,10 +22094,10 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_setDimensions(PyObject *SWIGUNUSE
   }
   arg1 = reinterpret_cast< nitf_ImageSubheader * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   {
-    arg3 = (nitf_Uint32)PyInt_AsLong(obj2);
+    arg3 = (uint32_t)PyInt_AsLong(obj2);
   }
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
@@ -22225,12 +22225,12 @@ fail:
 
 SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_computeBlocking(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  nitf_Uint32 arg1 ;
-  nitf_Uint32 arg2 ;
-  nitf_Uint32 *arg3 = (nitf_Uint32 *) 0 ;
-  nitf_Uint32 *arg4 = (nitf_Uint32 *) 0 ;
-  nitf_Uint32 *arg5 = (nitf_Uint32 *) 0 ;
-  nitf_Uint32 *arg6 = (nitf_Uint32 *) 0 ;
+  uint32_t arg1 ;
+  uint32_t arg2 ;
+  uint32_t *arg3 = (uint32_t *) 0 ;
+  uint32_t *arg4 = (uint32_t *) 0 ;
+  uint32_t *arg5 = (uint32_t *) 0 ;
+  uint32_t *arg6 = (uint32_t *) 0 ;
   void *argp3 = 0 ;
   int res3 = 0 ;
   void *argp4 = 0 ;
@@ -22248,31 +22248,31 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_computeBlocking(PyObject *SWIGUNU
   
   if (!PyArg_ParseTuple(args,(char *)"OOOOOO:nitf_ImageSubheader_computeBlocking",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
   {
-    arg1 = (nitf_Uint32)PyInt_AsLong(obj0);
+    arg1 = (uint32_t)PyInt_AsLong(obj0);
   }
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_ImageSubheader_computeBlocking" "', argument " "3"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_ImageSubheader_computeBlocking" "', argument " "3"" of type '" "uint32_t *""'"); 
   }
-  arg3 = reinterpret_cast< nitf_Uint32 * >(argp3);
+  arg3 = reinterpret_cast< uint32_t * >(argp3);
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
-    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "nitf_ImageSubheader_computeBlocking" "', argument " "4"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "nitf_ImageSubheader_computeBlocking" "', argument " "4"" of type '" "uint32_t *""'"); 
   }
-  arg4 = reinterpret_cast< nitf_Uint32 * >(argp4);
+  arg4 = reinterpret_cast< uint32_t * >(argp4);
   res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res5)) {
-    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "nitf_ImageSubheader_computeBlocking" "', argument " "5"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "nitf_ImageSubheader_computeBlocking" "', argument " "5"" of type '" "uint32_t *""'"); 
   }
-  arg5 = reinterpret_cast< nitf_Uint32 * >(argp5);
+  arg5 = reinterpret_cast< uint32_t * >(argp5);
   res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_uint32_t, 0 |  0 );
   if (!SWIG_IsOK(res6)) {
-    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "nitf_ImageSubheader_computeBlocking" "', argument " "6"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "nitf_ImageSubheader_computeBlocking" "', argument " "6"" of type '" "uint32_t *""'"); 
   }
-  arg6 = reinterpret_cast< nitf_Uint32 * >(argp6);
+  arg6 = reinterpret_cast< uint32_t * >(argp6);
   nitf_ImageSubheader_computeBlocking(arg1,arg2,arg3,arg4,arg5,arg6);
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -22284,10 +22284,10 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_setBlocking(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_ImageSubheader *arg1 = (nitf_ImageSubheader *) 0 ;
-  nitf_Uint32 arg2 ;
-  nitf_Uint32 arg3 ;
-  nitf_Uint32 arg4 ;
-  nitf_Uint32 arg5 ;
+  uint32_t arg2 ;
+  uint32_t arg3 ;
+  uint32_t arg4 ;
+  uint32_t arg5 ;
   char *arg6 = (char *) 0 ;
   nitf_Error *arg7 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
@@ -22313,16 +22313,16 @@ SWIGINTERN PyObject *_wrap_nitf_ImageSubheader_setBlocking(PyObject *SWIGUNUSEDP
   }
   arg1 = reinterpret_cast< nitf_ImageSubheader * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   {
-    arg3 = (nitf_Uint32)PyInt_AsLong(obj2);
+    arg3 = (uint32_t)PyInt_AsLong(obj2);
   }
   {
-    arg4 = (nitf_Uint32)PyInt_AsLong(obj3);
+    arg4 = (uint32_t)PyInt_AsLong(obj3);
   }
   {
-    arg5 = (nitf_Uint32)PyInt_AsLong(obj4);
+    arg5 = (uint32_t)PyInt_AsLong(obj4);
   }
   res6 = SWIG_AsCharPtrAndSize(obj5, &buf6, NULL, &alloc6);
   if (!SWIG_IsOK(res6)) {
@@ -22546,7 +22546,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_GraphicSegment_offset_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_GraphicSegment *arg1 = (_nitf_GraphicSegment *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -22563,12 +22563,12 @@ SWIGINTERN PyObject *_wrap_nitf_GraphicSegment_offset_set(PyObject *SWIGUNUSEDPA
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_GraphicSegment_offset_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_GraphicSegment_offset_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_GraphicSegment_offset_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_GraphicSegment_offset_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -22587,7 +22587,7 @@ SWIGINTERN PyObject *_wrap_nitf_GraphicSegment_offset_get(PyObject *SWIGUNUSEDPA
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_GraphicSegment_offset_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_GraphicSegment, 0 |  0 );
@@ -22596,7 +22596,7 @@ SWIGINTERN PyObject *_wrap_nitf_GraphicSegment_offset_get(PyObject *SWIGUNUSEDPA
   }
   arg1 = reinterpret_cast< _nitf_GraphicSegment * >(argp1);
   result =  ((arg1)->offset);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -22606,7 +22606,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_GraphicSegment_end_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_GraphicSegment *arg1 = (_nitf_GraphicSegment *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -22623,12 +22623,12 @@ SWIGINTERN PyObject *_wrap_nitf_GraphicSegment_end_set(PyObject *SWIGUNUSEDPARM(
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_GraphicSegment_end_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_GraphicSegment_end_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_GraphicSegment_end_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_GraphicSegment_end_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -22647,7 +22647,7 @@ SWIGINTERN PyObject *_wrap_nitf_GraphicSegment_end_get(PyObject *SWIGUNUSEDPARM(
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_GraphicSegment_end_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_GraphicSegment, 0 |  0 );
@@ -22656,7 +22656,7 @@ SWIGINTERN PyObject *_wrap_nitf_GraphicSegment_end_get(PyObject *SWIGUNUSEDPARM(
   }
   arg1 = reinterpret_cast< _nitf_GraphicSegment * >(argp1);
   result =  ((arg1)->end);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -23919,7 +23919,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_LabelSegment_offset_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_LabelSegment *arg1 = (_nitf_LabelSegment *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -23936,12 +23936,12 @@ SWIGINTERN PyObject *_wrap_nitf_LabelSegment_offset_set(PyObject *SWIGUNUSEDPARM
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_LabelSegment_offset_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_LabelSegment_offset_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_LabelSegment_offset_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_LabelSegment_offset_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -23960,7 +23960,7 @@ SWIGINTERN PyObject *_wrap_nitf_LabelSegment_offset_get(PyObject *SWIGUNUSEDPARM
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_LabelSegment_offset_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_LabelSegment, 0 |  0 );
@@ -23969,7 +23969,7 @@ SWIGINTERN PyObject *_wrap_nitf_LabelSegment_offset_get(PyObject *SWIGUNUSEDPARM
   }
   arg1 = reinterpret_cast< _nitf_LabelSegment * >(argp1);
   result =  ((arg1)->offset);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -23979,7 +23979,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_LabelSegment_end_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_LabelSegment *arg1 = (_nitf_LabelSegment *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -23996,12 +23996,12 @@ SWIGINTERN PyObject *_wrap_nitf_LabelSegment_end_set(PyObject *SWIGUNUSEDPARM(se
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_LabelSegment_end_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_LabelSegment_end_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_LabelSegment_end_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_LabelSegment_end_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -24020,7 +24020,7 @@ SWIGINTERN PyObject *_wrap_nitf_LabelSegment_end_get(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_LabelSegment_end_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_LabelSegment, 0 |  0 );
@@ -24029,7 +24029,7 @@ SWIGINTERN PyObject *_wrap_nitf_LabelSegment_end_get(PyObject *SWIGUNUSEDPARM(se
   }
   arg1 = reinterpret_cast< _nitf_LabelSegment * >(argp1);
   result =  ((arg1)->end);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -25240,7 +25240,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_TextSegment_offset_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_TextSegment *arg1 = (_nitf_TextSegment *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -25257,12 +25257,12 @@ SWIGINTERN PyObject *_wrap_nitf_TextSegment_offset_set(PyObject *SWIGUNUSEDPARM(
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_TextSegment_offset_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_TextSegment_offset_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_TextSegment_offset_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_TextSegment_offset_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -25281,7 +25281,7 @@ SWIGINTERN PyObject *_wrap_nitf_TextSegment_offset_get(PyObject *SWIGUNUSEDPARM(
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_TextSegment_offset_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_TextSegment, 0 |  0 );
@@ -25290,7 +25290,7 @@ SWIGINTERN PyObject *_wrap_nitf_TextSegment_offset_get(PyObject *SWIGUNUSEDPARM(
   }
   arg1 = reinterpret_cast< _nitf_TextSegment * >(argp1);
   result =  ((arg1)->offset);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -25300,7 +25300,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_TextSegment_end_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_TextSegment *arg1 = (_nitf_TextSegment *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -25317,12 +25317,12 @@ SWIGINTERN PyObject *_wrap_nitf_TextSegment_end_set(PyObject *SWIGUNUSEDPARM(sel
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_TextSegment_end_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_TextSegment_end_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_TextSegment_end_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_TextSegment_end_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -25341,7 +25341,7 @@ SWIGINTERN PyObject *_wrap_nitf_TextSegment_end_get(PyObject *SWIGUNUSEDPARM(sel
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_TextSegment_end_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_TextSegment, 0 |  0 );
@@ -25350,7 +25350,7 @@ SWIGINTERN PyObject *_wrap_nitf_TextSegment_end_get(PyObject *SWIGUNUSEDPARM(sel
   }
   arg1 = reinterpret_cast< _nitf_TextSegment * >(argp1);
   result =  ((arg1)->end);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -26240,7 +26240,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_DESegment_offset_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_DESegment *arg1 = (_nitf_DESegment *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -26257,12 +26257,12 @@ SWIGINTERN PyObject *_wrap_nitf_DESegment_offset_set(PyObject *SWIGUNUSEDPARM(se
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_DESegment_offset_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_DESegment_offset_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_DESegment_offset_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_DESegment_offset_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -26281,7 +26281,7 @@ SWIGINTERN PyObject *_wrap_nitf_DESegment_offset_get(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_DESegment_offset_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_DESegment, 0 |  0 );
@@ -26290,7 +26290,7 @@ SWIGINTERN PyObject *_wrap_nitf_DESegment_offset_get(PyObject *SWIGUNUSEDPARM(se
   }
   arg1 = reinterpret_cast< _nitf_DESegment * >(argp1);
   result =  ((arg1)->offset);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -26300,7 +26300,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_DESegment_end_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_DESegment *arg1 = (_nitf_DESegment *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -26317,12 +26317,12 @@ SWIGINTERN PyObject *_wrap_nitf_DESegment_end_set(PyObject *SWIGUNUSEDPARM(self)
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_DESegment_end_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_DESegment_end_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_DESegment_end_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_DESegment_end_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -26341,7 +26341,7 @@ SWIGINTERN PyObject *_wrap_nitf_DESegment_end_get(PyObject *SWIGUNUSEDPARM(self)
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_DESegment_end_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_DESegment, 0 |  0 );
@@ -26350,7 +26350,7 @@ SWIGINTERN PyObject *_wrap_nitf_DESegment_end_get(PyObject *SWIGUNUSEDPARM(self)
   }
   arg1 = reinterpret_cast< _nitf_DESegment * >(argp1);
   result =  ((arg1)->end);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -26930,7 +26930,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_DESubheader_dataLength_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_DESubheader *arg1 = (_nitf_DESubheader *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -26947,12 +26947,12 @@ SWIGINTERN PyObject *_wrap_nitf_DESubheader_dataLength_set(PyObject *SWIGUNUSEDP
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_DESubheader_dataLength_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_DESubheader_dataLength_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_DESubheader_dataLength_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_DESubheader_dataLength_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -26971,7 +26971,7 @@ SWIGINTERN PyObject *_wrap_nitf_DESubheader_dataLength_get(PyObject *SWIGUNUSEDP
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_DESubheader_dataLength_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_DESubheader, 0 |  0 );
@@ -26980,7 +26980,7 @@ SWIGINTERN PyObject *_wrap_nitf_DESubheader_dataLength_get(PyObject *SWIGUNUSEDP
   }
   arg1 = reinterpret_cast< _nitf_DESubheader * >(argp1);
   result =  ((arg1)->dataLength);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -27196,7 +27196,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_RESegment_offset_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_RESegment *arg1 = (_nitf_RESegment *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -27213,12 +27213,12 @@ SWIGINTERN PyObject *_wrap_nitf_RESegment_offset_set(PyObject *SWIGUNUSEDPARM(se
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_RESegment_offset_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_RESegment_offset_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_RESegment_offset_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_RESegment_offset_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -27237,7 +27237,7 @@ SWIGINTERN PyObject *_wrap_nitf_RESegment_offset_get(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_RESegment_offset_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_RESegment, 0 |  0 );
@@ -27246,7 +27246,7 @@ SWIGINTERN PyObject *_wrap_nitf_RESegment_offset_get(PyObject *SWIGUNUSEDPARM(se
   }
   arg1 = reinterpret_cast< _nitf_RESegment * >(argp1);
   result =  ((arg1)->offset);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -27256,7 +27256,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_RESegment_end_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_RESegment *arg1 = (_nitf_RESegment *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -27273,12 +27273,12 @@ SWIGINTERN PyObject *_wrap_nitf_RESegment_end_set(PyObject *SWIGUNUSEDPARM(self)
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_RESegment_end_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_RESegment_end_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_RESegment_end_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_RESegment_end_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -27297,7 +27297,7 @@ SWIGINTERN PyObject *_wrap_nitf_RESegment_end_get(PyObject *SWIGUNUSEDPARM(self)
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_RESegment_end_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_RESegment, 0 |  0 );
@@ -27306,7 +27306,7 @@ SWIGINTERN PyObject *_wrap_nitf_RESegment_end_get(PyObject *SWIGUNUSEDPARM(self)
   }
   arg1 = reinterpret_cast< _nitf_RESegment * >(argp1);
   result =  ((arg1)->end);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -27852,7 +27852,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_RESubheader_dataLength_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_RESubheader *arg1 = (_nitf_RESubheader *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -27869,12 +27869,12 @@ SWIGINTERN PyObject *_wrap_nitf_RESubheader_dataLength_set(PyObject *SWIGUNUSEDP
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_RESubheader_dataLength_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_RESubheader_dataLength_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_RESubheader_dataLength_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_RESubheader_dataLength_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -27893,7 +27893,7 @@ SWIGINTERN PyObject *_wrap_nitf_RESubheader_dataLength_get(PyObject *SWIGUNUSEDP
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_RESubheader_dataLength_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_RESubheader, 0 |  0 );
@@ -27902,7 +27902,7 @@ SWIGINTERN PyObject *_wrap_nitf_RESubheader_dataLength_get(PyObject *SWIGUNUSEDP
   }
   arg1 = reinterpret_cast< _nitf_RESubheader * >(argp1);
   result =  ((arg1)->dataLength);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -28145,8 +28145,8 @@ SWIGINTERN PyObject *nitf_ComponentInfo_swigregister(PyObject *SWIGUNUSEDPARM(se
 
 SWIGINTERN PyObject *_wrap_nitf_ComponentInfo_construct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  nitf_Uint32 arg1 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg1 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp3 = 0 ;
   int res3 = 0 ;
@@ -28157,10 +28157,10 @@ SWIGINTERN PyObject *_wrap_nitf_ComponentInfo_construct(PyObject *SWIGUNUSEDPARM
   
   if (!PyArg_ParseTuple(args,(char *)"OOO:nitf_ComponentInfo_construct",&obj0,&obj1,&obj2)) SWIG_fail;
   {
-    arg1 = (nitf_Uint32)PyInt_AsLong(obj0);
+    arg1 = (uint32_t)PyInt_AsLong(obj0);
   }
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -28446,7 +28446,7 @@ SWIGINTERN PyObject *_wrap_nitf_ImageReader_read(PyObject *SWIGUNUSEDPARM(self),
   PyObject *resultobj = 0;
   nitf_ImageReader *arg1 = (nitf_ImageReader *) 0 ;
   nitf_SubWindow *arg2 = (nitf_SubWindow *) 0 ;
-  nitf_Uint8 **arg3 = (nitf_Uint8 **) 0 ;
+  uint8_t **arg3 = (uint8_t **) 0 ;
   int *arg4 = (int *) 0 ;
   nitf_Error *arg5 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
@@ -28479,9 +28479,9 @@ SWIGINTERN PyObject *_wrap_nitf_ImageReader_read(PyObject *SWIGUNUSEDPARM(self),
   arg2 = reinterpret_cast< nitf_SubWindow * >(argp2);
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_p_uint8_t, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_ImageReader_read" "', argument " "3"" of type '" "nitf_Uint8 **""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_ImageReader_read" "', argument " "3"" of type '" "uint8_t **""'"); 
   }
-  arg3 = reinterpret_cast< nitf_Uint8 ** >(argp3);
+  arg3 = reinterpret_cast< uint8_t ** >(argp3);
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_int, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
     SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "nitf_ImageReader_read" "', argument " "4"" of type '" "int *""'"); 
@@ -28503,8 +28503,8 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_ImageReader_readBlock(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nitf_ImageReader *arg1 = (nitf_ImageReader *) 0 ;
-  nitf_Uint32 arg2 ;
-  nitf_Uint64 *arg3 = (nitf_Uint64 *) 0 ;
+  uint32_t arg2 ;
+  uint64_t *arg3 = (uint64_t *) 0 ;
   nitf_Error *arg4 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -28516,7 +28516,7 @@ SWIGINTERN PyObject *_wrap_nitf_ImageReader_readBlock(PyObject *SWIGUNUSEDPARM(s
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
   PyObject * obj3 = 0 ;
-  nitf_Uint8 *result = 0 ;
+  uint8_t *result = 0 ;
   
   if (!PyArg_ParseTuple(args,(char *)"OOOO:nitf_ImageReader_readBlock",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_ImageReader, 0 |  0 );
@@ -28525,19 +28525,19 @@ SWIGINTERN PyObject *_wrap_nitf_ImageReader_readBlock(PyObject *SWIGUNUSEDPARM(s
   }
   arg1 = reinterpret_cast< nitf_ImageReader * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_uint64_t, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_ImageReader_readBlock" "', argument " "3"" of type '" "nitf_Uint64 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "nitf_ImageReader_readBlock" "', argument " "3"" of type '" "uint64_t *""'"); 
   }
-  arg3 = reinterpret_cast< nitf_Uint64 * >(argp3);
+  arg3 = reinterpret_cast< uint64_t * >(argp3);
   res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res4)) {
     SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "nitf_ImageReader_readBlock" "', argument " "4"" of type '" "nitf_Error *""'"); 
   }
   arg4 = reinterpret_cast< nitf_Error * >(argp4);
-  result = (nitf_Uint8 *)nitf_ImageReader_readBlock(arg1,arg2,arg3,arg4);
+  result = (uint8_t *)nitf_ImageReader_readBlock(arg1,arg2,arg3,arg4);
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uint8_t, 0 |  0 );
   return resultobj;
 fail:
@@ -28643,7 +28643,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_SegmentReader_dataLength_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_SegmentReader *arg1 = (_nitf_SegmentReader *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -28656,7 +28656,7 @@ SWIGINTERN PyObject *_wrap_nitf_SegmentReader_dataLength_set(PyObject *SWIGUNUSE
   }
   arg1 = reinterpret_cast< _nitf_SegmentReader * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   if (arg1) (arg1)->dataLength = arg2;
   resultobj = SWIG_Py_Void();
@@ -28672,7 +28672,7 @@ SWIGINTERN PyObject *_wrap_nitf_SegmentReader_dataLength_get(PyObject *SWIGUNUSE
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_SegmentReader_dataLength_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_SegmentReader, 0 |  0 );
@@ -28693,7 +28693,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_SegmentReader_baseOffset_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_SegmentReader *arg1 = (_nitf_SegmentReader *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -28710,12 +28710,12 @@ SWIGINTERN PyObject *_wrap_nitf_SegmentReader_baseOffset_set(PyObject *SWIGUNUSE
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_SegmentReader_baseOffset_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_SegmentReader_baseOffset_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_SegmentReader_baseOffset_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_SegmentReader_baseOffset_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -28734,7 +28734,7 @@ SWIGINTERN PyObject *_wrap_nitf_SegmentReader_baseOffset_get(PyObject *SWIGUNUSE
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_SegmentReader_baseOffset_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_SegmentReader, 0 |  0 );
@@ -28743,7 +28743,7 @@ SWIGINTERN PyObject *_wrap_nitf_SegmentReader_baseOffset_get(PyObject *SWIGUNUSE
   }
   arg1 = reinterpret_cast< _nitf_SegmentReader * >(argp1);
   result =  ((arg1)->baseOffset);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -28753,7 +28753,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_SegmentReader_virtualOffset_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_SegmentReader *arg1 = (_nitf_SegmentReader *) 0 ;
-  nitf_Uint64 arg2 ;
+  uint64_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
@@ -28770,12 +28770,12 @@ SWIGINTERN PyObject *_wrap_nitf_SegmentReader_virtualOffset_set(PyObject *SWIGUN
   {
     res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
     if (!SWIG_IsOK(res2)) {
-      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_SegmentReader_virtualOffset_set" "', argument " "2"" of type '" "nitf_Uint64""'"); 
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_SegmentReader_virtualOffset_set" "', argument " "2"" of type '" "uint64_t""'"); 
     }  
     if (!argp2) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_SegmentReader_virtualOffset_set" "', argument " "2"" of type '" "nitf_Uint64""'");
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "nitf_SegmentReader_virtualOffset_set" "', argument " "2"" of type '" "uint64_t""'");
     } else {
-      nitf_Uint64 * temp = reinterpret_cast< nitf_Uint64 * >(argp2);
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
       arg2 = *temp;
       if (SWIG_IsNewObj(res2)) delete temp;
     }
@@ -28794,7 +28794,7 @@ SWIGINTERN PyObject *_wrap_nitf_SegmentReader_virtualOffset_get(PyObject *SWIGUN
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint64 result;
+  uint64_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_SegmentReader_virtualOffset_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_SegmentReader, 0 |  0 );
@@ -28803,7 +28803,7 @@ SWIGINTERN PyObject *_wrap_nitf_SegmentReader_virtualOffset_get(PyObject *SWIGUN
   }
   arg1 = reinterpret_cast< _nitf_SegmentReader * >(argp1);
   result =  ((arg1)->virtualOffset);
-  resultobj = SWIG_NewPointerObj((new nitf_Uint64(static_cast< const nitf_Uint64& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -29085,7 +29085,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_SubWindow_startRow_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_SubWindow *arg1 = (_nitf_SubWindow *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -29098,7 +29098,7 @@ SWIGINTERN PyObject *_wrap_nitf_SubWindow_startRow_set(PyObject *SWIGUNUSEDPARM(
   }
   arg1 = reinterpret_cast< _nitf_SubWindow * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   if (arg1) (arg1)->startRow = arg2;
   resultobj = SWIG_Py_Void();
@@ -29114,7 +29114,7 @@ SWIGINTERN PyObject *_wrap_nitf_SubWindow_startRow_get(PyObject *SWIGUNUSEDPARM(
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_SubWindow_startRow_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_SubWindow, 0 |  0 );
@@ -29135,7 +29135,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_SubWindow_startCol_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_SubWindow *arg1 = (_nitf_SubWindow *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -29148,7 +29148,7 @@ SWIGINTERN PyObject *_wrap_nitf_SubWindow_startCol_set(PyObject *SWIGUNUSEDPARM(
   }
   arg1 = reinterpret_cast< _nitf_SubWindow * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   if (arg1) (arg1)->startCol = arg2;
   resultobj = SWIG_Py_Void();
@@ -29164,7 +29164,7 @@ SWIGINTERN PyObject *_wrap_nitf_SubWindow_startCol_get(PyObject *SWIGUNUSEDPARM(
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_SubWindow_startCol_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_SubWindow, 0 |  0 );
@@ -29185,7 +29185,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_SubWindow_numRows_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_SubWindow *arg1 = (_nitf_SubWindow *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -29198,7 +29198,7 @@ SWIGINTERN PyObject *_wrap_nitf_SubWindow_numRows_set(PyObject *SWIGUNUSEDPARM(s
   }
   arg1 = reinterpret_cast< _nitf_SubWindow * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   if (arg1) (arg1)->numRows = arg2;
   resultobj = SWIG_Py_Void();
@@ -29214,7 +29214,7 @@ SWIGINTERN PyObject *_wrap_nitf_SubWindow_numRows_get(PyObject *SWIGUNUSEDPARM(s
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_SubWindow_numRows_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_SubWindow, 0 |  0 );
@@ -29235,7 +29235,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_SubWindow_numCols_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_SubWindow *arg1 = (_nitf_SubWindow *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -29248,7 +29248,7 @@ SWIGINTERN PyObject *_wrap_nitf_SubWindow_numCols_set(PyObject *SWIGUNUSEDPARM(s
   }
   arg1 = reinterpret_cast< _nitf_SubWindow * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   if (arg1) (arg1)->numCols = arg2;
   resultobj = SWIG_Py_Void();
@@ -29264,7 +29264,7 @@ SWIGINTERN PyObject *_wrap_nitf_SubWindow_numCols_get(PyObject *SWIGUNUSEDPARM(s
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_SubWindow_numCols_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_SubWindow, 0 |  0 );
@@ -29285,7 +29285,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_SubWindow_bandList_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_SubWindow *arg1 = (_nitf_SubWindow *) 0 ;
-  nitf_Uint32 *arg2 = (nitf_Uint32 *) 0 ;
+  uint32_t *arg2 = (uint32_t *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 = 0 ;
@@ -29301,9 +29301,9 @@ SWIGINTERN PyObject *_wrap_nitf_SubWindow_bandList_set(PyObject *SWIGUNUSEDPARM(
   arg1 = reinterpret_cast< _nitf_SubWindow * >(argp1);
   res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint32_t, SWIG_POINTER_DISOWN |  0 );
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_SubWindow_bandList_set" "', argument " "2"" of type '" "nitf_Uint32 *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "nitf_SubWindow_bandList_set" "', argument " "2"" of type '" "uint32_t *""'"); 
   }
-  arg2 = reinterpret_cast< nitf_Uint32 * >(argp2);
+  arg2 = reinterpret_cast< uint32_t * >(argp2);
   if (arg1) (arg1)->bandList = arg2;
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -29318,7 +29318,7 @@ SWIGINTERN PyObject *_wrap_nitf_SubWindow_bandList_get(PyObject *SWIGUNUSEDPARM(
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint32 *result = 0 ;
+  uint32_t *result = 0 ;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_SubWindow_bandList_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_SubWindow, 0 |  0 );
@@ -29326,7 +29326,7 @@ SWIGINTERN PyObject *_wrap_nitf_SubWindow_bandList_get(PyObject *SWIGUNUSEDPARM(
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "nitf_SubWindow_bandList_get" "', argument " "1"" of type '" "_nitf_SubWindow *""'"); 
   }
   arg1 = reinterpret_cast< _nitf_SubWindow * >(argp1);
-  result = (nitf_Uint32 *) ((arg1)->bandList);
+  result = (uint32_t *) ((arg1)->bandList);
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uint32_t, 0 |  0 );
   return resultobj;
 fail:
@@ -29337,7 +29337,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_SubWindow_numBands_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_SubWindow *arg1 = (_nitf_SubWindow *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -29350,7 +29350,7 @@ SWIGINTERN PyObject *_wrap_nitf_SubWindow_numBands_set(PyObject *SWIGUNUSEDPARM(
   }
   arg1 = reinterpret_cast< _nitf_SubWindow * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   if (arg1) (arg1)->numBands = arg2;
   resultobj = SWIG_Py_Void();
@@ -29366,7 +29366,7 @@ SWIGINTERN PyObject *_wrap_nitf_SubWindow_numBands_get(PyObject *SWIGUNUSEDPARM(
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_SubWindow_numBands_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_SubWindow, 0 |  0 );
@@ -29732,7 +29732,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_DownSampler_rowSkip_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_DownSampler *arg1 = (_nitf_DownSampler *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -29745,7 +29745,7 @@ SWIGINTERN PyObject *_wrap_nitf_DownSampler_rowSkip_set(PyObject *SWIGUNUSEDPARM
   }
   arg1 = reinterpret_cast< _nitf_DownSampler * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   if (arg1) (arg1)->rowSkip = arg2;
   resultobj = SWIG_Py_Void();
@@ -29761,7 +29761,7 @@ SWIGINTERN PyObject *_wrap_nitf_DownSampler_rowSkip_get(PyObject *SWIGUNUSEDPARM
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_DownSampler_rowSkip_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_DownSampler, 0 |  0 );
@@ -29782,7 +29782,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_DownSampler_colSkip_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_DownSampler *arg1 = (_nitf_DownSampler *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -29795,7 +29795,7 @@ SWIGINTERN PyObject *_wrap_nitf_DownSampler_colSkip_set(PyObject *SWIGUNUSEDPARM
   }
   arg1 = reinterpret_cast< _nitf_DownSampler * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   if (arg1) (arg1)->colSkip = arg2;
   resultobj = SWIG_Py_Void();
@@ -29811,7 +29811,7 @@ SWIGINTERN PyObject *_wrap_nitf_DownSampler_colSkip_get(PyObject *SWIGUNUSEDPARM
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_DownSampler_colSkip_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_DownSampler, 0 |  0 );
@@ -29884,7 +29884,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_DownSampler_minBands_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_DownSampler *arg1 = (_nitf_DownSampler *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -29897,7 +29897,7 @@ SWIGINTERN PyObject *_wrap_nitf_DownSampler_minBands_set(PyObject *SWIGUNUSEDPAR
   }
   arg1 = reinterpret_cast< _nitf_DownSampler * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   if (arg1) (arg1)->minBands = arg2;
   resultobj = SWIG_Py_Void();
@@ -29913,7 +29913,7 @@ SWIGINTERN PyObject *_wrap_nitf_DownSampler_minBands_get(PyObject *SWIGUNUSEDPAR
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_DownSampler_minBands_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_DownSampler, 0 |  0 );
@@ -29934,7 +29934,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_DownSampler_maxBands_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_DownSampler *arg1 = (_nitf_DownSampler *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -29947,7 +29947,7 @@ SWIGINTERN PyObject *_wrap_nitf_DownSampler_maxBands_set(PyObject *SWIGUNUSEDPAR
   }
   arg1 = reinterpret_cast< _nitf_DownSampler * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   if (arg1) (arg1)->maxBands = arg2;
   resultobj = SWIG_Py_Void();
@@ -29963,7 +29963,7 @@ SWIGINTERN PyObject *_wrap_nitf_DownSampler_maxBands_get(PyObject *SWIGUNUSEDPAR
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_DownSampler_maxBands_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_DownSampler, 0 |  0 );
@@ -29984,7 +29984,7 @@ fail:
 SWIGINTERN PyObject *_wrap_nitf_DownSampler_types_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   _nitf_DownSampler *arg1 = (_nitf_DownSampler *) 0 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -29997,7 +29997,7 @@ SWIGINTERN PyObject *_wrap_nitf_DownSampler_types_set(PyObject *SWIGUNUSEDPARM(s
   }
   arg1 = reinterpret_cast< _nitf_DownSampler * >(argp1);
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   if (arg1) (arg1)->types = arg2;
   resultobj = SWIG_Py_Void();
@@ -30013,7 +30013,7 @@ SWIGINTERN PyObject *_wrap_nitf_DownSampler_types_get(PyObject *SWIGUNUSEDPARM(s
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"O:nitf_DownSampler_types_get",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_DownSampler, 0 |  0 );
@@ -30111,8 +30111,8 @@ SWIGINTERN PyObject *nitf_DownSampler_swigregister(PyObject *SWIGUNUSEDPARM(self
 
 SWIGINTERN PyObject *_wrap_nitf_PixelSkip_construct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  nitf_Uint32 arg1 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg1 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp3 = 0 ;
   int res3 = 0 ;
@@ -30123,10 +30123,10 @@ SWIGINTERN PyObject *_wrap_nitf_PixelSkip_construct(PyObject *SWIGUNUSEDPARM(sel
   
   if (!PyArg_ParseTuple(args,(char *)"OOO:nitf_PixelSkip_construct",&obj0,&obj1,&obj2)) SWIG_fail;
   {
-    arg1 = (nitf_Uint32)PyInt_AsLong(obj0);
+    arg1 = (uint32_t)PyInt_AsLong(obj0);
   }
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -30143,8 +30143,8 @@ fail:
 
 SWIGINTERN PyObject *_wrap_nitf_MaxDownSample_construct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  nitf_Uint32 arg1 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg1 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp3 = 0 ;
   int res3 = 0 ;
@@ -30155,10 +30155,10 @@ SWIGINTERN PyObject *_wrap_nitf_MaxDownSample_construct(PyObject *SWIGUNUSEDPARM
   
   if (!PyArg_ParseTuple(args,(char *)"OOO:nitf_MaxDownSample_construct",&obj0,&obj1,&obj2)) SWIG_fail;
   {
-    arg1 = (nitf_Uint32)PyInt_AsLong(obj0);
+    arg1 = (uint32_t)PyInt_AsLong(obj0);
   }
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -30175,8 +30175,8 @@ fail:
 
 SWIGINTERN PyObject *_wrap_nitf_SumSq2DownSample_construct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  nitf_Uint32 arg1 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg1 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp3 = 0 ;
   int res3 = 0 ;
@@ -30187,10 +30187,10 @@ SWIGINTERN PyObject *_wrap_nitf_SumSq2DownSample_construct(PyObject *SWIGUNUSEDP
   
   if (!PyArg_ParseTuple(args,(char *)"OOO:nitf_SumSq2DownSample_construct",&obj0,&obj1,&obj2)) SWIG_fail;
   {
-    arg1 = (nitf_Uint32)PyInt_AsLong(obj0);
+    arg1 = (uint32_t)PyInt_AsLong(obj0);
   }
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -30207,8 +30207,8 @@ fail:
 
 SWIGINTERN PyObject *_wrap_nitf_Select2DownSample_construct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  nitf_Uint32 arg1 ;
-  nitf_Uint32 arg2 ;
+  uint32_t arg1 ;
+  uint32_t arg2 ;
   nitf_Error *arg3 = (nitf_Error *) 0 ;
   void *argp3 = 0 ;
   int res3 = 0 ;
@@ -30219,10 +30219,10 @@ SWIGINTERN PyObject *_wrap_nitf_Select2DownSample_construct(PyObject *SWIGUNUSED
   
   if (!PyArg_ParseTuple(args,(char *)"OOO:nitf_Select2DownSample_construct",&obj0,&obj1,&obj2)) SWIG_fail;
   {
-    arg1 = (nitf_Uint32)PyInt_AsLong(obj0);
+    arg1 = (uint32_t)PyInt_AsLong(obj0);
   }
   {
-    arg2 = (nitf_Uint32)PyInt_AsLong(obj1);
+    arg2 = (uint32_t)PyInt_AsLong(obj1);
   }
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p__NRT_Error, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
@@ -30918,8 +30918,8 @@ SWIGINTERN PyObject *_wrap_nitf_BandInfo_init(PyObject *SWIGUNUSEDPARM(self), Py
   char *arg3 = (char *) 0 ;
   char *arg4 = (char *) 0 ;
   char *arg5 = (char *) 0 ;
-  nitf_Uint32 arg6 ;
-  nitf_Uint32 arg7 ;
+  uint32_t arg6 ;
+  uint32_t arg7 ;
   nitf_LookupTable *arg8 = (nitf_LookupTable *) 0 ;
   nitf_Error *arg9 = (nitf_Error *) 0 ;
   void *argp1 = 0 ;
@@ -30978,10 +30978,10 @@ SWIGINTERN PyObject *_wrap_nitf_BandInfo_init(PyObject *SWIGUNUSEDPARM(self), Py
   }
   arg5 = reinterpret_cast< char * >(buf5);
   {
-    arg6 = (nitf_Uint32)PyInt_AsLong(obj5);
+    arg6 = (uint32_t)PyInt_AsLong(obj5);
   }
   {
-    arg7 = (nitf_Uint32)PyInt_AsLong(obj6);
+    arg7 = (uint32_t)PyInt_AsLong(obj6);
   }
   res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_nitf_LookupTable, 0 |  0 );
   if (!SWIG_IsOK(res8)) {
@@ -31210,7 +31210,7 @@ SWIGINTERN PyObject *_wrap_py_Field_getInt(PyObject *SWIGUNUSEDPARM(self), PyObj
   int res2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
-  nitf_Uint32 result;
+  uint32_t result;
   
   if (!PyArg_ParseTuple(args,(char *)"OO:py_Field_getInt",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p__nitf_Field, 0 |  0 );
@@ -33429,10 +33429,10 @@ static swig_type_info _swigt__p_f_p_void_p_q_const__void_size_t_p__NRT_Error__bo
 static swig_type_info _swigt__p_f_p_void_p_void_off_t_p__NRT_Error__bool = {"_p_f_p_void_p_void_off_t_p__NRT_Error__bool", "bool (*)(void *,void *,off_t,_NRT_Error *)|NITF_IDATASOURCE_READ", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_f_p_void_p_void_size_t_p__NRT_Error__bool = {"_p_f_p_void_p_void_size_t_p__NRT_Error__bool", "bool (*)(void *,void *,size_t,_NRT_Error *)|NRT_IO_INTERFACE_READ", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_int = {"_p_int", "int *|nrt_IOHandle *|nitf_IOHandle *|nrt_CreationFlags *|nitf_CreationFlags *|nrt_AccessFlags *|nitf_AccessFlags *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_int16_t = {"_p_int16_t", "int16_t *|nitf_Int16 *|int16_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_int32_t = {"_p_int32_t", "int32_t *|int32_t *|nitf_Int32 *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_int64_t = {"_p_int64_t", "int64_t *|int64_t *|nitf_Int64 *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_int8_t = {"_p_int8_t", "int8_t *|nitf_Int8 *|int8_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_int16_t = {"_p_int16_t", "int16_t *|int16_t *|int16_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_int32_t = {"_p_int32_t", "int32_t *|int32_t *|int32_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_int64_t = {"_p_int64_t", "int64_t *|int64_t *|int64_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_int8_t = {"_p_int8_t", "int8_t *|int8_t *|int8_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_nitf_BlockingInfo = {"_p_nitf_BlockingInfo", "nitf_BlockingInfo *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_nitf_CompressionInterface = {"_p_nitf_CompressionInterface", "nitf_CompressionInterface *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_nitf_FieldWarning = {"_p_nitf_FieldWarning", "nitf_FieldWarning *", 0, 0, (void*)0, 0};
@@ -33492,12 +33492,12 @@ static swig_type_info _swigt__p_p_f_p_void_p_q_const__void_size_t_p__NRT_Error__
 static swig_type_info _swigt__p_p_f_p_void_p_void_size_t_p__NRT_Error__bool = {"_p_p_f_p_void_p_void_size_t_p__NRT_Error__bool", "bool (**)(void *,void *,size_t,_NRT_Error *)|NITF_IO_INTERFACE_READ *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_nitf_WriteHandler = {"_p_p_nitf_WriteHandler", "nitf_WriteHandler **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_nrt_List = {"_p_p_nrt_List", "nrt_List **", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_p_uint8_t = {"_p_p_uint8_t", "uint8_t **|nitf_Uint8 **", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_p_uint8_t = {"_p_p_uint8_t", "uint8_t **|uint8_t **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_void = {"_p_p_void", "NITF_DLL_FUNCTION_PTR *|NITF_NATIVE_DLL *|void **", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_uint16_t = {"_p_uint16_t", "uint16_t *|nitf_Uint16 *|uint16_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_uint32_t = {"_p_uint32_t", "uint32_t *|uint32_t *|nitf_Uint32 *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_uint64_t = {"_p_uint64_t", "uint64_t *|uint64_t *|nitf_Uint64 *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_uint8_t = {"_p_uint8_t", "uint8_t *|nitf_Uint8 *|uint8_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_uint16_t = {"_p_uint16_t", "uint16_t *|uint16_t *|uint16_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_uint32_t = {"_p_uint32_t", "uint32_t *|uint32_t *|uint32_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_uint64_t = {"_p_uint64_t", "uint64_t *|uint64_t *|uint64_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_uint8_t = {"_p_uint8_t", "uint8_t *|uint8_t *|uint8_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_void = {"_p_void", "NRT_DATA *|NITF_DATA *|void *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {

--- a/modules/python/nitf/source/nitro.i
+++ b/modules/python/nitf/source/nitro.i
@@ -56,8 +56,8 @@
     }
 
 
-%typemap(out) nitf_Uint32, nitf_Int32{$result = PyInt_FromLong($1);}
-%typemap(in) nitf_Uint32{$1 = (nitf_Uint32)PyInt_AsLong($input);}
+%typemap(out) uint32_t, int32_t{$result = PyInt_FromLong($1);}
+%typemap(in) uint32_t{$1 = (uint32_t)PyInt_AsLong($input);}
 %typemap(out) nitf_Off{$result = PyLong_FromLong($1);}
 %typemap(in) nitf_Off{$1 = (nitf_Off)PyLong_AsLong($input);}
 
@@ -189,7 +189,7 @@
 }
 
 
-%typemap(out) nitf_Uint8 {$result = SWIG_From_char((char)($1));}
+%typemap(out) uint8_t {$result = SWIG_From_char((char)($1));}
 
 /* NRT_FILE is supposed to expand to the current source file during
  * preprocessing (and similar with the other ignored values below).
@@ -364,9 +364,9 @@
         return buf;
     }
 
-    nitf_Uint32 py_Field_getInt(nitf_Field *field, nitf_Error *error)
+    uint32_t py_Field_getInt(nitf_Field *field, nitf_Error *error)
     {
-        nitf_Uint32 intVal;
+        uint32_t intVal;
         NITF_TRY_GET_UINT32(field, &intVal, error);
         return intVal;
 
@@ -478,7 +478,7 @@
 
     nitf_ComponentInfo* py_FileHeader_getComponentInfo(nitf_FileHeader* header, int index, char* type, nitf_Error* error)
     {
-        nitf_Uint32 num;
+        uint32_t num;
 
         if (!type)
         	goto CATCH_ERROR;
@@ -579,7 +579,7 @@
 
         window->numBands = PySequence_Length(bandList);
         if (window->numBands < 0) window->numBands = 0;
-        window->bandList = (nitf_Uint32*)NITF_MALLOC(sizeof(nitf_Uint32) * window->numBands);
+        window->bandList = (uint32_t*)NITF_MALLOC(sizeof(uint32_t) * window->numBands);
         if (!window->bandList)
         {
             PyErr_NoMemory();
@@ -605,17 +605,17 @@
     PyObject* py_ImageReader_read(nitf_ImageReader* reader, nitf_SubWindow* window, int nbpp, nitf_Error* error)
     {
         /* TODO somehow get the NUMBITSPERPIXEL in the future */
-        nitf_Uint8 **buf = NULL;
-        nitf_Uint8 *pyArrayBuffer = NULL;
+        uint8_t **buf = NULL;
+        uint8_t *pyArrayBuffer = NULL;
         PyObject* result = Py_None;
         int padded, rowSkip, colSkip;
-        nitf_Uint64 subimageSize;
-        nitf_Uint32 i;
+        uint64_t subimageSize;
+        uint32_t i;
         types::RowCol<size_t> dims;
 
         rowSkip = window->downsampler ? window->downsampler->rowSkip : 1;
         colSkip = window->downsampler ? window->downsampler->colSkip : 1;
-        subimageSize = static_cast<nitf_Uint64>(window->numRows/rowSkip) *
+        subimageSize = static_cast<uint64_t>(window->numRows/rowSkip) *
                 (window->numCols/colSkip) *
                 nitf_ImageIO_pixelSize(reader->imageDeblocker);
         if (subimageSize > std::numeric_limits<size_t>::max())
@@ -631,18 +631,18 @@
 
         numpyutils::createOrVerify(result, NPY_UINT8, dims);
 
-        buf = (nitf_Uint8**) NITF_MALLOC(sizeof(nitf_Uint8*) * window->numBands);
+        buf = (uint8_t**) NITF_MALLOC(sizeof(uint8_t*) * window->numBands);
         if (!buf)
         {
             PyErr_NoMemory();
             goto CATCH_ERROR;
         }
 
-        memset(buf, 0, sizeof(nitf_Uint8*) * window->numBands);
+        memset(buf, 0, sizeof(uint8_t*) * window->numBands);
 
         for (i = 0; i < window->numBands; ++i)
         {
-            buf[i] = (nitf_Uint8*) NITF_MALLOC(sizeof(nitf_Uint8) * subimageSize);
+            buf[i] = (uint8_t*) NITF_MALLOC(sizeof(uint8_t) * subimageSize);
             if (!buf[i])
             {
                 PyErr_NoMemory();
@@ -659,11 +659,11 @@
         }
 
         // Copy to output numpy array
-        pyArrayBuffer = numpyutils::getBuffer<nitf_Uint8>(result);
+        pyArrayBuffer = numpyutils::getBuffer<uint8_t>(result);
         for (i = 0; i < window->numBands; ++i)
         {
             memcpy(pyArrayBuffer + i * subimageSize,
-                   buf[i], sizeof(nitf_Uint8) * subimageSize);
+                   buf[i], sizeof(uint8_t) * subimageSize);
         }
 
         for (i = 0; i < window->numBands; ++i)


### PR DESCRIPTION
Use Standard C types (e.g., `int32_t`) rather than our own homebrew `typedef`s.