### PR TITLE
Fix invalid const cast error

### DIFF
--- a/modules/c++/nitf/include/nitf/ImageSubheader.hpp
+++ b/modules/c++/nitf/include/nitf/ImageSubheader.hpp
@@ -137,7 +137,7 @@ private:
     void getCornersAsLatLons_(double (*corners)[2]) const;
 public:
     template<typename T>
-    void getCornersAsLatLons(const T& corners) const
+    void getCornersAsLatLons(T& corners) const
     {
         getCornersAsLatLons_(corners);
     }


### PR DESCRIPTION
Looks like this line is causing a compile error for me.
`getCornersAsLatLons_` modifies corners so I don't think the const here is correct?
