### PR TITLE
Fixes an issue with the long-form Command Header where the Parameter …

### DIFF
--- a/modules/c/cgm/source/MetafileWriter.c
+++ b/modules/c/cgm/source/MetafileWriter.c
@@ -54,9 +54,9 @@ NITFPRIV(NITF_BOOL) writeHeader(short classType, short code, short size,
         (*actual)++;
     }
 
-    if (*actual >= 31)
+    if (size >= 31)
     {
-        extendedParams = *actual;
+        extendedParams = size;
         params = 31;
     }
 


### PR DESCRIPTION
…List Length (2nd word) incorrectly included the padding octet.

Problem was originally detected by CIVA (NITF validation utility), which rejected an otherwise valid NITF with an embedded Nitro-generated CGM.

I took a valid CGM, round-tripped it through Nitro, and compared against the original in a hex editor. In long-form command headers, the parameter list length was including the padding octet after the parameter list in its count of bytes, which is incorrect according to the CGM binary spec (also, the short-form command header doesn't include the padding octet either).

