### PR TITLE
use std::shared_ptr and filesystem instead of mem:: and sys:: routines

### DIFF
--- a/externals/coda-oss/modules/c++/sys/include/sys/Filesystem.h
+++ b/externals/coda-oss/modules/c++/sys/include/sys/Filesystem.h
@@ -57,6 +57,7 @@ namespace sys
 
 		bool is_regular_file(const path& p); // https://en.cppreference.com/w/cpp/filesystem/is_regular_file
 		bool is_directory(const path& p); // https://en.cppreference.com/w/cpp/filesystem/is_directory
+        bool exists(const path& p ); // https://en.cppreference.com/w/cpp/filesystem/exists
     }
 }
 

--- a/externals/coda-oss/modules/c++/sys/source/Filesystem.cpp
+++ b/externals/coda-oss/modules/c++/sys/source/Filesystem.cpp
@@ -219,6 +219,12 @@ bool fs::is_directory(const path& p)
 	return os.isDirectory(p);
 }
 
+bool fs::exists(const path& p)
+{
+    const sys::OS os;
+    return os.exists(p);
+}
+
 bool fs::remove(const path& p)
 {
 	// https://en.cppreference.com/w/cpp/io/c/remove

--- a/modules/c++/nitf/include/nitf/BufferedReader.hpp
+++ b/modules/c++/nitf/include/nitf/BufferedReader.hpp
@@ -110,7 +110,7 @@ private:
     void readNextBuffer();
 
     const nitf::Off mMaxBufferSize;
-    const mem::ScopedArray<char> mScopedBuffer;
+    const std::shared_ptr<char[]> mScopedBuffer;
     char* const mBuffer;
 
     nitf::Off mPosition;

--- a/modules/c++/nitf/include/nitf/BufferedWriter.hpp
+++ b/modules/c++/nitf/include/nitf/BufferedWriter.hpp
@@ -87,7 +87,7 @@ protected:
 
 private:
     const size_t mBufferSize;
-    const mem::ScopedArray<char> mScopedBuffer;
+    const std::shared_ptr<char[]> mScopedBuffer;
     char* const mBuffer;
 
     nitf::Off mPosition;

--- a/modules/c++/nitf/tests/strip_invisible_segments.cpp
+++ b/modules/c++/nitf/tests/strip_invisible_segments.cpp
@@ -28,6 +28,9 @@
 #include <vector>
 #include <memory>
 
+#include <sys/Filesystem.h>
+namespace fs = sys::Filesystem;
+
 // Round-trip a NITF, removing any image segments with an IREP of NODISPLY
 namespace
 {
@@ -73,7 +76,7 @@ int main(int argc, char** argv)
         //  Check argv and make sure we are happy
         if (argc != 3)
         {
-            std::cerr << "Usage: " << sys::Path::basename(argv[0])
+            std::cerr << "Usage: " << fs::path(argv[0]).filename().string()
                     << " <input-file> <output-file>" << std::endl;
             return 1;
         }

--- a/modules/c++/nitf/tests/test_direct_block_round_trip.cpp
+++ b/modules/c++/nitf/tests/test_direct_block_round_trip.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
         std::vector<nitf::ImageReader> imageReaders;
         std::vector<nitf::ImageWriter> imageWriters;
         std::map<std::string, void*> writerOptions;
-        std::vector<mem::SharedPtr<nitf::DirectBlockSource> > bandSources;
+        std::vector<std::shared_ptr<nitf::DirectBlockSource> > bandSources;
 
         //uint32_t numRes = 1;
         //writerOptions[C8_NUM_RESOLUTIONS_KEY] = &numRes;
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
             imageWriters.push_back(writer.newImageWriter(i, writerOptions));
             nitf::ImageSource iSource;
 
-            bandSources.push_back(mem::SharedPtr<nitf::DirectBlockSource>(
+            bandSources.push_back(std::shared_ptr<nitf::DirectBlockSource>(
                                       new TestDirectBlockSource(imageReaders[i], 1)));
             iSource.addBand(*bandSources[bandSources.size()-1]);
 
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
         for (uint32_t i = 0; i < num; i++)
         {
             nitf::SegmentReaderSource readerSource(reader.newGraphicReader(i));
-            mem::SharedPtr< ::nitf::WriteHandler> segmentWriter(
+            std::shared_ptr< ::nitf::WriteHandler> segmentWriter(
                 new nitf::SegmentWriter(readerSource));
             writer.setGraphicWriteHandler(i, segmentWriter);
         }
@@ -126,7 +126,7 @@ int main(int argc, char **argv)
         for (uint32_t i = 0; i < num; i++)
         {
             nitf::SegmentReaderSource readerSource(reader.newTextReader(i));
-            mem::SharedPtr< ::nitf::WriteHandler> segmentWriter(
+            std::shared_ptr< ::nitf::WriteHandler> segmentWriter(
                 new nitf::SegmentWriter(readerSource));
             writer.setTextWriteHandler(i, segmentWriter);
         }
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
         for (uint32_t i = 0; i < num; i++)
         {
             nitf::SegmentReaderSource readerSource(reader.newDEReader(i));
-            mem::SharedPtr< ::nitf::WriteHandler> segmentWriter(
+            std::shared_ptr< ::nitf::WriteHandler> segmentWriter(
                 new nitf::SegmentWriter(readerSource));
             writer.setDEWriteHandler(i, segmentWriter);
         }

--- a/modules/c++/nitf/tests/test_handles.cpp
+++ b/modules/c++/nitf/tests/test_handles.cpp
@@ -45,6 +45,9 @@
 #include <iostream>
 #include <vector>
 
+#include <sys/Filesystem.h>
+namespace fs = sys::Filesystem;
+
 template <typename T>
 class Foo
 {
@@ -166,11 +169,10 @@ int main(int argc, char** argv)
 
 
         //open a file
-        sys::OS os;
         std::vector< std::string > files;
         for (int i = 1; i < argc; ++i)
         {
-            if (!os.exists(argv[i]))
+            if (!fs::exists(argv[i]))
                 std::cout << "Error -> File does not exist: " << argv[i] << std::endl;
             else
                 files.push_back(argv[i]);

--- a/modules/c++/nitf/tests/test_image_loading++.cpp
+++ b/modules/c++/nitf/tests/test_image_loading++.cpp
@@ -23,6 +23,9 @@
 #include <import/nitf.hpp>
 #include <import/except.h>
 
+#include <sys/Filesystem.h>
+namespace fs = sys::Filesystem;
+
 void writeImage(nitf::ImageSegment &segment,
                 nitf::Reader &reader,
                 const int imageNumber,
@@ -134,7 +137,7 @@ void writeImage(nitf::ImageSegment &segment,
     for (i = 0; i < nBands; i++)
     {
         std::cout << "Writing band # " << i << std::endl;
-        std::string base = sys::Path::basename(imageName);
+        std::string base = fs::path(imageName).filename().string();
 
         size_t where = 0;
         while ((where = base.find(".")) != (size_t)std::string::npos)

--- a/modules/c++/nitf/tests/test_round_trip.cpp
+++ b/modules/c++/nitf/tests/test_round_trip.cpp
@@ -155,7 +155,7 @@ int main(int argc, char **argv)
         for (uint32_t i = 0; i < num; i++)
         {
             nitf::SegmentReaderSource readerSource(reader.newGraphicReader(i));
-            mem::SharedPtr< ::nitf::WriteHandler> segmentWriter(
+            std::shared_ptr< ::nitf::WriteHandler> segmentWriter(
                 new nitf::SegmentWriter(readerSource));
             writer.setGraphicWriteHandler(i, segmentWriter);
         }
@@ -164,7 +164,7 @@ int main(int argc, char **argv)
         for (uint32_t i = 0; i < num; i++)
         {
             nitf::SegmentReaderSource readerSource(reader.newTextReader(i));
-            mem::SharedPtr< ::nitf::WriteHandler> segmentWriter(
+            std::shared_ptr< ::nitf::WriteHandler> segmentWriter(
                 new nitf::SegmentWriter(readerSource));
             writer.setTextWriteHandler(i, segmentWriter);
         }
@@ -173,7 +173,7 @@ int main(int argc, char **argv)
         for (uint32_t i = 0; i < num; i++)
         {
             nitf::SegmentReaderSource readerSource(reader.newDEReader(i));
-            mem::SharedPtr< ::nitf::WriteHandler> segmentWriter(
+            std::shared_ptr< ::nitf::WriteHandler> segmentWriter(
                 new nitf::SegmentWriter(readerSource));
             writer.setDEWriteHandler(i, segmentWriter);
         }

--- a/modules/c++/nitf/tests/test_tre_create.cpp
+++ b/modules/c++/nitf/tests/test_tre_create.cpp
@@ -31,6 +31,9 @@
 #include <except/Exception.h>
 #include <nitf/Writer.hpp>
 
+#include <sys/Filesystem.h>
+namespace fs = sys::Filesystem;
+
 int main(int argc, char** argv)
 {
     try
@@ -38,7 +41,7 @@ int main(int argc, char** argv)
         // Parse the command line
         if (argc != 2)
         {
-            std::cerr << "Usage: " << sys::Path::basename(argv[0])
+            std::cerr << "Usage: " << fs::path(argv[0]).filename().string()
                       << " <output pathname>\n\n";
             return 1;
         }

--- a/modules/c++/nitf/tests/test_writer_4.cpp
+++ b/modules/c++/nitf/tests/test_writer_4.cpp
@@ -26,13 +26,16 @@
 #include <iostream>
 #include <string>
 
+#include <sys/Filesystem.h>
+namespace fs = sys::Filesystem;
+
 int main(int argc, char **argv)
 {
     try
     {
         if (argc != 3)
         {
-            std::cerr << "Usage: " << sys::Path::basename(argv[0])
+            std::cerr << "Usage: " << fs::path(argv[0]).filename().string()
                       << " <input-file> <output-file>\n\n";
             return 1;
         }

--- a/modules/c++/nitf/tests/test_writer_5.cpp
+++ b/modules/c++/nitf/tests/test_writer_5.cpp
@@ -28,13 +28,16 @@
 #include <string>
 #include <vector>
 
+#include <sys/Filesystem.h>
+namespace fs = sys::Filesystem;
+
 int main(int argc, char **argv)
 {
     try
     {
         if (argc != 3)
         {
-            std::cerr << "Usage: " << sys::Path::basename(argv[0])
+            std::cerr << "Usage: " << fs::path(argv[0]).filename().string()
                       << " <input-file> <output-file>\n\n";
             return 1;
         }

--- a/modules/c++/nitf/unittests/test_image_writer.cpp
+++ b/modules/c++/nitf/unittests/test_image_writer.cpp
@@ -162,7 +162,7 @@ TEST_CASE(changeFileHeader)
 
 TEST_MAIN(
     (void)argc;
-	argv0 = sys::Path::absolutePath(argv[0]);
+	argv0 = fs::absolute(argv[0]).string();
 
     TEST_CHECK(imageWriterThrowsOnFailedConstruction);
     TEST_CHECK(constructValidImageWriter);


### PR DESCRIPTION
use `std::shared_ptr` and filesystem instead of `mem::` and `sys::` routines