### PR TITLE
CMake: Build c libraries, in Windows, as DLLs

### DIFF
--- a/modules/c/CMakeLists.txt
+++ b/modules/c/CMakeLists.txt
@@ -4,5 +4,9 @@ set(TARGET_LANGUAGE c)
 add_subdirectory(nrt)
 add_subdirectory(nitf)
 add_subdirectory(cgm)
-add_subdirectory(j2k)
+
+if (ENABLE_J2K)
+    add_subdirectory(j2k)
+endif()
+
 add_subdirectory(jpeg)

--- a/modules/c/cgm/CMakeLists.txt
+++ b/modules/c/cgm/CMakeLists.txt
@@ -1,5 +1,12 @@
 set(MODULE_NAME cgm)
 
+if (BUILD_SHARED)
+    set(BUILD_SHARED_LIBS ON)
+    add_definitions(
+        -DNITF_MODULE_EXPORTS
+    )
+endif()
+
 coda_add_module(
     ${MODULE_NAME}
     DEPS nitf-c

--- a/modules/c/j2k/CMakeLists.txt
+++ b/modules/c/j2k/CMakeLists.txt
@@ -4,6 +4,13 @@ if (TARGET openjpeg)
     set(HAVE_OPENJPEG_H 1)
 endif()
 
+if (BUILD_SHARED)
+    set(BUILD_SHARED_LIBS ON)
+    add_definitions(
+        -DJ2K_MODULE_EXPORTS
+    )
+endif()
+
 coda_generate_module_config_header(${MODULE_NAME})
 
 coda_add_module(

--- a/modules/c/jpeg/CMakeLists.txt
+++ b/modules/c/jpeg/CMakeLists.txt
@@ -1,3 +1,11 @@
+
+if (BUILD_SHARED)
+    set(BUILD_SHARED_LIBS ON)
+    add_definitions(
+        -DNITF_MODULE_EXPORTS
+    )
+endif()
+
 if (TARGET jpeg) # refers to libjpeg (external dependency)
     coda_add_module(
         jpeg    # becomes jpeg-c (nitro module)

--- a/modules/c/nitf/CMakeLists.txt
+++ b/modules/c/nitf/CMakeLists.txt
@@ -2,6 +2,13 @@ set(MODULE_NAME nitf)
 
 coda_generate_module_config_header(${MODULE_NAME})
 
+if (BUILD_SHARED)
+    set(BUILD_SHARED_LIBS ON)
+    add_definitions(
+        -DNITF_MODULE_EXPORTS
+    )
+endif()
+
 coda_add_module(
     ${MODULE_NAME}
     DEPS nrt-c

--- a/modules/c/nrt/CMakeLists.txt
+++ b/modules/c/nrt/CMakeLists.txt
@@ -2,6 +2,13 @@ set(MODULE_NAME nrt)
 
 coda_generate_module_config_header(${MODULE_NAME})
 
+if (BUILD_SHARED)
+    set(BUILD_SHARED_LIBS ON)
+    add_definitions(
+        -DNRT_MODULE_EXPORTS
+    )
+endif()
+
 coda_add_module(
     ${MODULE_NAME}
     DEPS ${CMAKE_DL_LIBS} config-c++


### PR DESCRIPTION
The CMake build does not support building shared libraries correctly on windows for `nrt-c`, `nitf-c`, `cgm-c` .

This PR adds an option `-DBUILD_SHARED=ON` to tell CMake to build modules that support it as shared libraries.

NOTE: The existing `BUILD_SHARED_LIBS` is not used because not all libraries support or have correct dllexport statements for windows.  These are mostly the c++ projects.

Additionally the `j2k-c` library and tests are not built if `-DENABLE_J2K=OFF` is passed.