### PR TITLE
get coda-oss #includes via coda-oss.hpp to augment "std"

### DIFF
--- a/modules/c++/nitf/include/nitf/System.hpp
+++ b/modules/c++/nitf/include/nitf/System.hpp
@@ -30,12 +30,11 @@
 
 #include <stdint.h>
 
-#include <sys/CStdDef.h>
-#include <sys/Conf.h>
-
 #include "nitf/System.h"
 #include "nitf/Field.h"
 #include "nitf/Types.h"
+
+#include "nitf/coda-oss.hpp"
 
 namespace nitf
 {


### PR DESCRIPTION
get **coda-oss** `#include`s via **coda-oss.hpp** to augment `std`.