### PR TITLE
Guard GNU specific options

### DIFF
--- a/modules/c++/CMakeLists.txt
+++ b/modules/c++/CMakeLists.txt
@@ -10,7 +10,7 @@ if (MSVC)
     # > extremely noisy and low-value warnings. In general, the STL does not attempt to be `/Wall` clean.
     string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}") # add_compile_options(/W4)
 
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     #add_compile_options(-Wall -pedantic -Wextra)
     add_compile_options(-Wall -Wextra)
 endif()

--- a/modules/c++/CMakeLists.txt
+++ b/modules/c++/CMakeLists.txt
@@ -10,7 +10,7 @@ if (MSVC)
     # > extremely noisy and low-value warnings. In general, the STL does not attempt to be `/Wall` clean.
     string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}") # add_compile_options(/W4)
 
-elseif (UNIX)
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     #add_compile_options(-Wall -pedantic -Wextra)
     add_compile_options(-Wall -Wextra)
 endif()

--- a/modules/c++/nitf/include/nitf/Object.hpp
+++ b/modules/c++/nitf/include/nitf/Object.hpp
@@ -133,7 +133,7 @@ public:
     }
 
     //! Get native object
-    virtual T * getNativeOrThrow() const noexcept(false)
+    virtual T * getNativeOrThrow() const
     {
         T* val = getNative();
         if (val)

--- a/modules/c/CMakeLists.txt
+++ b/modules/c/CMakeLists.txt
@@ -12,17 +12,22 @@ if (MSVC)
     string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}") # add_compile_options(/W4)
 
     add_compile_options(/wd4996) # '...': This function or variable may be unsafe.
-elseif (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+elseif (CMAKE_C_COMPILER_ID MATCHES "GNU|CLang")
     #add_compile_options(-Wall -pedantic -Wextra)
     add_compile_options(-Wall -Wextra)
 
     add_compile_options(-Wno-implicit-fallthrough)
     add_compile_options(-Wno-unused-function)
     add_compile_options(-Wno-sign-compare -Wno-pointer-sign)
-    add_compile_options(-Wno-missing-field-initializers -Wno-maybe-uninitialized)
+    add_compile_options(-Wno-missing-field-initializers)
     add_compile_options(-Wno-unused-parameter)
     add_compile_options(-Wno-cast-function-type)
     add_compile_options(-Wno-misleading-indentation)
+    
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        add_compile_options(-Wno-maybe-uninitialized)
+    endif()
+
 endif()
 
 add_subdirectory(nrt)

--- a/modules/c/CMakeLists.txt
+++ b/modules/c/CMakeLists.txt
@@ -12,7 +12,7 @@ if (MSVC)
     string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}") # add_compile_options(/W4)
 
     add_compile_options(/wd4996) # '...': This function or variable may be unsafe.
-elseif (UNIX)
+elseif (CMAKE_C_COMPILER_ID STREQUAL "GNU")
     #add_compile_options(-Wall -pedantic -Wextra)
     add_compile_options(-Wall -Wextra)
 


### PR DESCRIPTION
Allow other compilers that don't support GNU options to build on Unix