### PR TITLE
tre: add MATESA support

### DIFF
--- a/modules/c/nitf/CMakeLists.txt
+++ b/modules/c/nitf/CMakeLists.txt
@@ -115,6 +115,7 @@ set(tre_srcs  ACCHZB
               J2KLRA
               JITCID
               MAPLOB
+              MATESA
               MENSRA
               MENSRB
               MPDSRA

--- a/modules/c/nitf/shared/MATESA.c
+++ b/modules/c/nitf/shared/MATESA.c
@@ -1,0 +1,51 @@
+/* =========================================================================
+ * This file is part of NITRO
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ * (C) Copyright 2020, Brad Hards <bradh@frogmouth.net>
+ *
+ * NITRO is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#include <import/nitf.h>
+
+NITF_CXX_GUARD
+
+/* From STDI-0002-1 Appendix AK: Table AK.6-5: MATESA */
+static nitf_TREDescription description[] = {
+    {NITF_BCS_A, 42, "Current File/Segment Source", "CUR_SOURCE" },
+    {NITF_BCS_A, 16, "Current File/Segment Mate Type", "CUR_MATE_TYPE" },
+    {NITF_BCS_N, 4, "Length of the CUR_FILE_ID field", "CUR_FILE_ID_LEN" },
+    {NITF_BCS_A, NITF_TRE_CONDITIONAL_LENGTH, "ID of the Current File/Segment", "CUR_FILE_ID", "CUR_FILE_ID_LEN" },
+    {NITF_BCS_N, 4, "Number of Mate Relationship Groups", "NUM_GROUPS" },
+    {NITF_LOOP, 0, NULL, "NUM_GROUPS" },
+        {NITF_BCS_A, 24, "Mate Relationship", "RELATIONSHIP" },
+        {NITF_BCS_N, 4, "Number of Mates in the Group", "NUM_MATES" },
+        {NITF_LOOP, 0, NULL, "NUM_MATES" },
+            {NITF_BCS_A, 42, "Mate Source", "SOURCE" },
+            {NITF_BCS_A, 16, "Mate Identifier Type", "MATE_TYPE" },
+            {NITF_BCS_N, 4, "Length of the MATE_ID field", "MATE_ID_LEN" },
+            {NITF_BCS_A, NITF_TRE_CONDITIONAL_LENGTH, "Mate File Identifier", "MATE_ID", "MATE_ID_LEN" },
+        {NITF_ENDLOOP, 0, NULL, NULL },
+    {NITF_ENDLOOP, 0, NULL, NULL },
+    {NITF_END, 0, NULL, NULL },
+};
+
+NITF_DECLARE_SINGLE_PLUGIN(MATESA, description)
+
+NITF_CXX_ENDGUARD


### PR DESCRIPTION
This TRE is defined in STDI-0002-1 Appendix AK: "MATESA 1.0" and is used in the SNIP Reference Implementation Products (RIPs). 

Here is a sample of the output:
```
--------------- MATESA TRE (897) - (MATESA) ---------------
CUR_SOURCE (Current File/Segment Source) = [EO-1_HYPERION                             ]
CUR_MATE_TYPE (Current File/Segment Mate Type) = [FTITLE          ]
CUR_FILE_ID_LEN (Length of the CUR_FILE_ID field) = [0063]
CUR_FILE_ID (ID of the Current File/Segment) = [07APR2005_Hyperion_331406N0442000E_SWIR172_001_L1R-01B-BIP-GLAS]
NUM_GROUPS (Number of Mate Relationship Groups) = [0005]
RELATIONSHIP[0] (Mate Relationship) = [RADIOMTRC_CALIB         ]
NUM_MATES[0] (Number of Mates in the Group) = [0001]
SOURCE[0][0] (Mate Source) = [EO-1_HYPERION                             ]
MATE_TYPE[0][0] (Mate Identifier Type) = [FILENAME        ]
MATE_ID_LEN[0][0] (Length of the MATE_ID field) = [0020]
MATE_ID[0][0] (Mate File Identifier) = [HypGain_revC.dat.svf]
RELATIONSHIP[1] (Mate Relationship) = [PARENT                  ]
NUM_MATES[1] (Number of Mates in the Group) = [0001]
SOURCE[1][0] (Mate Source) = [EO-1_HYPERION                             ]
MATE_TYPE[1][0] (Mate Identifier Type) = [FILENAME        ]
MATE_ID_LEN[1][0] (Length of the MATE_ID field) = [0032]
MATE_ID[1][0] (Mate File Identifier) = [EO12005097_020D020C_r1_WPS_01.L0]
RELATIONSHIP[2] (Mate Relationship) = [PRE_DARKCOLLECT         ]
NUM_MATES[2] (Number of Mates in the Group) = [0001]
SOURCE[2][0] (Mate Source) = [EO-1_HYPERION                             ]
MATE_TYPE[2][0] (Mate Identifier Type) = [FILENAME        ]
MATE_ID_LEN[2][0] (Length of the MATE_ID field) = [0032]
MATE_ID[2][0] (Mate File Identifier) = [EO12005097_020A0209_r1_WPS_01.L0]
RELATIONSHIP[3] (Mate Relationship) = [POST_DARKCOLLECT        ]
NUM_MATES[3] (Number of Mates in the Group) = [0001]
SOURCE[3][0] (Mate Source) = [EO-1_HYPERION                             ]
MATE_TYPE[3][0] (Mate Identifier Type) = [FILENAME        ]
MATE_ID_LEN[3][0] (Length of the MATE_ID field) = [0032]
MATE_ID[3][0] (Mate File Identifier) = [EO12005097_020F020E_r1_WPS_01.L0]
RELATIONSHIP[4] (Mate Relationship) = [PARENT                  ]
NUM_MATES[4] (Number of Mates in the Group) = [0003]
SOURCE[4][0] (Mate Source) = [EO-1_HYPERION                             ]
MATE_TYPE[4][0] (Mate Identifier Type) = [FILENAME        ]
MATE_ID_LEN[4][0] (Length of the MATE_ID field) = [0026]
MATE_ID[4][0] (Mate File Identifier) = [EO1H1680372005097110PZ.L1R]
SOURCE[4][1] (Mate Source) = [EO-1_HYPERION                             ]
MATE_TYPE[4][1] (Mate Identifier Type) = [FILENAME        ]
MATE_ID_LEN[4][1] (Length of the MATE_ID field) = [0026]
MATE_ID[4][1] (Mate File Identifier) = [EO1H1680372005097110PZ.AUX]
SOURCE[4][2] (Mate Source) = [EO-1_HYPERION                             ]
MATE_TYPE[4][2] (Mate Identifier Type) = [FILENAME        ]
MATE_ID_LEN[4][2] (Length of the MATE_ID field) = [0026]
MATE_ID[4][2] (Mate File Identifier) = [EO1H1680372005097110PZ.MET]
---------------------------------------------
```