### PR TITLE
apps: fix display of TREs from file extended header section

### DIFF
--- a/modules/c++/nitf/apps/show_nitf++.cpp
+++ b/modules/c++/nitf/apps/show_nitf++.cpp
@@ -375,7 +375,7 @@ void showFileHeader(const nitf::FileHeader& header)
     {
         std::cout << "\t<ExtendedHeader>\n";
     }
-    showExtensions(udExts);
+    showExtensions(exExts);
     if (format_as_xml)
     {
         std::cout << "\t</ExtendedHeader>\n";


### PR DESCRIPTION
TREs in the file header extended header aren't displayed. The previous code dumped the user defined header twice - looks like cut-n-paste of line 366.