### PR TITLE
Work around Windows defining min and max macros

### DIFF
--- a/externals/coda-oss/modules/c++/str/include/str/Convert.h
+++ b/externals/coda-oss/modules/c++/str/include/str/Convert.h
@@ -121,6 +121,13 @@ unsigned long long strtoull(const char* str, char** endptr, int base);
 template <typename T>
 T toType(const std::string& s, int base)
 {
+    // This file has issues in Windows builds,
+    // because Windows defines min and max as function-like macros.
+    // This causes syntax errors in expressions like std::numeric_limits<T>::min() .
+    // Putting parentheses around the entire class-qualified function name
+    // prevents its evaluation as a macro.
+    // This is a less intrusive solution than defining macros like NOMINMAX.
+
     char* end;
     errno = 0;
     const char* str = s.c_str();
@@ -130,8 +137,8 @@ T toType(const std::string& s, int base)
     if (std::numeric_limits<T>::is_signed)
     {
         const long long longRes = str::strtoll(str, &end, base);
-        if (longRes < static_cast<long long>(std::numeric_limits<T>::min()) ||
-            longRes > static_cast<long long>(std::numeric_limits<T>::max()))
+        if (longRes < static_cast<long long>((std::numeric_limits<T>::min)()) ||
+            longRes > static_cast<long long>((std::numeric_limits<T>::max)()))
         {
             overflow = true;
         }
@@ -141,9 +148,9 @@ T toType(const std::string& s, int base)
     {
         const unsigned long long longRes = str::strtoull(str, &end, base);
         if (longRes < static_cast<unsigned long long>(
-                              std::numeric_limits<T>::min()) ||
+                              (std::numeric_limits<T>::min)()) ||
             longRes > static_cast<unsigned long long>(
-                              std::numeric_limits<T>::max()))
+                              (std::numeric_limits<T>::max)()))
         {
             overflow = true;
         }


### PR DESCRIPTION
Windows defines `min` and `max` as function-like macros.  This causes syntax errors in expressions `std::numeric_limits<T>::min()` and `std::numeric_limits<T>::max()` that were used in this header file (before this change).  Putting parentheses around the entire class-qualified function name prevents its evaluation as a macro.

Another solution would be to define the `NOMINMAX` macro.  However, that would require changing builds for all code that includes this header, or includes a header that includes this header.

We particularly experienced build errors with Microsoft Visual Studio 2019 16.7, and 16.8 preview 3.  However, this issue could arise with other Windows compilers, depending on the order of includes.