### PR TITLE
Build A single TRE Plugin

### DIFF
--- a/externals/coda-oss/modules/drivers/j2k/openjpeg/CMakeLists.txt
+++ b/externals/coda-oss/modules/drivers/j2k/openjpeg/CMakeLists.txt
@@ -85,6 +85,13 @@ else()
     configure_file("${SOURCE_DIR}/src/lib/openjp2/opj_config_private.h.cmake.in"
                    "opj_config_private.h")
 
+    if (UNIX)
+        remove_definitions(
+            -D_LARGEFILE_SOURCE
+            -D_FILE_OFFSET_BITS=64
+        )
+    endif()
+
     foreach(src "bio.c" "cio.c" "dwt.c" "event.c" "image.c" "invert.c"
                 "j2k.c" "jp2.c" "mct.c" "mqc.c" "openjpeg.c"
                 "opj_clock.c" "opj_malloc.c" "pi.c" "sparse_array.c"

--- a/modules/c/nitf/CMakeLists.txt
+++ b/modules/c/nitf/CMakeLists.txt
@@ -186,6 +186,18 @@ set(tre_srcs  ACCHZB
               USE00A
               XML_DATA_CONTENT)
 
+# Optionaly build all TREs into a single Shared Library
+set(ENABLE_SINGLEPLUGIN OFF CACHE BOOL "enable building all plugins as a single plugin")
+if (ENABLE_SINGLEPLUGIN)
+    set(tre_srcs_default ${tre_srcs})
+    set(tre_srcs DEFAULT_TRES)
+    
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${CODA_STD_PROJECT_INCLUDE_DIR}/tre_config.h" "// Default TREs\n")
+    foreach(tre ${tre_srcs_default})
+        file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/${CODA_STD_PROJECT_INCLUDE_DIR}/tre_config.h" "\"${tre}\",\n")
+    endforeach()
+endif()
+
 foreach(tre ${tre_srcs})
     add_library(${tre} SHARED shared/${tre}.c)
     target_link_libraries(${tre} PUBLIC nitf-c)
@@ -194,6 +206,12 @@ foreach(tre ${tre_srcs})
     # This line is making sure the resultant TRE is named, e.g.
     # XML_DATA_CONTENT.so instead of libXML_DATA_CONTENT.so
     set_target_properties(${tre} PROPERTIES PREFIX "")
+
+    if (ENABLE_SINGLEPLUGIN)
+        foreach(tre ${tre_srcs_default})
+            target_sources(DEFAULT_TRES PUBLIC shared/${tre}.c)
+        endforeach()
+    endif()
 
     if (ENABLE_STATIC_TRES)
         set(tre_static ${tre}-static-c)

--- a/modules/c/nitf/shared/DEFAULT_TRES.c
+++ b/modules/c/nitf/shared/DEFAULT_TRES.c
@@ -1,0 +1,114 @@
+/* =========================================================================
+ * This file is part of NITRO
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * NITRO is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <import/nitf.h>
+
+NITF_CXX_GUARD
+
+
+static const char* tres[] = {
+    #include "tre_config.h"
+    NULL
+};
+
+#define MAX_IDENT 1000
+static const char* ident[MAX_IDENT] = {
+    NITF_PLUGIN_TRE_KEY,
+    NULL
+};
+
+static nitf_TREHandler DEFAULT_TRESHandler; 
+NITFAPI(const char**) DEFAULT_TRES_init(nitf_Error* error){ 
+    nitf_DLL* dll;
+    dll = nitf_DLL_construct(error);
+    nitf_DLL_load(dll, "DEFAULT_TRES", error);
+
+    int identIdx = 1;
+
+    for (int i = 0; tres[i]; ++i)
+    {
+        NITF_PLUGIN_INIT_FUNCTION init;
+        const char** subIdent;
+        
+        char name[NITF_MAX_PATH];
+        memset(name, 0, NITF_MAX_PATH);
+        NITF_SNPRINTF(name, NITF_MAX_PATH, "%s%s", tres[i], NITF_PLUGIN_INIT_SUFFIX);
+        init = (NITF_PLUGIN_INIT_FUNCTION)nitf_DLL_retrieve(dll, name, error);
+        if (!init)
+        {
+            nitf_Error_print(error, stdout, "Invalid init hook in DSO");
+            return NULL;
+        }
+        
+        /*  Else, call it  */
+        
+        subIdent = (*init)(error);
+        if (!subIdent)
+        {
+            nitf_Error_initf(error,
+                NITF_CTXT,
+                NITF_ERR_INVALID_OBJECT,
+                "The plugin [%s] is not retrievable",
+                tres[i]);
+            return NULL;
+        }
+
+        /* Check for ID */
+        
+        if (strcmp(subIdent[0], NITF_PLUGIN_TRE_KEY) != 0)
+        {
+            nitf_Error_initf(error,
+                NITF_CTXT,
+                NITF_ERR_INVALID_OBJECT,
+                "The plugin [%s] is not retrievable",
+                tres[i]);
+            continue;
+        }
+
+        /* Add to master Ident list */
+        
+        for (int s = 1; subIdent[s]; ++s)
+        {
+            if (identIdx >= MAX_IDENT)
+            {
+                nitf_Error_initf(error,
+                    NITF_CTXT,
+                    NITF_ERR_INVALID_OBJECT,
+                    "Too Many TREs, unable to register more than 1000",
+                    tres[i]);
+                return NULL;
+            }
+        
+            ident[identIdx++] = subIdent[s];
+        }
+    }
+
+    ident[identIdx++] = NULL;
+
+    return ident; 
+} 
+NITFAPI(nitf_TREHandler*) DEFAULT_TRES_handler(nitf_Error* error) { 
+    (void)error; 
+    return &DEFAULT_TRESHandler; 
+}
+
+NITF_CXX_ENDGUARD


### PR DESCRIPTION
Currently each TRE is built as individual libraries.  This is a very large number of dlls and makes install management more complex with both number of dlls and additional overhead size.

This PR adds an option `-DENABLE_SINGLEPLUGIN=ON` to tell CMake to build all tres as a single plugin `DEFAULT_TRES`.