### PR TITLE
Fix comparison error when NITF_IF "eq NA" is used to compare to field with more characters than "NA" value.

### DIFF
--- a/modules/c/nitf/source/TRECursor.c
+++ b/modules/c/nitf/source/TRECursor.c
@@ -669,7 +669,8 @@ NITFPRIV(int) nitf_TRECursor_evalIf(nitf_TRE* tre,
                             NITF_CTXT, NITF_ERR_INVALID_PARAMETER);
             return NITF_FAILURE;
         }
-        status = strncmp(field->raw, valPtr, field->length);
+        int valLen = strlen(valPtr);
+        status = strncmp(field->raw, valPtr, valLen < field->length ? valLen : field->length);
         status = strcmp(op, "eq") == 0 ? !status : status;
     }
     /* check if it is a logical operator for ints */


### PR DESCRIPTION
Fix comparison error when NITF_IF "eq NA" is compared against field with length four.  
The offending source is on line 222 of file modules/c/nitf/shared/CMETAA.c .