### PR TITLE
Re-add show_nitf++ app

### DIFF
--- a/modules/c++/nitf/CMakeLists.txt
+++ b/modules/c++/nitf/CMakeLists.txt
@@ -95,3 +95,10 @@ coda_add_tests(
         test_tre_mods++.cpp
         test_tre_create++.cpp
         test_tre_read.cpp)
+
+add_executable(show_nitf++ apps/show_nitf++.cpp)
+target_link_libraries(show_nitf++ PRIVATE nitf-c++)
+
+install(TARGETS show_nitf++
+        ${CODA_INSTALL_OPTION}
+        RUNTIME DESTINATION "${CODA_STD_PROJECT_BIN_DIR}")


### PR DESCRIPTION
When NITRO switched from waf to CMake, the `show_nitf++` app was not included as a CMake build target. The source file still exists, so this is a minimal change to add the `show_nitf++` executable build target.

See #438.