### PR TITLE
std::byte -> nitf::byte until we can use C++17 everywhere

### DIFF
--- a/modules/c++/nitf/include/nitf/ByteProvider.hpp
+++ b/modules/c++/nitf/include/nitf/ByteProvider.hpp
@@ -130,7 +130,7 @@ public:
     }
 
     //! \return The raw file header bytes
-    const std::vector<std::byte>& getFileHeader() const
+    const std::vector<nitf::byte>& getFileHeader() const
     {
         return mFileHeader;
     }
@@ -139,7 +139,7 @@ public:
      * \return The raw bytes for each image subheader.  Vector size matches the
      * number of image segments.
      */
-    const std::vector<std::vector<std::byte> >& getImageSubheaders() const
+    const std::vector<std::vector<nitf::byte>>& getImageSubheaders() const
     {
         return mImageSubheaders;
     }
@@ -148,7 +148,7 @@ public:
      * \return The raw bytes for each DES (subheader immediately followed by
      * raw DES data).  Vector size matches the number of data extension segments.
      */
-    const std::vector<std::byte>& getDesSubheaderAndData() const
+    const std::vector<nitf::byte>& getDesSubheaderAndData() const
     {
         return mDesSubheaderAndData;
     }
@@ -263,7 +263,7 @@ protected:
                     size_t numColsPerBlock = 0);
 
     static void copyFromStreamAndClear(io::ByteStream& stream,
-                                       std::vector<std::byte>& rawBytes);
+                                       std::vector<nitf::byte>& rawBytes);
 
     size_t countPadRows(
             size_t seg, size_t numRowsToWrite,
@@ -351,11 +351,11 @@ protected:
 
     std::vector<SegmentInfo> mImageSegmentInfo; // Per segment
 
-    std::vector<std::byte> mFileHeader;
-    std::vector<std::vector<std::byte> > mImageSubheaders; // Per segment
+    std::vector<nitf::byte> mFileHeader;
+    std::vector<std::vector<nitf::byte> > mImageSubheaders; // Per segment
 
     // All DES subheaders and data together contiguously
-    std::vector<std::byte> mDesSubheaderAndData;
+    std::vector<nitf::byte> mDesSubheaderAndData;
 
     std::vector<nitf::Off> mImageSubheaderFileOffsets; // Per segment
     nitf::Off mDesSubheaderFileOffset;

--- a/modules/c++/nitf/include/nitf/CompressedByteProvider.hpp
+++ b/modules/c++/nitf/include/nitf/CompressedByteProvider.hpp
@@ -175,7 +175,7 @@ protected:
             size_t seg,
             size_t startRow,
             size_t numRowsToWrite,
-            const std::byte* imageData,
+            const nitf::byte* imageData,
             nitf::Off& fileOffset,
             NITFBufferList& buffers) const;
 

--- a/modules/c++/nitf/include/nitf/ImageBlocker.hpp
+++ b/modules/c++/nitf/include/nitf/ImageBlocker.hpp
@@ -266,11 +266,11 @@ private:
                           size_t& lastBlockWithinLastSeg) const;
 
     void blockImpl(size_t seg,
-                   const std::byte* input,
+                   const nitf::byte* input,
                    size_t numValidRowsInBlock,
                    size_t numValidColsInBlock,
                    size_t numBytesPerPixel,
-                   std::byte* output) const
+                   nitf::byte* output) const
     {
         block(input, numBytesPerPixel, mNumCols, mNumRowsPerBlock[seg],
               mNumColsPerBlock, numValidRowsInBlock, numValidColsInBlock,
@@ -278,10 +278,10 @@ private:
     }
 
     void blockAcrossRow(size_t seg,
-                        const std::byte*& input,
+                        const nitf::byte*& input,
                         size_t numValidRowsInBlock,
                         size_t numBytesPerPixel,
-                        std::byte*& output) const;
+                        nitf::byte*& output) const;
 
 private:
     // Vectors all indexed by segment

