### PR TITLE
NITRO 2.10.13

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,10 +1,15 @@
 ﻿# NITRO (NITF i/o) Release Notes
 
+## [Version 2.10.13](https://github.com/mdaus/nitro/releases/tag/NITRO-2.10.13); March 13, 2023
+* [coda-oss](https://github.com/mdaus/coda-oss) release [2022-03-10](https://github.com/mdaus/coda-oss/releases/tag/2023-03-10)
+* Sanitize tar-file extraction; conan tweaks.
+* Final 🤞🏻 C++11 release; future releases will be C++14 from [main](https://github.com/mdaus/nitro/tree/main).
+
 ## [Version 2.10.12](https://github.com/mdaus/nitro/releases/tag/NITRO-2.10.12); August 30, 2022
 * [coda-oss](https://github.com/mdaus/coda-oss) release [2022-08-30](https://github.com/mdaus/coda-oss/releases/tag/2022-08-30)
 * Build JPEG decompression as a plug-in.
 * tweak unittests so they run in SIX.
-* Final C++11 release 🤞🏻; future releases will be C++14 from [main](https://github.com/mdaus/nitro/tree/main).
+* ~~Final C++11 release 🤞🏻; future releases will be C++14 from [main](https://github.com/mdaus/nitro/tree/main).~~
 
 ## [Version 2.10.11](https://github.com/mdaus/nitro/releases/tag/NITRO-2.10.11); August 2, 2022
 * [coda-oss](https://github.com/mdaus/coda-oss) release [2022-08-02](https://github.com/mdaus/coda-oss/releases/tag/2022-08-02)

--- a/modules/c++/nitf/include/nitf/Version.hpp
+++ b/modules/c++/nitf/include/nitf/Version.hpp
@@ -27,7 +27,8 @@
 #include "config/Version.h"
 #include "nitf/Version.h"
 
- // 2.10.12	August 30, 2022
+// 2.10.13	March 13, 2023
+// 2.10.12	August 30, 2022
 // 2.10.11	August 2, 2022
 // 2.10.10	June 29, 2022
 // 2.10.9	May 3, 2022
@@ -35,7 +36,7 @@
 // 2.10.7	December 13, 2021
 #define NITF_VERSION_MAJOR	2
 #define NITF_VERSION_MINOR	10
-#define NITF_VERSION_PATCH	12
+#define NITF_VERSION_PATCH	13
 #define NITF_VERSION_BUILD		0
 #define NITF_VERSION CODA_OSS_MAKE_VERSION_MMPB(NITF_VERSION_MAJOR, NITF_VERSION_MINOR, NITF_VERSION_PATCH, NITF_VERSION_BUILD)
 

--- a/modules/c/nrt/include/nrt/Version.h
+++ b/modules/c/nrt/include/nrt/Version.h
@@ -1,5 +1,5 @@
 #pragma once
 
 #if !defined(NRT_LIB_VERSION)
-#define NRT_LIB_VERSION "2.10.12"
+#define NRT_LIB_VERSION "2.10.13"
 #endif


### PR DESCRIPTION
* [coda-oss](https://github.com/mdaus/coda-oss) release [2022-03-10](https://github.com/mdaus/coda-oss/releases/tag/2023-03-10)
* Sanitize tar-file extraction; conan tweaks.
* Final 🤞🏻 C++11 release; future releases will be C++14 from [main](https://github.com/mdaus/nitro/tree/main).
