### PR TITLE
Throw helpful exception on null blockingInfo, in ImageReader.cpp

### DIFF
--- a/modules/c++/nitf/source/ImageReader.cpp
+++ b/modules/c++/nitf/source/ImageReader.cpp
@@ -51,6 +51,8 @@ nitf::BlockingInfo ImageReader::getBlockingInfo() const
 {
     nitf_BlockingInfo* blockingInfo =
             nitf_ImageReader_getBlockingInfo(getNativeOrThrow(), &error);
+    if (!blockingInfo)
+        throw nitf::NITFException(&error);
     // This creates a new object, not a reference to a field,
     // So need to tell the wrapper it needs to destruct itself
     nitf::BlockingInfo cppBlockingInfo(blockingInfo);


### PR DESCRIPTION
When errors occur in nitf_ImageIO_getBlockingInfo, it returns a NULL pointer and sets error to a helpful message. Previously the code wasn't checking for this, leading to a later less helpful error like "Invalid handle". This two-line fix enables the more precise errors to be passed up the call stack to the caller.