--- a/modules/c++/nitf/include/nitf/ImageReader.hpp
+++ b/modules/c++/nitf/include/nitf/ImageReader.hpp
@@ -40,8 +40,8 @@ namespace nitf
 {
     class BufferList final
     {
-        std::vector<std::byte*> buffer;
-        std::vector<std::unique_ptr<std::byte[]>> buffer_;
+        std::vector<nitf::byte*> buffer;
+        std::vector<std::unique_ptr<nitf::byte[]>> buffer_;
 
     public:
         BufferList(size_t nBands)
@@ -53,7 +53,7 @@ namespace nitf
         {
             for (size_t i = 0; i < size(); i++)
             {
-                buffer_[i].reset(new std::byte[subWindowSize]);
+                buffer_[i].reset(new nitf::byte[subWindowSize]);
                 buffer[i] = buffer_[i].get();
             }
         }
@@ -64,12 +64,12 @@ namespace nitf
             return buffer.size();
         }
 
-        std::byte** data() noexcept
+        nitf::byte** data() noexcept
         {
             return buffer.data();
         }
 
-        std::byte*& operator[](size_t i)noexcept
+        nitf::byte*& operator[](size_t i)noexcept
         {
             return buffer[i];
         }
@@ -103,7 +103,7 @@ public:
      *  \param  padded  Returns TRUE if pad pixels may have been read
      */
     void read(nitf::SubWindow & subWindow, uint8_t ** user, int * padded);
-    void read(nitf::SubWindow & subWindow, std::byte ** user, int* padded)
+    void read(nitf::SubWindow & subWindow, nitf::byte ** user, int* padded)
     {
         read(subWindow, reinterpret_cast<uint8_t**>(user), padded);
     }

--- a/modules/c++/nitf/include/nitf/NITFBufferList.hpp
+++ b/modules/c++/nitf/include/nitf/NITFBufferList.hpp
@@ -27,7 +27,7 @@
 #include <stddef.h>
 #include <vector>
 
-#include "nitf/coda-oss.hpp"
+#include "nitf/cstddef.h"
 
 namespace nitf
 {

--- a/modules/c++/nitf/include/nitf/System.hpp
+++ b/modules/c++/nitf/include/nitf/System.hpp
@@ -34,6 +34,9 @@
 #include "nitf/Field.h"
 #include "nitf/Types.h"
 
+#include "sys/CStdDef.h"
+#include "sys/Conf.h"
+
 namespace nitf
 {
 	// Keeping these here so that code using "nitf::Uint64" still compiles;
@@ -54,5 +57,12 @@ typedef nitf_FieldType FieldType;
 typedef nitf_AccessFlags AccessFlags;
 typedef nitf_CreationFlags CreationFlags;
 typedef nitf_CornersType CornersType;
+
+#if CODA_OSS_cpp17
+using byte = nitf::byte;
+#else
+using byte = sys::byte;
+#endif
+
 }
 #endif

--- a/modules/c++/nitf/include/nitf/cstddef.h
+++ b/modules/c++/nitf/include/nitf/cstddef.h
@@ -1,3 +1,4 @@
 #pragma once
 
-#include <sys/CStdDef.h>
+#include "coda-oss.hpp"
+#include "System.hpp"

--- a/modules/c++/nitf/source/ByteProvider.cpp
+++ b/modules/c++/nitf/source/ByteProvider.cpp
@@ -60,7 +60,7 @@ ByteProvider::~ByteProvider()
 }
 
 void ByteProvider::copyFromStreamAndClear(io::ByteStream& stream,
-                                          std::vector<std::byte>& rawBytes)
+                                          std::vector<nitf::byte>& rawBytes)
 {
     rawBytes.resize(stream.getSize());
     if (!rawBytes.empty())
@@ -403,8 +403,8 @@ void ByteProvider::addImageData(
     // Figure out what offset of 'imageData' we're writing from
     const size_t startLocalRowToWrite =
             startGlobalRowToWrite - startRow + numPadRowsSoFar;
-    const std::byte* imageDataPtr =
-            static_cast<const std::byte*>(imageData) +
+    const auto imageDataPtr =
+            static_cast<const nitf::byte*>(imageData) +
             startLocalRowToWrite * mNumBytesPerRow;
 
     if (buffers.empty())

--- a/modules/c++/nitf/source/CompressedByteProvider.cpp
+++ b/modules/c++/nitf/source/CompressedByteProvider.cpp
@@ -148,7 +148,7 @@ size_t CompressedByteProvider::addImageData(
         size_t seg,
         size_t startRow,
         size_t numRowsToWrite,
-        const std::byte* imageData,
+        const nitf::byte* imageData,
         nitf::Off& fileOffset,
         NITFBufferList& buffers) const
 {
@@ -226,7 +226,7 @@ void CompressedByteProvider::getBytes(
         nitf::Off& fileOffset,
         NITFBufferList& buffers) const
 {
-    const std::byte* imageDataPtr = static_cast<const std::byte*>(imageData);
+    auto imageDataPtr = static_cast<const nitf::byte*>(imageData);
     fileOffset = std::numeric_limits<nitf::Off>::max();
     buffers.clear();
 

--- a/modules/c++/nitf/source/IOStreamReader.cpp
+++ b/modules/c++/nitf/source/IOStreamReader.cpp
@@ -34,7 +34,7 @@ IOStreamReader::IOStreamReader(io::SeekableInputStream& stream) :
 
 void IOStreamReader::readImpl(void* buffer, size_t size)
 {
-    mStream.read(static_cast<std::byte*>(buffer), size);
+    mStream.read(static_cast<nitf::byte*>(buffer), size);
 }
 
 void IOStreamReader::writeImpl(const void* , size_t)

--- a/modules/c++/nitf/source/IOStreamWriter.cpp
+++ b/modules/c++/nitf/source/IOStreamWriter.cpp
@@ -41,7 +41,7 @@ void IOStreamWriter::readImpl(void* , size_t )
 
 void IOStreamWriter::writeImpl(const void* buffer, size_t size)
 {
-    mStream->write(static_cast<const std::byte*>(buffer), size);
+    mStream->write(static_cast<const nitf::byte*>(buffer), size);
 }
 
 bool IOStreamWriter::canSeekImpl() const

--- a/modules/c++/nitf/source/ImageBlocker.cpp
+++ b/modules/c++/nitf/source/ImageBlocker.cpp
@@ -265,8 +265,8 @@ void ImageBlocker::block(const void* input,
 {
     const size_t inStride = numCols * numBytesPerPixel;
     const size_t outNumValidBytes = numValidColsInBlock * numBytesPerPixel;
-    const std::byte* inputPtr = static_cast<const std::byte*>(input);
-    std::byte* outputPtr = static_cast<std::byte*>(output);
+    auto inputPtr = static_cast<const nitf::byte*>(input);
+    auto outputPtr = static_cast<nitf::byte*>(output);
 
     if (numValidColsInBlock == numColsPerBlock)
     {
@@ -306,10 +306,10 @@ void ImageBlocker::block(const void* input,
 }
 
 void ImageBlocker::blockAcrossRow(size_t seg,
-                                  const std::byte*& input,
+                                  const nitf::byte*& input,
                                   size_t numValidRowsInBlock,
                                   size_t numBytesPerPixel,
-                                  std::byte*& output) const
+                                  nitf::byte*& output) const
 {
     const size_t outStride =
             mNumRowsPerBlock[seg] * mNumColsPerBlock * numBytesPerPixel;
@@ -358,8 +358,8 @@ void ImageBlocker::block(const void* input,
     findSegmentRange(startRow, numRows, firstSegIdx, startBlockWithinFirstSeg,
                      lastSegIdx, lastBlockWithinLastSeg);
 
-    const std::byte* inputPtr = static_cast<const std::byte*>(input);
-    std::byte* outputPtr = static_cast<std::byte*>(output);
+    auto inputPtr = static_cast<const nitf::byte*>(input);
+    auto outputPtr = static_cast<nitf::byte*>(output);
 
     for (size_t seg = firstSegIdx; seg <= lastSegIdx; ++seg)
     {

--- a/modules/c++/nitf/tests/test_buffered_read.cpp
+++ b/modules/c++/nitf/tests/test_buffered_read.cpp
@@ -35,7 +35,7 @@ void doRead(const std::string& inFile,
     nitf::Reader reader;
     nitf::BufferedReader io(inFile, bufferSize);
     nitf::Record record = reader.readIO(io);
-    std::vector<std::byte> image;
+    std::vector<nitf::byte> image;
 
     /*  Set this to the end, so we'll know when we're done!  */
     nitf::List imageList(record.getImages());
@@ -69,8 +69,8 @@ void doRead(const std::string& inFile,
 
         if (!image.empty())
         {
-            std::vector<std::byte*> imagePtrs;
-            std::byte*imagePtr(image.data());
+            std::vector<nitf::byte*> imagePtrs;
+            nitf::byte*imagePtr(image.data());
             for (size_t ii = 0;
                     ii < subWindow.getNumBands();
                     ++ii, imagePtr += numBytesPerBand)

--- a/modules/c++/nitf/tests/test_round_trip.cpp
+++ b/modules/c++/nitf/tests/test_round_trip.cpp
@@ -54,7 +54,7 @@ public:
     virtual void nextRow(uint32_t /*band*/, void* buffer)
     {
         int padded;
-        mReader.read(mWindow, reinterpret_cast<std::byte**>(&buffer), &padded);
+        mReader.read(mWindow, reinterpret_cast<nitf::byte**>(&buffer), &padded);
         mWindow.setStartRow(mWindow.getStartRow() + 1);
     }
 

--- a/modules/c++/nitf/unittests/test_create_nitf++.cpp
+++ b/modules/c++/nitf/unittests/test_create_nitf++.cpp
@@ -1134,7 +1134,7 @@ namespace test_create_nitf_with_byte_provider
         for (size_t ii = 0; ii < buffers.mBuffers.size(); ++ii)
         {
             outputStream.write(
-                static_cast<const std::byte*>(buffers.mBuffers[ii].mData),
+                static_cast<const nitf::byte*>(buffers.mBuffers[ii].mData),
                 buffers.mBuffers[ii].mNumBytes);
         }
     }

--- a/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
+++ b/modules/c++/nitf/unittests/test_image_segment_blank_nm_compression.cpp
@@ -120,7 +120,7 @@ int64_t getNumberBlocksPresent(const uint64_t* mask,
    return numBlocksPresent;
 }
 
-void createSingleBandBuffer(std::vector<std::byte>& buffer,
+void createSingleBandBuffer(std::vector<nitf::byte>& buffer,
                             const nitf::ImageSegmentComputer& segmentComputer,
                             const types::RowCol<int64_t>& fullDims,
                             const size_t segmentIdxToMakeEmpty)
@@ -138,12 +138,12 @@ void createSingleBandBuffer(std::vector<std::byte>& buffer,
       /* Set only the center that way we are surrounded by empty blocks */
       if (segIdx != segmentIdxToMakeEmpty)
       {
-         segStart[segmentSizeInBytes/2] = static_cast<std::byte>(0xff);
+         segStart[segmentSizeInBytes/2] = static_cast<nitf::byte>(0xff);
       }
    }
 }
 
-void createBuffers(std::vector<std::vector<std::byte> >& buffers,
+void createBuffers(std::vector<std::vector<nitf::byte> >& buffers,
                    const nitf::ImageSegmentComputer& imageSegmentComputer,
                    const types::RowCol<int64_t>& fullDims)
 {
@@ -179,7 +179,7 @@ TEST_CASE(testBlankSegmentsValid)
    const int64_t bytesPerSegment = BLOCK_LENGTH_SCALED * BLOCK_LENGTH_SCALED * 2;
    const int64_t elementSize     = 1;
    const types::RowCol<int64_t> fullDims(numberLines, numberElements);
-   std::vector<std::vector<std::byte> > buffers;
+   std::vector<std::vector<nitf::byte> > buffers;
    nitf::ImageSegmentComputer imageSegmentComputer(numberLines,
                                                    numberElements,
                                                    elementSize,

--- a/modules/c++/nitf/unittests/test_nitf_buffer_list.cpp
+++ b/modules/c++/nitf/unittests/test_nitf_buffer_list.cpp
@@ -47,18 +47,18 @@ TEST_CASE(testGetNumBlocks)
 TEST_CASE(testGetBlock)
 {
     // 100 total bytes
-    std::vector<std::byte> buffer(100);
+    std::vector<nitf::byte> buffer(100);
     for (size_t ii = 0; ii < buffer.size(); ++ii)
     {
-        buffer[ii] = static_cast<std::byte>(rand() % 256);
+        buffer[ii] = static_cast<nitf::byte>(rand() % 256);
     }
 
     // Break this into a few pieces
-    std::vector<std::byte> buffer1(buffer.begin(), buffer.begin() + 10);
-    std::vector<std::byte> buffer2(buffer.begin() + 10, buffer.begin() + 20);
-    std::vector<std::byte> buffer3(buffer.begin() + 20, buffer.begin() + 35);
-    std::vector<std::byte> buffer4(buffer.begin() + 35, buffer.begin() + 57);
-    std::vector<std::byte> buffer5(buffer.begin() + 57, buffer.end());
+    std::vector<nitf::byte> buffer1(buffer.begin(), buffer.begin() + 10);
+    std::vector<nitf::byte> buffer2(buffer.begin() + 10, buffer.begin() + 20);
+    std::vector<nitf::byte> buffer3(buffer.begin() + 20, buffer.begin() + 35);
+    std::vector<nitf::byte> buffer4(buffer.begin() + 35, buffer.begin() + 57);
+    std::vector<nitf::byte> buffer5(buffer.begin() + 57, buffer.end());
 
     // Add them all on
     nitf::NITFBufferList bufferList;
@@ -82,9 +82,9 @@ TEST_CASE(testGetBlock)
         TEST_ASSERT_EQ(numTotalBytes, buffer.size());
 
         // Extract all the bytes
-        std::vector<std::byte> extracted(numTotalBytes);
-        std::byte* ptr = extracted.data();
-        std::vector<std::byte> scratch;
+        std::vector<nitf::byte> extracted(numTotalBytes);
+        nitf::byte* ptr = extracted.data();
+        std::vector<nitf::byte> scratch;
 
         size_t numBytesInBlock;
         for (size_t block = 0; block < numBlocks; ++block)


### PR DESCRIPTION
`std::byte` -> `nitf::byte` until we can use C++17 everywhere.