### PR TITLE
FmtX() -> str::Format()

### DIFF
--- a/modules/c++/nitf/include/nitf/Object.hpp
+++ b/modules/c++/nitf/include/nitf/Object.hpp
@@ -151,7 +151,7 @@ public:
      */
     std::string getObjectID() const
     {
-        return FmtX("%p", getNative());
+        return str::Format("%p", getNative());
     }
 
     bool isManaged() const noexcept { return isValid() && mHandle->isManaged(); }

--- a/modules/c++/nitf/source/FileHeader.cpp
+++ b/modules/c++/nitf/source/FileHeader.cpp
@@ -200,7 +200,7 @@ nitf::ComponentInfo FileHeader::getImageInfo(int i) const
 {
     int num = getNumImages();
     if (i < 0 || i >= num)
-        throw except::IndexOutOfRangeException(Ctxt(FmtX(
+        throw except::IndexOutOfRangeException(Ctxt(str::Format(
                 "Index out of range: (%d <= %d <= %d)", 0, i, num)));
     return make_ComponentInfo(getNativeOrThrow()->imageInfo, i);
 }
@@ -209,7 +209,7 @@ nitf::ComponentInfo FileHeader::getGraphicInfo(int i) const
 {
     int num = getNumGraphics();
     if (i < 0 || i >= num)
-        throw except::IndexOutOfRangeException(Ctxt(FmtX(
+        throw except::IndexOutOfRangeException(Ctxt(str::Format(
                 "Index out of range: (%d <= %d <= %d)", 0, i, num)));
     return make_ComponentInfo(getNativeOrThrow()->graphicInfo, i);
 }
@@ -218,7 +218,7 @@ nitf::ComponentInfo FileHeader::getLabelInfo(int i) const
 {
     int num = getNumLabels();
     if (i < 0 || i >= num)
-        throw except::IndexOutOfRangeException(Ctxt(FmtX(
+        throw except::IndexOutOfRangeException(Ctxt(str::Format(
                 "Index out of range: (%d <= %d <= %d)", 0, i, num)));
     return make_ComponentInfo(getNativeOrThrow()->labelInfo, i);
 }
@@ -227,7 +227,7 @@ nitf::ComponentInfo FileHeader::getTextInfo(int i) const
 {
     int num = getNumTexts();
     if (i < 0 || i >= num)
-        throw except::IndexOutOfRangeException(Ctxt(FmtX(
+        throw except::IndexOutOfRangeException(Ctxt(str::Format(
                 "Index out of range: (%d <= %d <= %d)", 0, i, num)));
     return make_ComponentInfo(getNativeOrThrow()->textInfo, i);
 }
@@ -236,7 +236,7 @@ nitf::ComponentInfo FileHeader::getDataExtensionInfo(int i) const
 {
     int num = getNumDataExtensions();
     if (i < 0 || i >= num)
-        throw except::IndexOutOfRangeException(Ctxt(FmtX(
+        throw except::IndexOutOfRangeException(Ctxt(str::Format(
                 "Index out of range: (%d <= %d <= %d)", 0, i, num)));
     return make_ComponentInfo(getNativeOrThrow()->dataExtensionInfo, i);
 }
@@ -245,7 +245,7 @@ nitf::ComponentInfo FileHeader::getReservedExtensionInfo(int i) const
 {
     int num = getNumReservedExtensions();
     if (i < 0 || i >= num)
-        throw except::IndexOutOfRangeException(Ctxt(FmtX(
+        throw except::IndexOutOfRangeException(Ctxt(str::Format(
                 "Index out of range: (%d <= %d <= %d)", 0, i, num)));
     return make_ComponentInfo(getNativeOrThrow()->reservedExtensionInfo, i);
 }

--- a/modules/c++/nitf/source/TRE.cpp
+++ b/modules/c++/nitf/source/TRE.cpp
@@ -96,7 +96,7 @@ nitf::Field TRE::getField(const std::string& key) const
     nitf_Field* field = ::nitf_TRE_getField(getNativeOrThrow(), key.c_str());
     if (!field)
         throw except::NoSuchKeyException(
-                Ctxt(FmtX("Field does not exist in TRE: %s", key.c_str())));
+                Ctxt(str::Format("Field does not exist in TRE: %s", key)));
     return nitf::Field(field);
 }
 

--- a/modules/c++/nitf/tests/test_create++.cpp
+++ b/modules/c++/nitf/tests/test_create++.cpp
@@ -28,7 +28,7 @@ int main(int argc, char** argv)
     {
         if (argc != 2)
         {
-            throw nitf::NITFException(Ctxt(FmtX("Usage %s <file-to-create>\n",
+            throw nitf::NITFException(Ctxt(str::Format("Usage %s <file-to-create>\n",
                                                 argv[0])));
         }
 

--- a/modules/c++/nitf/tests/test_extract.cpp
+++ b/modules/c++/nitf/tests/test_extract.cpp
@@ -44,9 +44,9 @@ static  std::vector<std::string> extract_image(const nitf::ImageSubheader& subhe
     size_t band = 0;
     for (const auto& data : bandData) // for band, data in enumerate(bandData):
     {
-        auto outName = FmtX("%s_%d__", baseName, index);
-	outName += FmtX("%d_x_%d_", window.getNumRows(), window.getNumCols());
-	outName += FmtX("%d_band_%d.out", static_cast<int>(nbpp), static_cast<int>(band));
+        auto outName = str::Format("%s_%d__", baseName, index);
+	outName += str::Format("%d_x_%d_", window.getNumRows(), window.getNumCols());
+	outName += str::Format("%d_band_%d.out", static_cast<int>(nbpp), static_cast<int>(band));
         outName = sys::Path::joinPaths(outDir, outName);
         auto f = fopen(outName.c_str(), "wb"); // f = open(outName, "wb");
         nitf::write(f, data); // fwrite(data.data(), sizeof(data[0]), data.size() / sizeof(data[0]), f);

--- a/modules/c++/nitf/tests/test_fhdr_clone++.cpp
+++ b/modules/c++/nitf/tests/test_fhdr_clone++.cpp
@@ -118,7 +118,7 @@ int main(int argc, char** argv)
     {
         if (argc != 2)
         {
-            throw nitf::NITFException(Ctxt(FmtX("Usage: %s <nitf-file>\n", argv[0])));
+            throw nitf::NITFException(Ctxt(str::Format("Usage: %s <nitf-file>\n", argv[0])));
         }
 
         nitf::Reader reader;

--- a/modules/c++/nitf/tests/test_functional.cpp
+++ b/modules/c++/nitf/tests/test_functional.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
     {
         nitf::Reader reader;
         if ( argc != 2 )
-            throw nitf::NITFException(Ctxt(FmtX("Usage: %s <nitf-file>\n", argv[0])));
+            throw nitf::NITFException(Ctxt(str::Format("Usage: %s <nitf-file>\n", argv[0])));
 
         nitf::IOHandle io(argv[1]);
         nitf::Record record = reader.read(io);

--- a/modules/c++/nitf/tests/test_j2k_nitf_read_region.cpp
+++ b/modules/c++/nitf/tests/test_j2k_nitf_read_region.cpp
@@ -47,8 +47,8 @@
 void writeFile(uint32_t x0, uint32_t y0,
     uint32_t x1, uint32_t y1, std::span<const uint8_t> buf, const std::string& prefix)
 {
-    auto filename = FmtX("%s-raw-", prefix);
-    filename += FmtX("%d_%d__%d_%d.out", x0, y0, x1, y1);
+    auto filename = str::Format("%s-raw-", prefix);
+    filename += str::Format("%d_%d__%d_%d.out", x0, y0, x1, y1);
     nitf::IOHandle outHandle(filename, NRT_ACCESS_WRITEONLY, NRT_CREATE);
     outHandle.write(buf.data(), buf.size());
     printf("Wrote file: %s\n", filename.c_str());
@@ -58,8 +58,8 @@ void writeJ2K(uint32_t x0, uint32_t y0,
     uint32_t x1, uint32_t y1, std::span<const uint8_t> buf,
     const j2k::Container& inContainer, const std::string& prefix)
 {
-    auto outName = FmtX("%s-raw-", prefix);
-    outName += FmtX("%d_%d__%d_%d.j2k", x0, y0, x1, y1);
+    auto outName = str::Format("%s-raw-", prefix);
+    outName += str::Format("%d_%d__%d_%d.j2k", x0, y0, x1, y1);
 
     const auto num_x_tiles = inContainer.getTilesX();
     const auto num_y_tiles = inContainer.getTilesY();
@@ -217,7 +217,7 @@ int main(int argc, char **argv)
                 const auto result_ = j2kReader.readRegion(0, 0, width, height, buf);
                 const std::span<const uint8_t> result(result_.data(), result_.size());
 
-                const auto namePrefix = FmtX("image-%d", (i + 1));
+                const auto namePrefix = str::Format("image-%d", (i + 1));
                 // TODO: Update write to only output tiles in read region
                 writeFile(0, 0, width, height, result, namePrefix);
                 writeJ2K(0, 0, width, height, result, container, namePrefix);

--- a/modules/c++/nitf/tests/test_read_acftb.cpp
+++ b/modules/c++/nitf/tests/test_read_acftb.cpp
@@ -83,7 +83,7 @@ int main(int argc, char** argv)
         nitf::Reader reader;
         if (argc != 2)
         {
-            throw nitf::NITFException(Ctxt(FmtX("Usage: %s <nitf-file>\n",
+            throw nitf::NITFException(Ctxt(str::Format("Usage: %s <nitf-file>\n",
                                                 argv[0])));
         }
         nitf::IOHandle io(argv[1]);

--- a/modules/c++/nitf/unittests/test_j2k_loading++.cpp
+++ b/modules/c++/nitf/unittests/test_j2k_loading++.cpp
@@ -168,8 +168,8 @@ TEST_CASE(test_j2k_nitf)
 void writeFile(uint32_t x0, uint32_t y0,
     uint32_t x1, uint32_t y1, std::span<const uint8_t> buf, const std::string& prefix)
 {
-    auto filename = FmtX("%s-raw-", prefix);
-    filename += FmtX("%d_%d__%d_%d.out", x0, y0, x1, y1);
+    auto filename = str::Format("%s-raw-", prefix);
+    filename += str::Format("%d_%d__%d_%d.out", x0, y0, x1, y1);
     nitf::IOHandle outHandle(filename, NRT_ACCESS_WRITEONLY, NRT_CREATE);
     outHandle.write(buf.data(), buf.size());
     //printf("Wrote file: %s\n", filename.c_str());
@@ -178,8 +178,8 @@ void writeJ2K(uint32_t x0, uint32_t y0,
     uint32_t x1, uint32_t y1, std::span<const uint8_t> buf,
     const j2k::Container& inContainer, const std::string& prefix)
 {
-    auto outName = FmtX("%s-raw-", prefix);
-    outName += FmtX("%d_%d__%d_%d.j2k", x0, y0, x1, y1);
+    auto outName = str::Format("%s-raw-", prefix);
+    outName += str::Format("%d_%d__%d_%d.j2k", x0, y0, x1, y1);
 
     const auto num_x_tiles = inContainer.getTilesX();
     const auto num_y_tiles = inContainer.getTilesY();
@@ -273,7 +273,7 @@ void test_j2k_nitf_read_region_(const std::string& testName,
         const auto result_ = j2kReader.readRegion(0, 0, width, height, buf);
         const auto result = sys::make_const_span(result_);
 
-        const auto namePrefix = FmtX("image-%d", (i + 1));
+        const auto namePrefix = str::Format("image-%d", (i + 1));
         // TODO: Update write to only output tiles in read region
         writeFile(0, 0, width, height, result, namePrefix);
         writeJ2K(0, 0, width, height, result, container, namePrefix);


### PR DESCRIPTION
Change using the `FmtX()` macro to calling the `str::Format()` method.