### PR TITLE
Null init imager writers before loop with error

### DIFF
--- a/modules/c/nitf/source/NitfWriter.c
+++ b/modules/c/nitf/source/NitfWriter.c
@@ -834,6 +834,13 @@ NITFAPI(NITF_BOOL) nitf_Writer_prepareIO(nitf_Writer* writer,
                             NITF_ERR_MEMORY);
             return NITF_FAILURE;
         }
+
+        /* first, set the writer to NULL */
+        for (i = 0; i < numImages; i++)
+        {
+            writer->imageWriters[i] = NULL;
+        }
+
         writer->numImageWriters = numImages;
         for (i = 0; i < numImages; i++)
         {
@@ -841,9 +848,6 @@ NITFAPI(NITF_BOOL) nitf_Writer_prepareIO(nitf_Writer* writer,
             nitf_ImageSubheader *subheader = NULL;
             uint32_t nbpp, nbands, xbands, nrows, ncols;
             uint64_t length;
-
-            /* first, set the writer to NULL */
-            writer->imageWriters[i] = NULL;
 
             /* guard against an overflowing data length */
             iter = nitf_List_at(record->images, i);


### PR DESCRIPTION
If the test https://github.com/mdaus/nitro/blob/e77ddad8f4e93c69cb3de1154396d9237a014ae7/modules/c/nitf/source/NitfWriter.c#L865 fails and returns, the array `writer->imageWriters` can not be left in a non-determinate state.

NOTE:   I also question this test because MIL-STD2500C defines the image length as the **compressed** image size if the image is compressed, This allows actual images to exceed 9,999,999,998 bytes . 