### PR TITLE
Fix conan build issues

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,16 +10,8 @@ class NitroConan(ConanFile):
     description = "library for reading and writing the National Imagery Transmission Format (NITF)"
     settings = "os", "compiler", "build_type", "arch"
     requires = ("coda-oss/master_1ac97fe4897896fd", )
-    options = {"shared": [True, False],
-               "PYTHON_HOME": "ANY",
-               "PYTHON_VERSION": "ANY",
-               "ENABLE_PYTHON": [True, False],
-               }
-    default_options = {"shared": False,
-                       "PYTHON_HOME": "",
-                       "PYTHON_VERSION": "",
-                       "ENABLE_PYTHON": True,
-                       }
+    options = {"shared": [True, False]}
+    default_options = {"shared": False}
     exports_sources = ("CMakeLists.txt",
                        "LICENSE",
                        "README.md",
@@ -41,12 +33,6 @@ class NitroConan(ConanFile):
     def set_version(self):
         git = tools.Git(folder=self.recipe_folder)
         self.version = git.get_revision()[:16]
-
-    def configure(self):
-        # Python-related options are forced to be the same for coda-oss
-        self.options["coda-oss"].PYTHON_HOME = self.options.PYTHON_HOME
-        self.options["coda-oss"].PYTHON_VERSION = self.options.PYTHON_VERSION
-        self.options["coda-oss"].ENABLE_PYTHON = self.options.ENABLE_PYTHON
 
     def _configure_cmake(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ class NitroConan(ConanFile):
     url = "https://github.com/mdaus/nitro"
     description = "library for reading and writing the National Imagery Transmission Format (NITF)"
     settings = "os", "compiler", "build_type", "arch"
-    requires = ("coda-oss/master_67d6362bcfcf07e2", )
+    requires = ("coda-oss/master_1ac97fe4897896fd", )
     options = {"shared": [True, False],
                "PYTHON_HOME": "ANY",
                "PYTHON_VERSION": "ANY",
@@ -51,6 +51,7 @@ class NitroConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["ENABLE_STATIC_TRES"] = True # always build static TRES
+        cmake.definitions["ENABLE_J2K"] = self.options["coda-oss"].ENABLE_J2K
         cmake.configure()
         return cmake
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,7 +40,7 @@ class NitroConan(ConanFile):
 
     def set_version(self):
         git = tools.Git(folder=self.recipe_folder)
-        self.version = "%s_%s" % (git.get_branch(), git.get_revision()[:16])
+        self.version = git.get_revision()[:16]
 
     def configure(self):
         # Python-related options are forced to be the same for coda-oss


### PR DESCRIPTION
This fixes an issue for Conan builds where the `ENABLE_J2K` CMake option was not propagated from coda-oss.

The branch name was also removed from the conan package version string. Branch names with slashes are incompatible with Conan package versioning, and there can be more than one branch at the same commit resulting in separate builds needed for each branch name.
