### PR TITLE
java: update to supported version

### DIFF
--- a/modules/java/CMakeLists.txt
+++ b/modules/java/CMakeLists.txt
@@ -28,7 +28,7 @@ if (NOT JNI_FOUND)
 elseif(NOT Java_FOUND)
     message(WARNING "Java SDK not found. Skipping Java modules")
 else()
-    set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.5" "-target" "1.5")
+    set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.8" "-target" "1.8" "-Xlint:deprecation" "-Xlint:-options")
 
     set(coda_jars "${CODA-OSS_JARS_DIR}/commons-io-1.3.2.jar"
                   "${CODA-OSS_JARS_DIR}/commons-cli-1.0-beta-2.jar"

--- a/modules/java/nitf.imageio/src/java/nitf/imageio/ImageIOUtils.java
+++ b/modules/java/nitf.imageio/src/java/nitf/imageio/ImageIOUtils.java
@@ -66,8 +66,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import sun.awt.image.SunWritableRaster;
-
 public class ImageIOUtils
 {
 
@@ -392,8 +390,7 @@ public class ImageIOUtils
         BandedSampleModel bsm = new BandedSampleModel(dataType, numElems,
                 numLines, bandOffsets.length, bandOffsets, bandOffsets);
 
-        SunWritableRaster ras = new SunWritableRaster(bsm, d, new Point(0, 0));
-        return ras;
+        return Raster.createWritableRaster(bsm, d, new Point(0, 0));
     }
 
     /**
@@ -433,8 +430,7 @@ public class ImageIOUtils
                 dataType, numElems, numLines, bandOffsets.length, numElems
                         * bandOffsets.length, bandOffsets);
 
-        SunWritableRaster ras = new SunWritableRaster(pism, d, new Point(0, 0));
-        return ras;
+        return Raster.createWritableRaster(pism, d, new Point(0, 0));
     }
 
     /**

--- a/modules/java/nitf.imageio/src/java/nitf/imageio/NITFReader.java
+++ b/modules/java/nitf.imageio/src/java/nitf/imageio/NITFReader.java
@@ -151,7 +151,7 @@ public class NITFReader extends ImageReader
     {
         checkIndex(imageIndex);
 
-        Integer key = new Integer(imageIndex);
+        Integer key = Integer.valueOf(imageIndex);
         try
         {
             if (!imageReaderMap.containsKey(key))

--- a/modules/java/nitf/src/java/nitf/BandSource.java
+++ b/modules/java/nitf/src/java/nitf/BandSource.java
@@ -123,7 +123,7 @@ public abstract class BandSource extends DestructibleObject
         BandSource source = null;
         synchronized (bandSourceMap)
         {
-            final Object o = bandSourceMap.get(new Long(address));
+            final Object o = bandSourceMap.get(Long.valueOf(address));
             if (o != null)
             {
                 source = (BandSource) o;
@@ -141,7 +141,7 @@ public abstract class BandSource extends DestructibleObject
     {
         synchronized (bandSourceMap)
         {
-            final Long key = new Long(bandSource.getAddress());
+            final Long key = Long.valueOf(bandSource.getAddress());
             if (!bandSourceMap.containsKey(key))
                 bandSourceMap.put(key, bandSource);
         }

--- a/modules/java/nitf/src/java/nitf/DownSampler.java
+++ b/modules/java/nitf/src/java/nitf/DownSampler.java
@@ -202,7 +202,7 @@ public abstract class DownSampler extends DestructibleObject
         DownSampler downSampler = null;
         synchronized (downSamplerMap)
         {
-            final Object o = downSamplerMap.get(new Long(address));
+            final Object o = downSamplerMap.get(Long.valueOf(address));
             if (o != null)
             {
                 downSampler = (DownSampler) o;
@@ -220,7 +220,7 @@ public abstract class DownSampler extends DestructibleObject
     {
         synchronized (downSamplerMap)
         {
-            final Long key = new Long(downSampler.getAddress());
+            final Long key = Long.valueOf(downSampler.getAddress());
             if (!downSamplerMap.containsKey(key))
                 downSamplerMap.put(key, downSampler);
         }

--- a/modules/java/nitf/src/java/nitf/NITFObject.java
+++ b/modules/java/nitf/src/java/nitf/NITFObject.java
@@ -131,7 +131,6 @@ public abstract class NITFObject
     @Override
     protected void finalize() throws Throwable
     {
-        super.finalize();
         address = INVALID_ADDRESS;
     }
 }


### PR DESCRIPTION
While trying to build on a new Ubuntu box with openjdk 11 (`javac 11.0.8`), I hit a problem:

```
[ 99%] Building Java objects for nitf-java.jar
warning: [options] bootstrap class path not set in conjunction with -source 5
error: Source option 5 is no longer supported. Use 6 or later.
error: Target option 1.5 is no longer supported. Use 1.6 or later.
make[2]: *** [modules/java/nitf/CMakeFiles/nitf-java.dir/build.make:133: modules/java/nitf/CMakeFiles/nitf-java.dir/java_compiled_nitf-java] Error 2
make[1]: *** [CMakeFiles/Makefile2:12293: modules/java/nitf/CMakeFiles/nitf-java.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```

This PR updates to 1.8, and fixes some warnings associated with that. There is more that could be done, but this gets it going again.
