### PR TITLE
Build jpeg decompression as a plugin.

### DIFF
--- a/modules/c/jpeg/CMakeLists.txt
+++ b/modules/c/jpeg/CMakeLists.txt
@@ -6,9 +6,9 @@ if (BUILD_SHARED)
     )
 endif()
 
-if (TARGET jpeg) # refers to libjpeg (external dependency)
-    coda_add_module(
-        jpeg    # becomes jpeg-c (nitro module)
-        DEPS jpeg nitf-c
-        SOURCES source/LibjpegDecompress.c)
+if (TARGET jpeg)
+    add_library(LibjpegDecompress SHARED source/LibjpegDecompress.c)
+    target_link_libraries(LibjpegDecompress PUBLIC jpeg nitf-c)
+    set_target_properties(LibjpegDecompress PROPERTIES PREFIX "")
+    install(TARGETS LibjpegDecompress DESTINATION "share/nitf/plugins")
 endif()


### PR DESCRIPTION
Decompression handlers are looked up in the plugin registry, so
we need to build as a plugin for this to be found.

Tested reading a "M3" compressed NITF from the AFRL Greene 07
dataset.  Closes #481.